### PR TITLE
Make fido_log_xxd call log_handler once per line.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,7 @@ list(APPEND COMPAT_SOURCES
 	../openbsd-compat/explicit_bzero.c
 	../openbsd-compat/explicit_bzero_win32.c
 	../openbsd-compat/recallocarray.c
+	../openbsd-compat/strlcat.c
 	../openbsd-compat/timingsafe_bcmp.c
 )
 

--- a/src/dev.c
+++ b/src/dev.c
@@ -237,7 +237,7 @@ fido_dev_info_manifest(fido_dev_info_t *devlist, size_t ilen, size_t *olen)
 
 	*olen = 0;
 
-        if (fido_dev_register_manifest_func(fido_hid_manifest) != FIDO_OK)
+	if (fido_dev_register_manifest_func(fido_hid_manifest) != FIDO_OK)
 		return (FIDO_ERR_INTERNAL);
 
 	for (curr = manifest_funcs; curr != NULL; curr = curr->next) {

--- a/src/log.c
+++ b/src/log.c
@@ -8,12 +8,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "fido.h"
 
 #ifndef FIDO_NO_DIAGNOSTIC
 
-#define XXD_LEN	8
-#define FMT_LEN	1024
+#define XXDLEN	8
+#define XXDROW	256
+#define LINELEN	1024
 
 #ifndef TLS
 #define TLS
@@ -36,46 +38,47 @@ fido_log_init(void)
 }
 
 void
-fido_log_xxd(const void *buf, size_t count)
-{
-	const uint8_t	*ptr = buf;
-	char		 log_line_buf[XXD_LEN * 16] = "  ";
-	size_t		 i;
-
-	if (!logging || log_handler == NULL)
-		return;
-
-	for (i = 0; i < count; i++) {
-		char c[XXD_LEN] = "\0";
-		snprintf(c, sizeof(c), "%02x ", *ptr++);
-		strcat(log_line_buf, c);
-		if ((i + 1) % 16 == 0 && i + 1 < count) {
-			strcat(log_line_buf, "\n");
-			log_handler(log_line_buf);
-			strcpy(log_line_buf, "  ");
-		}
-	}
-	strcat(log_line_buf, "\n");
-	log_handler(log_line_buf);
-}
-
-void
 fido_log_debug(const char *fmt, ...)
 {
-	char    fmtbuf[FMT_LEN];
+	char line[LINELEN];
 	va_list ap;
+	int r;
 
 	if (!logging || log_handler == NULL)
 		return;
 
 	va_start(ap, fmt);
-	size_t n = vsnprintf(fmtbuf, sizeof(fmtbuf), fmt, ap);
+	r = vsnprintf(line, sizeof(line) - 1, fmt, ap);
 	va_end(ap);
+	if (r < 0 || (size_t)r >= sizeof(line) - 1)
+		return;
+	strlcat(line, "\n", sizeof(line));
+	log_handler(line);
+}
 
-	if (n + 1 < sizeof(fmtbuf)) {
-		strncpy(fmtbuf + n, "\n", sizeof(fmtbuf) - n);
+void
+fido_log_xxd(const void *buf, size_t count)
+{
+	const uint8_t *ptr = buf;
+	char row[XXDROW];
+	char xxd[XXDLEN];
+	size_t i;
+
+	if (!logging || log_handler == NULL || count == 0)
+		return;
+
+	*row = '\0';
+
+	for (i = 0; i < count; i++) {
+		*xxd = '\0';
+		snprintf(xxd, sizeof(xxd), "%s%02x", (i % 16) ? " " : "  ",
+		    *ptr++);
+		strlcat(row, xxd, sizeof(row));
+		if ((i % 16) == 15 || i == count - 1) {
+			fido_log_debug("%s", row);
+			*row = '\0';
+		}
 	}
-	log_handler(fmtbuf);
 }
 
 void


### PR DESCRIPTION
 This makes the xxd message stay in the same line in some log system.

E.g in windows syslog, each call will occupy one line in the log system.