### PR TITLE
FIDO2 Standard 

### DIFF
--- a/src/cbor.c
+++ b/src/cbor.c
@@ -426,8 +426,8 @@ encode_pubkey(const fido_blob_t *pubkey)
 	cbor_item_t *cbor_key = NULL;
 
 	if ((cbor_key = cbor_new_definite_map(2)) == NULL ||
-	    cbor_add_string(cbor_key, "type", "public-key") < 0 ||
-	    cbor_add_bytestring(cbor_key, "id", pubkey->ptr, pubkey->len) < 0) {
+	    cbor_add_bytestring(cbor_key, "id", pubkey->ptr, pubkey->len) < 0 ||
+	    cbor_add_string(cbor_key, "type", "public-key") < 0) {
 		if (cbor_key)
 			cbor_decref(&cbor_key);
 		return (NULL);


### PR DESCRIPTION
According to CTAP2 Standard, Section 6 it is said

> The keys in every map must be sorted lowest value to highest. The sorting rules are:
> - If the major types are different, the one with the lower value in numerical order sorts earlier.
> - If two keys have different lengths, the shorter one sorts earlier;
> - If two keys have the same length, the one with the lower value in (byte-wise) lexical order sorts earlier

as it holds "id" < "type", the cbor map must contain id at first and then type. By changing this my FIDO2 Stick works.