### PR TITLE
Add BioPass FIDO2 to udev rules

### DIFF
--- a/udev/70-old-u2f.rules
+++ b/udev/70-old-u2f.rules
@@ -17,8 +17,8 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1e0d", ATTRS{idProduct
 # HyperSecu HyperFIDO
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="096e|2ccf", ATTRS{idProduct}=="0880", GROUP="plugdev", MODE="0660"
 
-# Feitian ePass FIDO
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="096e", ATTRS{idProduct}=="0850|0852|0853|0854|0856|0858|085a|085b", GROUP="plugdev", MODE="0660"
+# Feitian ePass FIDO, BioPass FIDO2
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="096e", ATTRS{idProduct}=="0850|0852|0853|0854|0856|0858|085a|085b|085d", GROUP="plugdev", MODE="0660"
 
 # JaCarta U2F
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="24dc", ATTRS{idProduct}=="0101", GROUP="plugdev", MODE="0660"

--- a/udev/70-u2f.rules
+++ b/udev/70-u2f.rules
@@ -17,8 +17,8 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1e0d", ATTRS{idProduct
 # HyperSecu HyperFIDO
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="096e|2ccf", ATTRS{idProduct}=="0880", TAG+="uaccess"
 
-# Feitian ePass FIDO
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="096e", ATTRS{idProduct}=="0850|0852|0853|0854|0856|0858|085a|085b", TAG+="uaccess"
+# Feitian ePass FIDO, BioPass FIDO2
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="096e", ATTRS{idProduct}=="0850|0852|0853|0854|0856|0858|085a|085b|085d", TAG+="uaccess"
 
 # JaCarta U2F
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="24dc", ATTRS{idProduct}=="0101", TAG+="uaccess"


### PR DESCRIPTION
This is backported from libu2f-host.

Even though it's an easy thing, it's been done through

```
git show 15c6ca2 > udev.patch
patch -p1 -i udev.patch
```

to be on the safe side.