### PR TITLE
fix attcred_raw.id_len on big-endian systems

### DIFF
--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -18,6 +18,7 @@
 #if defined(__APPLE__) && !defined(HAVE_ENDIAN_H)
 #include <libkern/OSByteOrder.h>
 #define be16toh(x) OSSwapBigToHostInt16((x))
+#define htobe16(x) OSSwapHostToBigInt16((x))
 #define be32toh(x) OSSwapBigToHostInt32((x))
 #endif /* __APPLE__ && !HAVE_ENDIAN_H */
 
@@ -27,6 +28,7 @@
 #include <sys/param.h>
 #endif
 #define be16toh(x) ntohs((x))
+#define htobe16(x) htons((x))
 #define be32toh(x) ntohl((x))
 #endif /* _WIN32 && !HAVE_ENDIAN_H */
 

--- a/src/u2f.c
+++ b/src/u2f.c
@@ -439,7 +439,7 @@ encode_cred_authdata(const char *rp_id, const uint8_t *kh, uint8_t kh_len,
 	authdata.sigcount = 0;
 
 	memset(&attcred_raw.aaguid, 0, sizeof(attcred_raw.aaguid));
-	attcred_raw.id_len = (uint16_t)(kh_len << 8); /* XXX */
+	attcred_raw.id_len = htobe16(kh_len);
 
 	len = authdata_blob.len = sizeof(authdata) + sizeof(attcred_raw) +
 	    kh_len + pk_blob.len;


### PR DESCRIPTION
This is a standalone fix for the endianness issue mentioned in #82.

The attested credential data uses big-endian encoding for the `credentialIdLength`:
https://www.w3.org/TR/webauthn/#sec-attested-credential-data