### PR TITLE
Avoid sign extension when printing USB vendor or device ID

### DIFF
--- a/examples/manifest.c
+++ b/examples/manifest.c
@@ -33,8 +33,8 @@ main(void)
 		const fido_dev_info_t *di = fido_dev_info_ptr(devlist, i);
 		printf("%s: vendor=0x%04x, product=0x%04x (%s %s)\n",
 		    fido_dev_info_path(di),
-		    fido_dev_info_vendor(di),
-		    fido_dev_info_product(di),
+		    (uint16_t)fido_dev_info_vendor(di),
+		    (uint16_t)fido_dev_info_product(di),
 		    fido_dev_info_manufacturer_string(di),
 		    fido_dev_info_product_string(di));
 	}

--- a/tools/token.c
+++ b/tools/token.c
@@ -270,8 +270,8 @@ token_list(int argc, char **argv)
 		const fido_dev_info_t *di = fido_dev_info_ptr(devlist, i);
 		printf("%s: vendor=0x%04x, product=0x%04x (%s %s)\n",
 		    fido_dev_info_path(di),
-		    fido_dev_info_vendor(di),
-		    fido_dev_info_product(di),
+		    (uint16_t)fido_dev_info_vendor(di),
+		    (uint16_t)fido_dev_info_product(di),
 		    fido_dev_info_manufacturer_string(di),
 		    fido_dev_info_product_string(di));
 	}


### PR DESCRIPTION
Cast vendor and device ID to uint16_t.  Previously vendor or device IDs
0x8000 or greater were displayed with a 0xffff prefix - for example,
product=0xffffa2ca.