### PR TITLE
Record keyid for checkonly

### DIFF
--- a/src/u2f.c
+++ b/src/u2f.c
@@ -687,17 +687,14 @@ u2f_authenticate_single(fido_dev_t *dev, const fido_blob_t *key_id,
 		goto fail;
 	}
 
+	if (fido_blob_set(&fa->stmt[idx].id, key_id->ptr, key_id->len) < 0) {
+		fido_log_debug("%s: fido_blob_set", __func__);
+		r = FIDO_ERR_INTERNAL;
+		goto fail;
+	}
+
 	if (fa->up == FIDO_OPT_FALSE) {
 		fido_log_debug("%s: checking for key existence only", __func__);
-		// key_id is a valid key handle and the sent apdu was
-		// check-only. Count this as a good auth by recording key_id in
-		// fa->stmt[idx], but still return FIDO_ERR_USER_PRESENCE_REQUIRED to keep
-		// the semantics consistent with the upstream.
-		if (fido_blob_set(&fa->stmt[idx].id, key_id->ptr, key_id->len) < 0) {
-			fido_log_debug("%s: fido_blob_set", __func__);
-			r = FIDO_ERR_INTERNAL;
-			goto fail;
-		}
 		r = FIDO_ERR_USER_PRESENCE_REQUIRED;
 		goto fail;
 	}
@@ -708,8 +705,7 @@ u2f_authenticate_single(fido_dev_t *dev, const fido_blob_t *key_id,
 		goto fail;
 	}
 
-	if (fido_blob_set(&fa->stmt[idx].id, key_id->ptr, key_id->len) < 0 ||
-	    fido_assert_set_authdata(fa, idx, ad.ptr, ad.len) != FIDO_OK ||
+	if (fido_assert_set_authdata(fa, idx, ad.ptr, ad.len) != FIDO_OK ||
 	    fido_assert_set_sig(fa, idx, sig.ptr, sig.len) != FIDO_OK) {
 		fido_log_debug("%s: fido_assert_set", __func__);
 		r = FIDO_ERR_INTERNAL;

--- a/src/u2f.c
+++ b/src/u2f.c
@@ -734,7 +734,7 @@ int
 u2f_authenticate(fido_dev_t *dev, fido_assert_t *fa, int ms)
 {
 	int	nauth_ok = 0;
-	int nauth_ok_with_up = 0;
+	int	nauth_ok_with_up = 0;
 	int	r;
 
 	if (fa->uv == FIDO_OPT_TRUE || fa->allow_list.ptr == NULL) {


### PR DESCRIPTION
Hi, Pedro,
   This change is intended to let fido_dev_get_assert records the key_id in the attstmt_t for check-only cases as well. We believe this is a common use case (a user has a sequence of key_ids from the rp and they want to check which one of them is valid for the device, without a user touch).