### PR TITLE
headers: Add 'extern "C"' declarations for C++ support.

### DIFF
--- a/src/blob.h
+++ b/src/blob.h
@@ -10,6 +10,10 @@
 #include <cbor.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 typedef struct fido_blob {
 	unsigned char	*ptr;
 	size_t		 len;
@@ -27,5 +31,9 @@ int fido_blob_is_empty(const fido_blob_t *);
 int fido_blob_set(fido_blob_t *, const unsigned char *, size_t);
 void fido_blob_free(fido_blob_t **);
 void fido_free_blob_array(fido_blob_array_t *);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif /* !_BLOB_H */

--- a/src/extern.h
+++ b/src/extern.h
@@ -12,6 +12,10 @@
 #include "fido/types.h"
 #include "blob.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /* aes256 */
 int aes256_cbc_dec(const fido_blob_t *, const fido_blob_t *, fido_blob_t *);
 int aes256_cbc_enc(const fido_blob_t *, const fido_blob_t *, fido_blob_t *);
@@ -142,5 +146,9 @@ int fido_hid_manifest(fido_dev_info_t *, size_t, size_t *);
 typedef int (*dev_manifest_func_t)(fido_dev_info_t *, size_t, size_t *);
 int fido_dev_register_manifest_func(const dev_manifest_func_t);
 void fido_dev_unregister_manifest_func(const dev_manifest_func_t);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif /* !_EXTERN_H */

--- a/src/fido.h
+++ b/src/fido.h
@@ -173,7 +173,7 @@ uint64_t fido_cbor_info_maxmsgsiz(const fido_cbor_info_t *);
 bool fido_dev_is_fido2(const fido_dev_t *);
 
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif /* !_FIDO_H */

--- a/src/fido.h
+++ b/src/fido.h
@@ -28,6 +28,10 @@
 #include "fido/param.h"
 #include "fido/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 fido_assert_t *fido_assert_new(void);
 fido_cred_t *fido_cred_new(void);
 fido_dev_t *fido_dev_new(void);
@@ -167,5 +171,9 @@ int16_t  fido_dev_info_product(const fido_dev_info_t *);
 uint64_t fido_cbor_info_maxmsgsiz(const fido_cbor_info_t *);
 
 bool fido_dev_is_fido2(const fido_dev_t *);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
 
 #endif /* !_FIDO_H */

--- a/src/fido/bio.h
+++ b/src/fido/bio.h
@@ -21,6 +21,10 @@
 #include <fido/param.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #ifdef _FIDO_INTERNAL
 struct fido_bio_template {
 	fido_blob_t id;
@@ -99,5 +103,9 @@ void fido_bio_enroll_free(fido_bio_enroll_t **);
 void fido_bio_info_free(fido_bio_info_t **);
 void fido_bio_template_array_free(fido_bio_template_array_t **);
 void fido_bio_template_free(fido_bio_template_t **);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif /* !_FIDO_BIO_H */

--- a/src/fido/credman.h
+++ b/src/fido/credman.h
@@ -21,6 +21,10 @@
 #include <fido/param.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #ifdef _FIDO_INTERNAL
 struct fido_credman_metadata {
 	uint64_t rk_existing;
@@ -78,5 +82,9 @@ uint64_t fido_credman_rk_remaining(const fido_credman_metadata_t *);
 void fido_credman_metadata_free(fido_credman_metadata_t **);
 void fido_credman_rk_free(fido_credman_rk_t **);
 void fido_credman_rp_free(fido_credman_rp_t **);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif /* !_FIDO_CREDMAN_H */

--- a/src/fido/eddsa.h
+++ b/src/fido/eddsa.h
@@ -18,6 +18,10 @@
 #include <fido.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 eddsa_pk_t *eddsa_pk_new(void);
 void eddsa_pk_free(eddsa_pk_t **);
 EVP_PKEY *eddsa_pk_to_EVP_PKEY(const eddsa_pk_t *);
@@ -40,6 +44,10 @@ int EVP_DigestVerify(EVP_MD_CTX *, const unsigned char *, size_t,
 EVP_MD_CTX *EVP_MD_CTX_new(void);
 void EVP_MD_CTX_free(EVP_MD_CTX *);
 #endif
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif /* _FIDO_INTERNAL */
 

--- a/src/fido/eddsa.h
+++ b/src/fido/eddsa.h
@@ -45,10 +45,10 @@ EVP_MD_CTX *EVP_MD_CTX_new(void);
 void EVP_MD_CTX_free(EVP_MD_CTX *);
 #endif
 
+#endif /* _FIDO_INTERNAL */
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */
-
-#endif /* _FIDO_INTERNAL */
 
 #endif /* !_FIDO_EDDSA_H */

--- a/src/fido/err.h
+++ b/src/fido/err.h
@@ -64,6 +64,14 @@
 #define FIDO_ERR_USER_PRESENCE_REQUIRED	-8
 #define FIDO_ERR_INTERNAL		-9
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 const char *fido_strerr(int);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif /* _FIDO_ERR_H */

--- a/src/fido/es256.h
+++ b/src/fido/es256.h
@@ -18,6 +18,10 @@
 #include <fido.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 es256_pk_t *es256_pk_new(void);
 void es256_pk_free(es256_pk_t **);
 EVP_PKEY *es256_pk_to_EVP_PKEY(const es256_pk_t *);
@@ -36,5 +40,9 @@ int es256_sk_create(es256_sk_t *);
 int es256_pk_set_x(es256_pk_t *, const unsigned char *);
 int es256_pk_set_y(es256_pk_t *, const unsigned char *);
 #endif
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif /* !_FIDO_ES256_H */

--- a/src/fido/rs256.h
+++ b/src/fido/rs256.h
@@ -18,11 +18,19 @@
 #include <fido.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 rs256_pk_t *rs256_pk_new(void);
 void rs256_pk_free(rs256_pk_t **);
 EVP_PKEY *rs256_pk_to_EVP_PKEY(const rs256_pk_t *);
 
 int rs256_pk_from_RSA(rs256_pk_t *, const RSA *);
 int rs256_pk_from_ptr(rs256_pk_t *, const void *, size_t);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif /* !_FIDO_RS256_H */

--- a/src/fido/types.h
+++ b/src/fido/types.h
@@ -10,6 +10,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 struct fido_dev;
 
 typedef void *fido_dev_io_open_t(const char *);
@@ -217,5 +221,9 @@ typedef struct es256_sk es256_sk_t;
 typedef struct rs256_pk rs256_pk_t;
 typedef struct eddsa_pk eddsa_pk_t;
 #endif /* _FIDO_INTERNAL */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif /* !_FIDO_TYPES_H */

--- a/src/iso7816.h
+++ b/src/iso7816.h
@@ -12,6 +12,10 @@
 
 #include "packed.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 PACKED_TYPE(iso7816_header_t,
 struct iso7816_header {
 	uint8_t cla;
@@ -37,5 +41,9 @@ int iso7816_add(iso7816_apdu_t *, const void *, size_t);
 iso7816_apdu_t *iso7816_new(uint8_t, uint8_t, uint16_t);
 size_t iso7816_len(const iso7816_apdu_t *);
 void iso7816_free(iso7816_apdu_t **);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif /* !_ISO7816_H */


### PR DESCRIPTION
Linking libfido2 into a C++ project will fail, as the headers
are missing the 'extern "C"' declarations - thus, the linker will
assume C++ name wrangling and fail to find the invoked functions into
libfido2.so. Add extern "C" to all declarations inside header files.