### PR TITLE
src/log.c: bump XXDLEN 16->32 to ensure buffer isn't too small

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -13,7 +13,7 @@
 
 #ifndef FIDO_NO_DIAGNOSTIC
 
-#define XXDLEN	16
+#define XXDLEN	32
 #define XXDROW	128
 #define LINELEN	256
 


### PR DESCRIPTION
GCC 8 and GCC 9 both are uncomfortable with the snprintf'ing
of format string "%04zu: %02x" fitting into 16 bytes,
and it's unclear to me this is an unwarranted concern.

If the buffer is indeed too small, the result would not
be a memory safety error AFAIK but the truncated string
would provide poor log messages.

Likely harmless but instead of worrying about any of that
just allocate a few more bytes to make it clear to programmers and
compilers alike that there's nothing to worry about.