### PR TITLE
call gzip with -n argument for manpages

### DIFF
--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -224,7 +224,7 @@ endforeach()
 # man_gzip
 foreach(f ${MAN_SOURCES})
 	add_custom_command(OUTPUT ${f}.gz
-		COMMAND gzip -c ${f} > ${f}.gz
+		COMMAND gzip -cn ${f} > ${f}.gz
 		DEPENDS ${f})
 	list(APPEND GZ_FILES ${f}.gz)
 endforeach()


### PR DESCRIPTION
calling gzip without -n breaks reproducible builds
see the following for more info:

https://wiki.debian.org/ReproducibleBuilds/TimestampsInGzipHeaders