### PR TITLE
Add FreeBSD support for usbhid library detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,8 @@ else()
 		add_definitions(-D_GNU_SOURCE)
 		# If using hidapi, use hidapi-hidraw.
 		set(HIDAPI_SUFFIX -hidraw)
-	elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+	elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR
+	       CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
 		set(BASE_LIBRARIES usbhid)
 	endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ else()
 		add_definitions(-D_GNU_SOURCE)
 		# If using hidapi, use hidapi-hidraw.
 		set(HIDAPI_SUFFIX -hidraw)
-	elseif(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+	elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
 		set(BASE_LIBRARIES usbhid)
 	endif()
 


### PR DESCRIPTION
It avoid manually setting "LDFLAGS+= -lusbhid" in the ports Makefile.