### PR TITLE
Encode COSE Algorithm as per spec

### DIFF
--- a/src/cbor.c
+++ b/src/cbor.c
@@ -327,6 +327,7 @@ encode_pubkey_param(int cose_alg)
 {
 	cbor_item_t		*item = NULL;
 	cbor_item_t		*body = NULL;
+	cbor_item_t		*alg_item = NULL;
 	struct cbor_pair	 alg;
 
 	if ((item = cbor_new_definite_array(1)) == NULL ||
@@ -335,7 +336,13 @@ encode_pubkey_param(int cose_alg)
 		goto fail;
 
 	alg.key = cbor_move(cbor_build_string("alg"));
-	alg.value = cbor_move(cbor_build_negint16((uint16_t)(-cose_alg - 1)));
+
+	if (-cose_alg - 1 > UINT8_MAX)
+		alg_item = cbor_build_negint16((uint16_t)(-cose_alg - 1));
+	else
+		alg_item = cbor_build_negint8((uint8_t)(-cose_alg - 1));
+
+	alg.value = cbor_move(alg_item);
 
 	if (cbor_map_add(body, alg) == false ||
 	    cbor_add_string(body, "type", "public-key") < 0 ||


### PR DESCRIPTION
It seems like libfido2 is not correctly encoding small COSE algorithm values.

From what I understand, a device does not have the obligation to enforce those encoding rules and this is why the Yubikey 5 NFC does work even without this modification.

However the BioPass FIDO2 is stiffer and so does not allow for algorithm values < -25 encoded with an additional uint16_t.

This solves https://github.com/Yubico/libfido2/issues/10

Ref.:

FIDO 2.0: Client To Authenticator Protocol
  6. Message encoding

Integers must be encoded as small as possible.
  0 to 23 and -1 to -24 must be expressed in the same byte as the major type;
  24 to 255 and -25 to -256 must be expressed only with an additional uint8_t;