### PR TITLE
Add a fido_assert_sigcount() function

### DIFF
--- a/src/assert.c
+++ b/src/assert.c
@@ -815,6 +815,15 @@ fido_assert_flags(const fido_assert_t *assert, size_t idx)
 	return (assert->stmt[idx].authdata.flags);
 }
 
+uint32_t
+fido_assert_sigcount(const fido_assert_t *assert, size_t idx)
+{
+	if (idx >= assert->stmt_len)
+		return (0);
+
+	return (assert->stmt[idx].authdata.sigcount);
+}
+
 const unsigned char *
 fido_assert_authdata_ptr(const fido_assert_t *assert, size_t idx)
 {

--- a/src/fido.h
+++ b/src/fido.h
@@ -177,6 +177,7 @@ size_t fido_cred_sig_len(const fido_cred_t *);
 size_t fido_cred_x5c_len(const fido_cred_t *);
 
 uint8_t  fido_assert_flags(const fido_assert_t *, size_t);
+uint32_t  fido_assert_sigcount(const fido_assert_t *, size_t);
 uint8_t  fido_cred_flags(const fido_cred_t *);
 uint8_t  fido_dev_protocol(const fido_dev_t *);
 uint8_t  fido_dev_major(const fido_dev_t *);


### PR DESCRIPTION
This allows access to the signature counter in an assertion statement
and is useful when implementing a standalone verifier.