### PR TITLE
man: remove text about non-existing _FIDO_DEBUG compile-time option

### DIFF
--- a/man/fido.3
+++ b/man/fido.3
@@ -33,9 +33,6 @@ on
 Alternatively, the
 .Ev FIDO_DEBUG
 environment variable may be set.
-Please note that debug output is conditional on
-.Dv _FIDO_DEBUG
-being defined when the library was compiled.
 .Sh SEE ALSO
 .Xr fido_assert 3 ,
 .Xr fido_cred 3 ,

--- a/man/fido2-cred.1
+++ b/man/fido2-cred.1
@@ -144,7 +144,7 @@ When making a credential,
 .Nm
 expects its input to consist of:
 .Pp
-.Bl -enum -offset indent -compact                                   
+.Bl -enum -offset indent -compact
 .It
 client data hash (base64 blob);
 .It


### PR DESCRIPTION
..also remove trailing whitespace from fido2-cred man page.