### PR TITLE
Warn fido21 pre

### DIFF
--- a/man/fido_bio_dev_get_info.3
+++ b/man/fido_bio_dev_get_info.3
@@ -34,8 +34,9 @@
 .Sh DESCRIPTION
 The functions described in this page allow biometric
 templates on a FIDO2 authenticator to be listed, created,
-removed, and customised. As the functions build on a draft 
-specification they may be subject to future changes.
+removed, and customised.
+Please note that not all FIDO2 authenticators support biometric
+enrollment.
 For a description of the types involved, please refer to
 .Xr fido_bio_info_new 3 ,
 .Xr fido_bio_enroll_new 3 ,

--- a/man/fido_bio_dev_get_info.3
+++ b/man/fido_bio_dev_get_info.3
@@ -115,6 +115,14 @@ are defined in
 On success,
 .Dv FIDO_OK
 is returned.
+.Sh CAVEATS
+Biometric enrollment is a tentative feature of FIDO 2.1.
+Applications willing to strictly abide by FIDO 2.0 should refrain
+from using biometric enrollment.
+Applications using biometric enrollment should ensure it is
+supported by the authenticator prior to using the API.
+Since FIDO 2.1 hasn't been finalised, there is a chance the
+functionality and associated data structures may change.
 .Sh SEE ALSO
 .Xr fido_bio_enroll_new 3 ,
 .Xr fido_bio_info_new 3 ,

--- a/man/fido_bio_dev_get_info.3
+++ b/man/fido_bio_dev_get_info.3
@@ -34,7 +34,8 @@
 .Sh DESCRIPTION
 The functions described in this page allow biometric
 templates on a FIDO2 authenticator to be listed, created,
-removed, and customised.
+removed, and customised. As the functions build on a draft 
+specification they may be subject to future changes.
 For a description of the types involved, please refer to
 .Xr fido_bio_info_new 3 ,
 .Xr fido_bio_enroll_new 3 ,

--- a/man/fido_bio_dev_get_info.3
+++ b/man/fido_bio_dev_get_info.3
@@ -116,6 +116,10 @@ are defined in
 On success,
 .Dv FIDO_OK
 is returned.
+.Sh SEE ALSO
+.Xr fido_bio_enroll_new 3 ,
+.Xr fido_bio_info_new 3 ,
+.Xr fido_bio_template 3
 .Sh CAVEATS
 Biometric enrollment is a tentative feature of FIDO 2.1.
 Applications willing to strictly abide by FIDO 2.0 should refrain
@@ -124,7 +128,3 @@ Applications using biometric enrollment should ensure it is
 supported by the authenticator prior to using the API.
 Since FIDO 2.1 hasn't been finalised, there is a chance the
 functionality and associated data structures may change.
-.Sh SEE ALSO
-.Xr fido_bio_enroll_new 3 ,
-.Xr fido_bio_info_new 3 ,
-.Xr fido_bio_template 3

--- a/man/fido_credman_metadata_new.3
+++ b/man/fido_credman_metadata_new.3
@@ -72,7 +72,9 @@ The credential management API of
 .Em libfido2
 allows resident credentials on a FIDO2 authenticator to be listed,
 inspected, and removed.
-Please note that not all authenticators support credential management.
+Please note that not all FIDO2 authenticators support credential management 
+as it uses a draft specification of the credentials management API.
+The functions and structures may be subject to future changes.
 To obtain information on what an authenticator supports, please
 refer to
 .Xr fido_cbor_info_new 3 .

--- a/man/fido_credman_metadata_new.3
+++ b/man/fido_credman_metadata_new.3
@@ -295,6 +295,9 @@ On error, a different error code defined in
 is returned.
 Functions returning pointers are not guaranteed to succeed, and
 should have their return values checked for NULL.
+.Sh SEE ALSO
+.Xr fido_cbor_info_new 3 ,
+.Xr fido_cred_new 3
 .Sh CAVEATS
 Credential management is a tentative feature of FIDO 2.1.
 Applications willing to strictly abide by FIDO 2.0 should refrain
@@ -303,6 +306,3 @@ Applications using credential management should ensure it is
 supported by the authenticator prior to using the API.
 Since FIDO 2.1 hasn't been finalised, there is a chance the
 functionality and associated data structures may change.
-.Sh SEE ALSO
-.Xr fido_cbor_info_new 3 ,
-.Xr fido_cred_new 3

--- a/man/fido_credman_metadata_new.3
+++ b/man/fido_credman_metadata_new.3
@@ -72,9 +72,8 @@ The credential management API of
 .Em libfido2
 allows resident credentials on a FIDO2 authenticator to be listed,
 inspected, and removed.
-Please note that not all FIDO2 authenticators support credential management 
-as it uses a draft specification of the credentials management API.
-The functions and structures may be subject to future changes.
+Please note that not all FIDO2 authenticators support credential
+management.
 To obtain information on what an authenticator supports, please
 refer to
 .Xr fido_cbor_info_new 3 .
@@ -296,6 +295,14 @@ On error, a different error code defined in
 is returned.
 Functions returning pointers are not guaranteed to succeed, and
 should have their return values checked for NULL.
+.Sh CAVEATS
+Credential management is a tentative feature of FIDO 2.1.
+Applications willing to strictly abide by FIDO 2.0 should refrain
+from using credential management.
+Applications using credential management should ensure it is
+supported by the authenticator prior to using the API.
+Since FIDO 2.1 hasn't been finalised, there is a chance the
+functionality and associated data structures may change.
 .Sh SEE ALSO
 .Xr fido_cbor_info_new 3 ,
 .Xr fido_cred_new 3


### PR DESCRIPTION
Since I complained about the documentation in #129 , maybe it makes sense to add a least a word of warning that the functions are not included in the current spec.