### PR TITLE
hid_openbsd: synchronize changes from OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ else()
 		set(HIDAPI_SUFFIX -hidraw)
 	elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR
 	       CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
-		set(BASE_LIBRARIES usbhid)
+		set(BASE_LIBRARIES)
 	endif()
 
 	if(MINGW)

--- a/src/hid_openbsd.c
+++ b/src/hid_openbsd.c
@@ -20,7 +20,7 @@
 #include "fido.h"
 
 #define MAX_UHID	64
-#define MAX_REPORT_LEN	(sizeof(((struct usb_ctl_report *)(NULL))->ucr_data))
+#define MAX_U2FHID_LEN	64
 
 struct hid_openbsd {
 	int fd;
@@ -33,11 +33,8 @@ fido_hid_manifest(fido_dev_info_t *devlist, size_t ilen, size_t *olen)
 {
 	size_t i;
 	char path[64];
-	int is_fido, fd;
+	int fd;
 	struct usb_device_info udi;
-	report_desc_t rdesc = NULL;
-	hid_data_t hdata = NULL;
-	hid_item_t hitem;
 	fido_dev_info_t *di;
 
 	if (ilen == 0)
@@ -47,7 +44,7 @@ fido_hid_manifest(fido_dev_info_t *devlist, size_t ilen, size_t *olen)
 		return (FIDO_ERR_INVALID_ARGUMENT);
 
 	for (i = *olen = 0; i < MAX_UHID && *olen < ilen; i++) {
-		snprintf(path, sizeof(path), "/dev/uhid%zu", i);
+		snprintf(path, sizeof(path), "/dev/fido/%zu", i);
 		if ((fd = open(path, O_RDWR)) == -1) {
 			if (errno != ENOENT && errno != ENXIO) {
 				fido_log_debug("%s: open %s: %s", __func__,
@@ -55,6 +52,7 @@ fido_hid_manifest(fido_dev_info_t *devlist, size_t ilen, size_t *olen)
 			}
 			continue;
 		}
+
 		memset(&udi, 0, sizeof(udi));
 		if (ioctl(fd, USB_GET_DEVICEINFO, &udi) != 0) {
 			fido_log_debug("%s: get device info %s: %s", __func__,
@@ -62,34 +60,7 @@ fido_hid_manifest(fido_dev_info_t *devlist, size_t ilen, size_t *olen)
 			close(fd);
 			continue;
 		}
-		if ((rdesc = hid_get_report_desc(fd)) == NULL) {
-			fido_log_debug("%s: failed to get report descriptor: %s",
-			    __func__, path);
-			close(fd);
-			continue;
-		}
-		if ((hdata = hid_start_parse(rdesc,
-		    1<<hid_collection, -1)) == NULL) {
-			fido_log_debug("%s: failed to parse report descriptor: %s",
-			    __func__, path);
-			hid_dispose_report_desc(rdesc);
-			close(fd);
-			continue;
-		}
-		is_fido = 0;
-		for (is_fido = 0; !is_fido;) {
-			memset(&hitem, 0, sizeof(hitem));
-			if (hid_get_item(hdata, &hitem) <= 0)
-				break;
-			if ((hitem._usage_page & 0xFFFF0000) == 0xf1d00000)
-				is_fido = 1;
-		}
-		hid_end_parse(hdata);
-		hid_dispose_report_desc(rdesc);
 		close(fd);
-
-		if (!is_fido)
-			continue;
 
 		fido_log_debug("%s: %s: bus = 0x%02x, addr = 0x%02x",
 		    __func__, path, udi.udi_bus, udi.udi_addr);
@@ -184,42 +155,15 @@ void *
 fido_hid_open(const char *path)
 {
 	struct hid_openbsd *ret = NULL;
-	report_desc_t rdesc = NULL;
-	int len, usb_report_id = 0;
 
 	if ((ret = calloc(1, sizeof(*ret))) == NULL ||
 	    (ret->fd = open(path, O_RDWR)) < 0) {
 		free(ret);
 		return (NULL);
 	}
-	if (ioctl(ret->fd, USB_GET_REPORT_ID, &usb_report_id) != 0) {
-		fido_log_debug("%s: failed to get report ID: %s", __func__,
-		    strerror(errno));
-		goto fail;
-	}
-	if ((rdesc = hid_get_report_desc(ret->fd)) == NULL) {
-		fido_log_debug("%s: failed to get report descriptor", __func__);
-		goto fail;
-	}
-	if ((len = hid_report_size(rdesc, hid_input, usb_report_id)) <= 0 ||
-	    (size_t)len > MAX_REPORT_LEN) {
-		fido_log_debug("%s: bad input report size %d", __func__, len);
-		goto fail;
-	}
-	ret->report_in_len = (size_t)len;
-	if ((len = hid_report_size(rdesc, hid_output, usb_report_id)) <= 0 ||
-	    (size_t)len > MAX_REPORT_LEN) {
-		fido_log_debug("%s: bad output report size %d", __func__, len);
- fail:
-		hid_dispose_report_desc(rdesc);
-		close(ret->fd);
-		free(ret);
-		return NULL;
-	}	
-	ret->report_out_len = (size_t)len;
-	hid_dispose_report_desc(rdesc);
-	fido_log_debug("%s: USB report ID %d, inlen = %zu outlen = %zu",
-	    __func__, usb_report_id, ret->report_in_len, ret->report_out_len);
+	ret->report_in_len = ret->report_out_len = MAX_U2FHID_LEN;
+	fido_log_debug("%s: inlen = %zu outlen = %zu", __func__,
+	    ret->report_in_len, ret->report_out_len);
 
 	/*
 	 * OpenBSD (as of 201910) has a bug that causes it to lose

--- a/src/hid_openbsd.c
+++ b/src/hid_openbsd.c
@@ -8,13 +8,11 @@
 
 #include <sys/ioctl.h>
 #include <dev/usb/usb.h>
-#include <dev/usb/usbhid.h>
 
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>
-#include <usbhid.h>
 #include <poll.h>
 
 #include "fido.h"


### PR DESCRIPTION
Only change is we keep using the USB_GET_DEVICEINFO ioctl,
OpenBSD removed it to be more pledge friendly.