### PR TITLE
Custom transport

### DIFF
--- a/fuzz/fuzz_assert.c
+++ b/fuzz/fuzz_assert.c
@@ -354,12 +354,12 @@ get_assert(fido_assert_t *assert, uint8_t u2f, const struct blob *cdh,
 	fido_dev_t	*dev;
 	fido_dev_io_t	 io;
 
+	memset(&io, 0, sizeof(io));
+
 	io.open = dev_open;
 	io.close = dev_close;
 	io.read = dev_read;
 	io.write = dev_write;
-	io.rx = NULL;
-	io.tx = NULL;
 
 	if ((dev = fido_dev_new()) == NULL || fido_dev_set_io_functions(dev,
 	    &io) != FIDO_OK || fido_dev_open(dev, "nodev") != FIDO_OK) {

--- a/fuzz/fuzz_assert.c
+++ b/fuzz/fuzz_assert.c
@@ -358,6 +358,8 @@ get_assert(fido_assert_t *assert, uint8_t u2f, const struct blob *cdh,
 	io.close = dev_close;
 	io.read = dev_read;
 	io.write = dev_write;
+	io.rx = NULL;
+	io.tx = NULL;
 
 	if ((dev = fido_dev_new()) == NULL || fido_dev_set_io_functions(dev,
 	    &io) != FIDO_OK || fido_dev_open(dev, "nodev") != FIDO_OK) {

--- a/fuzz/fuzz_bio.c
+++ b/fuzz/fuzz_bio.c
@@ -481,6 +481,8 @@ prepare_dev()
 	io.close = dev_close;
 	io.read = dev_read;
 	io.write = dev_write;
+	io.rx = NULL;
+	io.tx = NULL;
 
 	if ((dev = fido_dev_new()) == NULL || fido_dev_set_io_functions(dev,
 	    &io) != FIDO_OK || fido_dev_open(dev, "nodev") != FIDO_OK) {

--- a/fuzz/fuzz_bio.c
+++ b/fuzz/fuzz_bio.c
@@ -477,12 +477,12 @@ prepare_dev()
 	fido_dev_t	*dev;
 	fido_dev_io_t	 io;
 
+	memset(&io, 0, sizeof(io));
+
 	io.open = dev_open;
 	io.close = dev_close;
 	io.read = dev_read;
 	io.write = dev_write;
-	io.rx = NULL;
-	io.tx = NULL;
 
 	if ((dev = fido_dev_new()) == NULL || fido_dev_set_io_functions(dev,
 	    &io) != FIDO_OK || fido_dev_open(dev, "nodev") != FIDO_OK) {

--- a/fuzz/fuzz_cred.c
+++ b/fuzz/fuzz_cred.c
@@ -697,6 +697,8 @@ make_cred(fido_cred_t *cred, uint8_t u2f, int type, const struct blob *cdh,
 	io.close = dev_close;
 	io.read = dev_read;
 	io.write = dev_write;
+	io.rx = NULL;
+	io.tx = NULL;
 
 	if ((dev = fido_dev_new()) == NULL || fido_dev_set_io_functions(dev,
 	    &io) != FIDO_OK || fido_dev_open(dev, "nodev") != FIDO_OK) {

--- a/fuzz/fuzz_cred.c
+++ b/fuzz/fuzz_cred.c
@@ -693,12 +693,12 @@ make_cred(fido_cred_t *cred, uint8_t u2f, int type, const struct blob *cdh,
 	fido_dev_t	*dev;
 	fido_dev_io_t	 io;
 
+	memset(&io, 0, sizeof(io));
+
 	io.open = dev_open;
 	io.close = dev_close;
 	io.read = dev_read;
 	io.write = dev_write;
-	io.rx = NULL;
-	io.tx = NULL;
 
 	if ((dev = fido_dev_new()) == NULL || fido_dev_set_io_functions(dev,
 	    &io) != FIDO_OK || fido_dev_open(dev, "nodev") != FIDO_OK) {

--- a/fuzz/fuzz_credman.c
+++ b/fuzz/fuzz_credman.c
@@ -434,6 +434,8 @@ prepare_dev()
 	io.close = dev_close;
 	io.read = dev_read;
 	io.write = dev_write;
+	io.rx = NULL;
+	io.tx = NULL;
 
 	if ((dev = fido_dev_new()) == NULL || fido_dev_set_io_functions(dev,
 	    &io) != FIDO_OK || fido_dev_open(dev, "nodev") != FIDO_OK) {

--- a/fuzz/fuzz_credman.c
+++ b/fuzz/fuzz_credman.c
@@ -430,12 +430,12 @@ prepare_dev()
 	fido_dev_t	*dev;
 	fido_dev_io_t	 io;
 
+	memset(&io, 0, sizeof(io));
+
 	io.open = dev_open;
 	io.close = dev_close;
 	io.read = dev_read;
 	io.write = dev_write;
-	io.rx = NULL;
-	io.tx = NULL;
 
 	if ((dev = fido_dev_new()) == NULL || fido_dev_set_io_functions(dev,
 	    &io) != FIDO_OK || fido_dev_open(dev, "nodev") != FIDO_OK) {

--- a/fuzz/fuzz_mgmt.c
+++ b/fuzz/fuzz_mgmt.c
@@ -287,6 +287,8 @@ prepare_dev()
 	io.close = dev_close;
 	io.read = dev_read;
 	io.write = dev_write;
+	io.rx = NULL;
+	io.tx = NULL;
 
 	if ((dev = fido_dev_new()) == NULL || fido_dev_set_io_functions(dev,
 	    &io) != FIDO_OK || fido_dev_open(dev, "nodev") != FIDO_OK) {

--- a/fuzz/fuzz_mgmt.c
+++ b/fuzz/fuzz_mgmt.c
@@ -283,12 +283,12 @@ prepare_dev()
 	fido_dev_t	*dev;
 	fido_dev_io_t	 io;
 
+	memset(&io, 0, sizeof(io));
+
 	io.open = dev_open;
 	io.close = dev_close;
 	io.read = dev_read;
 	io.write = dev_write;
-	io.rx = NULL;
-	io.tx = NULL;
 
 	if ((dev = fido_dev_new()) == NULL || fido_dev_set_io_functions(dev,
 	    &io) != FIDO_OK || fido_dev_open(dev, "nodev") != FIDO_OK) {

--- a/regress/assert.c
+++ b/regress/assert.c
@@ -87,31 +87,6 @@ dummy_write(void *handle, const unsigned char *buf, size_t len)
 	/* NOTREACHED */
 }
 
-static int
-dummy_rx(uint8_t cmd, unsigned char *buf, size_t len, int ms, fido_dev_t *dev)
-{
-	(void)cmd;
-	(void)buf;
-	(void)len;
-	(void)ms;
-	(void)dev;
-
-	abort();
-	/* NOTREACHED */
-}
-
-static int
-dummy_tx(uint8_t cmd, const unsigned char *buf, size_t len, fido_dev_t *dev)
-{
-	(void)cmd;
-	(void)buf;
-	(void)len;
-	(void)dev;
-
-	abort();
-	/* NOTREACHED */
-}
-
 static fido_assert_t *
 alloc_assert(void)
 {
@@ -241,14 +216,16 @@ empty_assert_tests(void)
 	fido_dev_io_t io_f;
 	int i;
 
+	memset(&io_f, 0, sizeof(io_f));
+
 	a = alloc_assert();
 	d = alloc_dev();
+
 	io_f.open = dummy_open;
 	io_f.close = dummy_close;
 	io_f.read = dummy_read;
 	io_f.write = dummy_write;
-	io_f.rx = dummy_rx;
-	io_f.tx = dummy_tx;
+
 	assert(fido_dev_set_io_functions(d, &io_f) == FIDO_OK);
 
 	empty_assert(d, a, 0);

--- a/regress/assert.c
+++ b/regress/assert.c
@@ -87,6 +87,31 @@ dummy_write(void *handle, const unsigned char *buf, size_t len)
 	/* NOTREACHED */
 }
 
+static int
+dummy_rx(uint8_t cmd, unsigned char *buf, size_t len, int ms, fido_dev_t *dev)
+{
+	(void)cmd;
+	(void)buf;
+	(void)len;
+	(void)ms;
+	(void)dev;
+
+	abort();
+	/* NOTREACHED */
+}
+
+static int
+dummy_tx(uint8_t cmd, const unsigned char *buf, size_t len, fido_dev_t *dev)
+{
+	(void)cmd;
+	(void)buf;
+	(void)len;
+	(void)dev;
+
+	abort();
+	/* NOTREACHED */
+}
+
 static fido_assert_t *
 alloc_assert(void)
 {
@@ -222,6 +247,8 @@ empty_assert_tests(void)
 	io_f.close = dummy_close;
 	io_f.read = dummy_read;
 	io_f.write = dummy_write;
+	io_f.rx = dummy_rx;
+	io_f.tx = dummy_tx;
 	assert(fido_dev_set_io_functions(d, &io_f) == FIDO_OK);
 
 	empty_assert(d, a, 0);

--- a/regress/cred.c
+++ b/regress/cred.c
@@ -271,31 +271,6 @@ dummy_write(void *handle, const unsigned char *buf, size_t len)
 	/* NOTREACHED */
 }
 
-static int
-dummy_rx(uint8_t cmd, unsigned char *buf, size_t len, int ms, fido_dev_t *dev)
-{
-	(void)cmd;
-	(void)buf;
-	(void)len;
-	(void)ms;
-	(void)dev;
-
-	abort();
-	/* NOTREACHED */
-}
-
-static int
-dummy_tx(uint8_t cmd, const unsigned char *buf, size_t len, fido_dev_t *dev)
-{
-	(void)cmd;
-	(void)buf;
-	(void)len;
-	(void)dev;
-
-	abort();
-	/* NOTREACHED */
-}
-
 static fido_cred_t *
 alloc_cred(void)
 {
@@ -358,12 +333,13 @@ empty_cred(void)
 	assert(fido_cred_x5c_ptr(c) == NULL);
 	assert(fido_cred_verify(c) == FIDO_ERR_INVALID_ARGUMENT);
 
+	memset(&io_f, 0, sizeof(io_f));
+
 	io_f.open = dummy_open;
 	io_f.close = dummy_close;
 	io_f.read = dummy_read;
 	io_f.write = dummy_write;
-	io_f.rx = dummy_rx;
-	io_f.tx = dummy_tx;
+
 	d = alloc_dev();
 
 	fido_dev_force_u2f(d);

--- a/regress/cred.c
+++ b/regress/cred.c
@@ -271,6 +271,31 @@ dummy_write(void *handle, const unsigned char *buf, size_t len)
 	/* NOTREACHED */
 }
 
+static int
+dummy_rx(uint8_t cmd, unsigned char *buf, size_t len, int ms, fido_dev_t *dev)
+{
+	(void)cmd;
+	(void)buf;
+	(void)len;
+	(void)ms;
+	(void)dev;
+
+	abort();
+	/* NOTREACHED */
+}
+
+static int
+dummy_tx(uint8_t cmd, const unsigned char *buf, size_t len, fido_dev_t *dev)
+{
+	(void)cmd;
+	(void)buf;
+	(void)len;
+	(void)dev;
+
+	abort();
+	/* NOTREACHED */
+}
+
 static fido_cred_t *
 alloc_cred(void)
 {
@@ -337,6 +362,8 @@ empty_cred(void)
 	io_f.close = dummy_close;
 	io_f.read = dummy_read;
 	io_f.write = dummy_write;
+	io_f.rx = dummy_rx;
+	io_f.tx = dummy_tx;
 	d = alloc_dev();
 
 	fido_dev_force_u2f(d);

--- a/regress/dev.c
+++ b/regress/dev.c
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include <fido.h>
+#include <string.h>
 
 #define FAKE_DEV_HANDLE	((void *)0xdeadbeef)
 #define REPORT_LEN	(64 + 1)
@@ -52,6 +53,7 @@ open_iff_ok(void)
 {
 	fido_dev_t	*dev = NULL;
 	fido_dev_io_t	 io;
+	memset(&io, 0, sizeof(fido_dev_io_t));
 
 	io.open = dummy_open;
 	io.close = dummy_close;

--- a/regress/dev.c
+++ b/regress/dev.c
@@ -53,7 +53,8 @@ open_iff_ok(void)
 {
 	fido_dev_t	*dev = NULL;
 	fido_dev_io_t	 io;
-	memset(&io, 0, sizeof(fido_dev_io_t));
+
+	memset(&io, 0, sizeof(io));
 
 	io.open = dummy_open;
 	io.close = dummy_close;

--- a/src/dev.c
+++ b/src/dev.c
@@ -302,13 +302,16 @@ fido_dev_set_io_functions(fido_dev_t *dev, const fido_dev_io_t *io)
 	}
 
 	if (io == NULL || io->open == NULL || io->close == NULL ||
-	    io->read == NULL || io->write == NULL || io->rx == NULL ||
-	    io->tx == NULL) {
+	    io->read == NULL || io->write == NULL) {
 		fido_log_debug("%s: NULL function", __func__);
 		return (FIDO_ERR_INVALID_ARGUMENT);
 	}
 
 	dev->dev_info->io = *io;
+	if (dev->dev_info->io.rx == NULL)
+		dev->dev_info->io.rx = fido_default_hid_rx;
+	if (dev->dev_info->io.tx == NULL)
+		dev->dev_info->io.tx = fido_default_hid_tx;
 
 	return (FIDO_OK);
 }
@@ -360,7 +363,7 @@ fido_dev_new_with_info(const fido_dev_info_t *dev_info)
 
 	if (dev_info->io.open == NULL || dev_info->io.close == NULL ||
 	    dev_info->io.read == NULL || dev_info->io.write == NULL ||
-			dev_info->io.rx == NULL || dev_info->io.tx == NULL) {
+	    dev_info->io.rx == NULL || dev_info->io.tx == NULL) {
 		fido_log_debug("%s: NULL function", __func__);
 		fido_dev_free(&dev);
 		return (NULL);

--- a/src/dev.c
+++ b/src/dev.c
@@ -302,7 +302,8 @@ fido_dev_set_io_functions(fido_dev_t *dev, const fido_dev_io_t *io)
 	}
 
 	if (io == NULL || io->open == NULL || io->close == NULL ||
-	    io->read == NULL || io->write == NULL) {
+	    io->read == NULL || io->write == NULL || io->rx == NULL ||
+	    io->tx == NULL) {
 		fido_log_debug("%s: NULL function", __func__);
 		return (FIDO_ERR_INVALID_ARGUMENT);
 	}
@@ -339,7 +340,9 @@ fido_dev_new(void)
 		&fido_hid_open,
 		&fido_hid_close,
 		&fido_hid_read,
-		&fido_hid_write
+		&fido_hid_write,
+		&fido_default_hid_rx,
+		&fido_default_hid_tx
 	};
 
 	return (dev);
@@ -356,7 +359,8 @@ fido_dev_new_with_info(const fido_dev_info_t *dev_info)
 	dev->cid = CTAP_CID_BROADCAST;
 
 	if (dev_info->io.open == NULL || dev_info->io.close == NULL ||
-	    dev_info->io.read == NULL || dev_info->io.write == NULL) {
+	    dev_info->io.read == NULL || dev_info->io.write == NULL ||
+			dev_info->io.rx == NULL || dev_info->io.tx == NULL) {
 		fido_log_debug("%s: NULL function", __func__);
 		fido_dev_free(&dev);
 		return (NULL);

--- a/src/extern.h
+++ b/src/extern.h
@@ -79,12 +79,6 @@ void cbor_vector_free(cbor_item_t **, size_t);
 int fido_buf_read(const unsigned char **, size_t *, void *, size_t);
 int fido_buf_write(unsigned char **, size_t *, const void *, size_t);
 
-/* hid i/o */
-void *fido_hid_open(const char *);
-void  fido_hid_close(void *);
-int   fido_hid_read(void *, unsigned char *, size_t, int);
-int   fido_hid_write(void *, const unsigned char *, size_t);
-
 /* generic i/o */
 int fido_rx_cbor_status(fido_dev_t *, int);
 int fido_rx(fido_dev_t *, uint8_t, void *, size_t, int);
@@ -136,6 +130,10 @@ int fido_verify_sig_eddsa(const fido_blob_t *, const eddsa_pk_t *,
 
 /* hid device manifest */
 int fido_hid_manifest(fido_dev_info_t *, size_t, size_t *);
+
+/* abstract hid tx/rx functions, implemented by io.c */
+int fido_default_hid_rx(uint8_t, unsigned char *, size_t, int, fido_dev_t *);
+int fido_default_hid_tx(uint8_t, const unsigned char *, size_t, fido_dev_t *);
 
 /* hid i/o */
 void *fido_hid_open(const char *);

--- a/src/extern.h
+++ b/src/extern.h
@@ -131,15 +131,15 @@ int fido_verify_sig_eddsa(const fido_blob_t *, const eddsa_pk_t *,
 /* hid device manifest */
 int fido_hid_manifest(fido_dev_info_t *, size_t, size_t *);
 
-/* abstract hid tx/rx functions, implemented by io.c */
-int fido_default_hid_rx(uint8_t, unsigned char *, size_t, int, fido_dev_t *);
-int fido_default_hid_tx(uint8_t, const unsigned char *, size_t, fido_dev_t *);
-
 /* hid i/o */
+// implemented in hid_*.c files
 void *fido_hid_open(const char *);
 void  fido_hid_close(void *);
 int fido_hid_read(void *, unsigned char *, size_t, int);
 int fido_hid_write(void *, const unsigned char *, size_t);
+// implemented in io.c
+int fido_default_hid_rx(uint8_t, unsigned char *, size_t, int, fido_dev_t *);
+int fido_default_hid_tx(uint8_t, const unsigned char *, size_t, fido_dev_t *);
 
 /* device manifest registration */
 typedef int (*dev_manifest_func_t)(fido_dev_info_t *, size_t, size_t *);

--- a/src/extern.h
+++ b/src/extern.h
@@ -79,6 +79,12 @@ void cbor_vector_free(cbor_item_t **, size_t);
 int fido_buf_read(const unsigned char **, size_t *, void *, size_t);
 int fido_buf_write(unsigned char **, size_t *, const void *, size_t);
 
+/* hid i/o */
+void *fido_hid_open(const char *);
+void  fido_hid_close(void *);
+int fido_hid_read(void *, unsigned char *, size_t, int);
+int fido_hid_write(void *, const unsigned char *, size_t);
+
 /* generic i/o */
 int fido_rx_cbor_status(fido_dev_t *, int);
 int fido_rx(fido_dev_t *, uint8_t, void *, size_t, int);
@@ -130,16 +136,6 @@ int fido_verify_sig_eddsa(const fido_blob_t *, const eddsa_pk_t *,
 
 /* hid device manifest */
 int fido_hid_manifest(fido_dev_info_t *, size_t, size_t *);
-
-/* hid i/o */
-// implemented in hid_*.c files
-void *fido_hid_open(const char *);
-void  fido_hid_close(void *);
-int fido_hid_read(void *, unsigned char *, size_t, int);
-int fido_hid_write(void *, const unsigned char *, size_t);
-// implemented in io.c
-int fido_default_hid_rx(uint8_t, unsigned char *, size_t, int, fido_dev_t *);
-int fido_default_hid_tx(uint8_t, const unsigned char *, size_t, fido_dev_t *);
 
 /* device manifest registration */
 typedef int (*dev_manifest_func_t)(fido_dev_info_t *, size_t, size_t *);

--- a/src/fido/types.h
+++ b/src/fido/types.h
@@ -8,17 +8,33 @@
 #define _FIDO_TYPES_H
 
 #include <stddef.h>
+#include <stdint.h>
+
+struct fido_dev;
 
 typedef void *fido_dev_io_open_t(const char *);
 typedef void  fido_dev_io_close_t(void *);
 typedef int   fido_dev_io_read_t(void *, unsigned char *, size_t, int);
 typedef int   fido_dev_io_write_t(void *, const unsigned char *, size_t);
+// an rx function should return number of bytes received on success,
+// -1 on error. Upon calling, the io_handle of fido_dev_t argument
+// would be set to the returned value of fido_dev_io_open_t (after calling
+// fido_dev_open_with_info or fido_dev_open)
+typedef int fido_dev_io_rx_t(uint8_t, unsigned char *, size_t, int,
+                             struct fido_dev *);
+// a tx function should return 0 on success, -1 on error. Upon calling, the
+// io_handle of fido_dev_t argument would be set to the returned value of
+// fido_dev_io_open_t (after calling fido_dev_open_with_info or fido_dev_open)
+typedef int fido_dev_io_tx_t(uint8_t, const unsigned char *, size_t,
+                             struct fido_dev *);
 
 typedef struct fido_dev_io {
 	fido_dev_io_open_t  *open;
 	fido_dev_io_close_t *close;
 	fido_dev_io_read_t  *read;
 	fido_dev_io_write_t *write;
+	fido_dev_io_rx_t *rx;
+	fido_dev_io_tx_t *tx;
 } fido_dev_io_t;
 
 typedef enum {

--- a/src/fido/types.h
+++ b/src/fido/types.h
@@ -16,25 +16,16 @@ typedef void *fido_dev_io_open_t(const char *);
 typedef void  fido_dev_io_close_t(void *);
 typedef int   fido_dev_io_read_t(void *, unsigned char *, size_t, int);
 typedef int   fido_dev_io_write_t(void *, const unsigned char *, size_t);
-// an rx function should return number of bytes received on success,
-// -1 on error. Upon calling, the io_handle of fido_dev_t argument
-// would be set to the returned value of fido_dev_io_open_t (after calling
-// fido_dev_open_with_info or fido_dev_open)
-typedef int fido_dev_io_rx_t(uint8_t, unsigned char *, size_t, int,
-                             struct fido_dev *);
-// a tx function should return 0 on success, -1 on error. Upon calling, the
-// io_handle of fido_dev_t argument would be set to the returned value of
-// fido_dev_io_open_t (after calling fido_dev_open_with_info or fido_dev_open)
-typedef int fido_dev_io_tx_t(uint8_t, const unsigned char *, size_t,
-                             struct fido_dev *);
+typedef int   fido_dev_io_rx_t(struct fido_dev *, uint8_t, unsigned char *, size_t, int);
+typedef int   fido_dev_io_tx_t(struct fido_dev *, uint8_t, const unsigned char *, size_t);
 
 typedef struct fido_dev_io {
 	fido_dev_io_open_t  *open;
 	fido_dev_io_close_t *close;
 	fido_dev_io_read_t  *read;
 	fido_dev_io_write_t *write;
-	fido_dev_io_rx_t *rx;
-	fido_dev_io_tx_t *tx;
+	fido_dev_io_rx_t    *rx;
+	fido_dev_io_tx_t    *tx;
 } fido_dev_io_t;
 
 typedef enum {
@@ -184,7 +175,7 @@ typedef struct fido_dev_info {
 	int16_t        product_id;   /* 2-byte product id */
 	char          *manufacturer; /* manufacturer string */
 	char          *product;      /* product string */
-	fido_dev_io_t  io;           /* device i/o functions */
+	fido_dev_io_t  io;           /* i/o functions */
 } fido_dev_info_t;
 
 PACKED_TYPE(fido_ctap_info_t,
@@ -203,8 +194,9 @@ typedef struct fido_dev {
 	uint64_t          nonce;     /* issued nonce */
 	fido_ctap_info_t  attr;      /* device attributes */
 	uint32_t          cid;       /* assigned channel id */
+	char             *path;      /* device path */
 	void             *io_handle; /* abstract i/o handle */
-	fido_dev_info_t  *dev_info;  /* dev infos */
+	fido_dev_io_t     io;        /* i/o functions */
 } fido_dev_t;
 
 #else

--- a/src/hid_hidapi.c
+++ b/src/hid_hidapi.c
@@ -122,8 +122,8 @@ fido_hid_manifest(fido_dev_info_t *dev_infos, size_t ilen, size_t *olen)
 				&fido_hid_close,
 				&fido_hid_read,
 				&fido_hid_write,
-				&fido_default_hid_rx,
-				&fido_default_hid_tx
+				NULL,
+				NULL,
 			};
 			(*olen)++;
 			curr_hid_dev = curr_hid_dev->next;

--- a/src/hid_hidapi.c
+++ b/src/hid_hidapi.c
@@ -121,7 +121,9 @@ fido_hid_manifest(fido_dev_info_t *dev_infos, size_t ilen, size_t *olen)
 				&fido_hid_open,
 				&fido_hid_close,
 				&fido_hid_read,
-				&fido_hid_write
+				&fido_hid_write,
+				&fido_default_hid_rx,
+				&fido_default_hid_tx
 			};
 			(*olen)++;
 			curr_hid_dev = curr_hid_dev->next;

--- a/src/hid_linux.c
+++ b/src/hid_linux.c
@@ -268,13 +268,13 @@ fido_hid_manifest(fido_dev_info_t *devlist, size_t ilen, size_t *olen)
 
 	udev_list_entry_foreach(udev_entry, udev_list) {
 		if (copy_info(&devlist[*olen], udev, udev_entry) == 0) {
-			devlist[*olen].io = (fido_dev_io_t){
+			devlist[*olen].io = (fido_dev_io_t) {
 				fido_hid_open,
 				fido_hid_close,
 				fido_hid_read,
 				fido_hid_write,
-				fido_default_hid_rx,
-				fido_default_hid_tx
+				NULL,
+				NULL,
 			};
 			if (++(*olen) == ilen)
 				break;

--- a/src/hid_linux.c
+++ b/src/hid_linux.c
@@ -272,7 +272,9 @@ fido_hid_manifest(fido_dev_info_t *devlist, size_t ilen, size_t *olen)
 				fido_hid_open,
 				fido_hid_close,
 				fido_hid_read,
-				fido_hid_write
+				fido_hid_write,
+				fido_default_hid_rx,
+				fido_default_hid_tx
 			};
 			if (++(*olen) == ilen)
 				break;

--- a/src/hid_openbsd.c
+++ b/src/hid_openbsd.c
@@ -105,7 +105,9 @@ fido_hid_manifest(fido_dev_info_t *devlist, size_t ilen, size_t *olen)
 			fido_hid_open,
 			fido_hid_close,
 			fido_hid_read,
-			fido_hid_write
+			fido_hid_write,
+			fido_default_hid_rx,
+			fido_default_hid_tx
 		};
 		if ((di->path = strdup(path)) == NULL ||
 		    (di->manufacturer = strdup(udi.udi_vendor)) == NULL ||

--- a/src/hid_openbsd.c
+++ b/src/hid_openbsd.c
@@ -101,13 +101,13 @@ fido_hid_manifest(fido_dev_info_t *devlist, size_t ilen, size_t *olen)
 
 		di = &devlist[*olen];
 		memset(di, 0, sizeof(*di));
-		di->io = (fido_dev_io_t){
+		di->io = (fido_dev_io_t) {
 			fido_hid_open,
 			fido_hid_close,
 			fido_hid_read,
 			fido_hid_write,
-			fido_default_hid_rx,
-			fido_default_hid_tx
+			NULL,
+			NULL,
 		};
 		if ((di->path = strdup(path)) == NULL ||
 		    (di->manufacturer = strdup(udi.udi_vendor)) == NULL ||

--- a/src/hid_osx.c
+++ b/src/hid_osx.c
@@ -240,13 +240,13 @@ fido_hid_manifest(fido_dev_info_t *devlist, size_t ilen, size_t *olen)
 
 	for (CFIndex i = 0; i < devcnt; i++) {
 		if (copy_info(&devlist[*olen], devs[i]) == 0) {
-			devlist[*olen].io = (fido_dev_io_t){
+			devlist[*olen].io = (fido_dev_io_t) {
 				fido_hid_open,
 				fido_hid_close,
 				fido_hid_read,
 				fido_hid_write,
-				fido_default_hid_rx,
-				fido_default_hid_tx
+				NULL,
+				NULL,
 			};
 			if (++(*olen) == ilen)
 				break;

--- a/src/hid_osx.c
+++ b/src/hid_osx.c
@@ -244,7 +244,9 @@ fido_hid_manifest(fido_dev_info_t *devlist, size_t ilen, size_t *olen)
 				fido_hid_open,
 				fido_hid_close,
 				fido_hid_read,
-				fido_hid_write
+				fido_hid_write,
+				fido_default_hid_rx,
+				fido_default_hid_tx
 			};
 			if (++(*olen) == ilen)
 				break;

--- a/src/hid_win.c
+++ b/src/hid_win.c
@@ -239,8 +239,8 @@ fido_hid_manifest(fido_dev_info_t *devlist, size_t ilen, size_t *olen)
 				fido_hid_close,
 				fido_hid_read,
 				fido_hid_write,
-				fido_default_hid_rx,
-				fido_default_hid_tx
+				NULL,
+				NULL,
 			};
 			if (++(*olen) == ilen)
 				break;

--- a/src/hid_win.c
+++ b/src/hid_win.c
@@ -238,7 +238,9 @@ fido_hid_manifest(fido_dev_info_t *devlist, size_t ilen, size_t *olen)
 				fido_hid_open,
 				fido_hid_close,
 				fido_hid_read,
-				fido_hid_write
+				fido_hid_write,
+				fido_default_hid_rx,
+				fido_default_hid_tx
 			};
 			if (++(*olen) == ilen)
 				break;

--- a/src/io.c
+++ b/src/io.c
@@ -85,33 +85,33 @@ tx_frame(fido_dev_t *d, int seq, const void *buf, size_t count)
 }
 
 int
-fido_default_hid_tx(uint8_t cmd, const unsigned char *payload, size_t len,
+fido_default_hid_tx(uint8_t cmd, const unsigned char *buf, size_t count,
                     fido_dev_t *d)
 {
-	int seq = 0;
-	size_t sent;
+	int	seq = 0;
+	size_t	sent;
 	fido_log_debug("%s: d=%p, cmd=0x%02x, payload=%p, len=%zu", __func__,
-	               (void *)d, cmd, (const void*) payload, len);
-	fido_log_xxd(payload, len);
+	               (void *)d, cmd, (const void*) buf, count);
+	fido_log_xxd(buf, count);
 
-	if (d->io_handle == NULL || len > UINT16_MAX) {
+	if (d->io_handle == NULL || count > UINT16_MAX) {
 		fido_log_debug("%s: invalid argument (%p, %zu)", __func__,
-		    d->io_handle, len);
+		    d->io_handle, count);
 		return (-1);
 	}
 
-	if ((sent = tx_preamble(d, cmd, payload, len)) == 0) {
+	if ((sent = tx_preamble(d, cmd, buf, count)) == 0) {
 		fido_log_debug("%s: tx_preamble", __func__);
 		return (-1);
 	}
 
-	while (sent < len) {
+	while (sent < count) {
 		if (seq & 0x80) {
 			fido_log_debug("%s: seq & 0x80", __func__);
 			return (-1);
 		}
-		const uint8_t *p = (const uint8_t *)payload + sent;
-		size_t n = tx_frame(d, seq++, p, len - sent);
+		const uint8_t *p = (const uint8_t *)buf + sent;
+		size_t n = tx_frame(d, seq++, p, count - sent);
 		if (n == 0) {
 			fido_log_debug("%s: tx_frame", __func__);
 			return (-1);


### PR DESCRIPTION
This branch is based on `custom-device-info-manifest`:
   - adds `fido_dev_io_tx_t` and `fido_dev_io_rx_t` to `fido_dev_io_t`
   - Defaults the two new i/o functions to the original `fido_tx` and `fido_rx` functions.
Combined with the changes in `custom-device-info-manifest`, this will allow easy registration of custom transport layers (e.g. BLE).