### PR TITLE
Add MSYS and CYGWIN build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,11 @@ add_definitions(-D_FIDO_MAJOR=${FIDO_MAJOR})
 add_definitions(-D_FIDO_MINOR=${FIDO_MINOR})
 add_definitions(-D_FIDO_PATCH=${FIDO_PATCH})
 
+if(CYGWIN OR MSYS)
+	set(WIN32 1)
+	add_definitions(-DWINVER=0x0a00)
+endif()
+
 if(WIN32)
 	add_definitions(-DWIN32_LEAN_AND_MEAN)
 endif()
@@ -133,6 +138,8 @@ else()
 	if(HAVE_STACK_PROTECTOR_ALL)
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")
 	endif()
+
+	add_definitions(-D_DEFAULT_SOURCE)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 
 	set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g2")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,7 +8,7 @@ list(APPEND COMPAT_SOURCES
 	../openbsd-compat/strlcpy.c
 )
 
-if(WIN32)
+if(WIN32 AND NOT CYGWIN AND NOT MSYS)
 	list(APPEND COMPAT_SOURCES ../openbsd-compat/posix_win.c)
 endif()
 

--- a/openbsd-compat/readpassphrase.c
+++ b/openbsd-compat/readpassphrase.c
@@ -52,7 +52,7 @@
 #  define _POSIX_VDISABLE       VDISABLE
 #endif
 
-static volatile sig_atomic_t signo[_NSIG];
+static volatile sig_atomic_t signo[NSIG];
 
 static void handler(int);
 
@@ -73,7 +73,7 @@ readpassphrase(const char *prompt, char *buf, size_t bufsiz, int flags)
 	}
 
 restart:
-	for (i = 0; i < _NSIG; i++)
+	for (i = 0; i < NSIG; i++)
 		signo[i] = 0;
 	need_restart = 0;
 	/*
@@ -177,7 +177,7 @@ restart:
 	 * If we were interrupted by a signal, resend it to ourselves
 	 * now that we have restored the signal handlers.
 	 */
-	for (i = 0; i < _NSIG; i++) {
+	for (i = 0; i < NSIG; i++) {
 		if (signo[i]) {
 			kill(getpid(), i);
 			switch (i) {

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -8,7 +8,7 @@ list(APPEND COMPAT_SOURCES
 	../openbsd-compat/strlcat.c
 )
 
-if(WIN32)
+if(WIN32 AND NOT CYGWIN AND NOT MSYS)
 	list(APPEND COMPAT_SOURCES
 		../openbsd-compat/bsd-getline.c
 		../openbsd-compat/explicit_bzero_win32.c


### PR DESCRIPTION
#132 asked for it. So this is my take.

Actually I found some interesting quirks, that could be problematic in other cases as well, e.g. using _NSIG instead of NSIG.

And that defining -std=c99 you don't get some some functions like strdup, so I defined _DEFAULT_SOURCE as I guess this does not hurt to make sure they are in...