### PR TITLE
remove several unnecessary fuzz wrappers

### DIFF
--- a/fuzz/wrap.c
+++ b/fuzz/wrap.c
@@ -232,22 +232,6 @@ WRAP(EC_KEY *,
 	1
 )
 
-WRAP(const EC_GROUP *,
-	EC_KEY_get0_group,
-	(const EC_KEY *key),
-	NULL,
-	(key),
-	1
-)
-
-WRAP(const BIGNUM *,
-	EC_KEY_get0_private_key,
-	(const EC_KEY *key),
-	NULL,
-	(key),
-	1
-)
-
 WRAP(EC_POINT *,
 	EC_POINT_new,
 	(const EC_GROUP *group),
@@ -472,22 +456,6 @@ WRAP(cbor_item_t *,
 	(uint32_t value),
 	NULL,
 	(value),
-	1
-)
-
-WRAP(struct cbor_pair *,
-	cbor_map_handle,
-	(const cbor_item_t *item),
-	NULL,
-	(item),
-	1
-)
-
-WRAP(cbor_item_t **,
-	cbor_array_handle,
-	(const cbor_item_t *item),
-	NULL,
-	(item),
 	1
 )
 

--- a/fuzz/wrapped.sym
+++ b/fuzz/wrapped.sym
@@ -4,7 +4,6 @@ BN_CTX_get
 BN_CTX_new
 BN_new
 calloc
-cbor_array_handle
 cbor_array_push
 cbor_build_bool
 cbor_build_bytestring
@@ -15,12 +14,9 @@ cbor_build_uint32
 cbor_build_uint8
 cbor_load
 cbor_map_add
-cbor_map_handle
 cbor_new_definite_array
 cbor_new_definite_map
 cbor_serialize_alloc
-EC_KEY_get0_group
-EC_KEY_get0_private_key
 EC_KEY_new_by_curve_name
 EC_POINT_get_affine_coordinates_GFp
 EC_POINT_new


### PR DESCRIPTION
The EC_KEY_get0_* and the two handle functions have deterministic behaviors---they return successful values for valid inputs, and error values otherwise. I don't think these functions should be wrapped to mock probabilistic failures. Indeed, our fuzzing tool has generated false-negative reports due to these mocking.