### PR TITLE
Sk libfido2 header

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -49,7 +49,7 @@ add_executable(fido2-token
 	${COMPAT_SOURCES}
 )
 
-add_library(sk-libfido2 MODULE sk-libfido2.c sk-libfido2.h)
+add_library(sk-libfido2 MODULE sk-libfido2.c)
 set_target_properties(sk-libfido2 PROPERTIES
 	COMPILE_FLAGS "-DSK_STANDALONE -DWITH_OPENSSL"
 	OUTPUT_NAME sk-libfido2

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -49,7 +49,7 @@ add_executable(fido2-token
 	${COMPAT_SOURCES}
 )
 
-add_library(sk-libfido2 MODULE sk-libfido2.c)
+add_library(sk-libfido2 MODULE sk-libfido2.c sk-libfido2.h)
 set_target_properties(sk-libfido2 PROPERTIES
 	COMPILE_FLAGS "-DSK_STANDALONE -DWITH_OPENSSL"
 	OUTPUT_NAME sk-libfido2

--- a/tools/sk-libfido2.c
+++ b/tools/sk-libfido2.c
@@ -37,6 +37,7 @@
 
 #ifndef SK_STANDALONE
 #include "log.h"
+#include "xmalloc.h"
 #endif
 
 /* #define SK_DEBUG 1 */

--- a/tools/sk-libfido2.h
+++ b/tools/sk-libfido2.h
@@ -1,0 +1,55 @@
+#ifndef THIRD_PARTY_LIBFIDO2_TOOLS_SK_LIBFIDO2_H_
+#define THIRD_PARTY_LIBFIDO2_TOOLS_SK_LIBFIDO2_H_
+
+#include <stdlib.h>
+#include <stdint.h>
+
+#define SK_VERSION_MAJOR	0x00020000 /* current API version */
+
+/* Return values */
+#define SK_SUCCESS 0
+#define SK_FAIL    1
+
+/* Flags */
+#define TUP_FLAG             0x01
+#define INDIVIDUAL_CERT_FLAG 0x80
+#define SK_USER_PRESENCE_REQD	0x01
+
+/* Algs */
+#define	SK_ECDSA		0x00
+#define	SK_ED25519		0x01
+
+struct sk_enroll_response {
+	uint8_t *public_key;
+	size_t public_key_len;
+	uint8_t *key_handle;
+	size_t key_handle_len;
+	uint8_t *signature;
+	size_t signature_len;
+	uint8_t *attestation_cert;
+	size_t attestation_cert_len;
+};
+
+struct sk_sign_response {
+	uint8_t flags;
+	uint32_t counter;
+	uint8_t *sig_r;
+	size_t sig_r_len;
+	uint8_t *sig_s;
+	size_t sig_s_len;
+};
+
+/* Return the version of the middleware API */
+uint32_t sk_api_version(void);
+
+/* Enroll a U2F key (private key generation) */
+int sk_enroll(int alg, const uint8_t *challenge_hash, size_t challenge_hash_len,
+    const char *application, uint8_t flags,
+    struct sk_enroll_response **enroll_response);
+
+/* Sign a challenge */
+int sk_sign(int alg, const uint8_t *message_hash, size_t message_hash_len,
+    const char *application, const uint8_t *key_handle, size_t key_handle_len,
+    uint8_t flags, struct sk_sign_response **sign_response);
+
+#endif  // THIRD_PARTY_LIBFIDO2_TOOLS_SK_LIBFIDO2_H_

--- a/tools/sk-libfido2.h
+++ b/tools/sk-libfido2.h
@@ -6,10 +6,6 @@
 
 #define SK_VERSION_MAJOR	0x00020000 /* current API version */
 
-/* Return values */
-#define SK_SUCCESS 0
-#define SK_FAIL    1
-
 /* Flags */
 #define TUP_FLAG             0x01
 #define INDIVIDUAL_CERT_FLAG 0x80

--- a/tools/sk-libfido2.h
+++ b/tools/sk-libfido2.h
@@ -1,5 +1,21 @@
-#ifndef THIRD_PARTY_LIBFIDO2_TOOLS_SK_LIBFIDO2_H_
-#define THIRD_PARTY_LIBFIDO2_TOOLS_SK_LIBFIDO2_H_
+/*
+ * Copyright (c) 2019 Markus Friedl
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _SK_LIBFIDO2_H_
+#define _SK_LIBFIDO2_H_
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -48,4 +64,4 @@ int sk_sign(int alg, const uint8_t *message_hash, size_t message_hash_len,
     const char *application, const uint8_t *key_handle, size_t key_handle_len,
     uint8_t flags, struct sk_sign_response **sign_response);
 
-#endif  // THIRD_PARTY_LIBFIDO2_TOOLS_SK_LIBFIDO2_H_
+#endif  // _SK_LIBFIDO2_H_


### PR DESCRIPTION
Factor out a header for convenient inclusion of this middleware, and also rename function parameters for readability.