### PR TITLE
Update FreeBSD manpage location

### DIFF
--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -5,7 +5,7 @@
 find_program(MANDOC_PATH mandoc)
 message(STATUS "MANDOC_PATH: ${MANDOC_PATH}")
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	find_program(GZIP_PATH gzip)
 	message(STATUS "GZIP_PATH: ${GZIP_PATH}")
 endif()


### PR DESCRIPTION
LOCALBASE/share/man is a valid path for manpages since [r523104](https://svnweb.freebsd.org/changeset/ports/523104).