### PR TITLE
MSVC Fixes

### DIFF
--- a/openbsd-compat/types.h
+++ b/openbsd-compat/types.h
@@ -23,13 +23,6 @@ typedef uint32_t        uid_t;
 #endif
 
 #ifdef _MSC_VER
-typedef unsigned char   u_char;
-typedef unsigned short  u_short;
-typedef unsigned int    u_int;
-typedef uint32_t        in_addr_t;
-typedef uint32_t        mode_t;
-typedef uint32_t        uid_t;
-
 #include <basetsd.h>
 typedef SSIZE_T ssize_t;
 

--- a/src/fido.h
+++ b/src/fido.h
@@ -32,6 +32,12 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#ifdef _MSC_VER
+#define FIDO_DEPRECATED(reason) __declspec(deprecated(reason))
+#else
+#define FIDO_DEPRECATED(reason) __attribute__((__deprecated__(reason)))
+#endif
+
 fido_assert_t *fido_assert_new(void);
 fido_cred_t *fido_cred_new(void);
 fido_dev_t *fido_dev_new(void);
@@ -98,8 +104,8 @@ int fido_assert_set_clientdata_hash(fido_assert_t *, const unsigned char *,
 int fido_assert_set_count(fido_assert_t *, size_t);
 int fido_assert_set_extensions(fido_assert_t *, int);
 int fido_assert_set_hmac_salt(fido_assert_t *, const unsigned char *, size_t);
-int fido_assert_set_options(fido_assert_t *, bool, bool)
-    __attribute__((__deprecated__("use fido_assert_set_up/fido_assert_set_uv")));
+FIDO_DEPRECATED("use fido_assert_set_up/fido_assert_set_uv")
+int fido_assert_set_options(fido_assert_t *, bool, bool);
 int fido_assert_set_rp(fido_assert_t *, const char *);
 int fido_assert_set_up(fido_assert_t *, fido_opt_t);
 int fido_assert_set_uv(fido_assert_t *, fido_opt_t);
@@ -112,8 +118,8 @@ int fido_cred_set_authdata_raw(fido_cred_t *, const unsigned char *, size_t);
 int fido_cred_set_clientdata_hash(fido_cred_t *, const unsigned char *, size_t);
 int fido_cred_set_extensions(fido_cred_t *, int);
 int fido_cred_set_fmt(fido_cred_t *, const char *);
-int fido_cred_set_options(fido_cred_t *, bool, bool)
-    __attribute__((__deprecated__("use fido_cred_set_rk/fido_cred_set_uv")));
+FIDO_DEPRECATED("use fido_cred_set_rk/fido_cred_set_uv")
+int fido_cred_set_options(fido_cred_t *, bool, bool);
 int fido_cred_set_prot(fido_cred_t *, int);
 int fido_cred_set_rk(fido_cred_t *, fido_opt_t);
 int fido_cred_set_rp(fido_cred_t *, const char *, const char *);


### PR DESCRIPTION
This addresses 2 problems that I've found:

* ```__attribute__``` isn't available, use ```__declspec``` instead
* The ```uid_t``` and ```mode_t``` types conflict for example with Perl's typedefs. Other projects also seem to chose the types I suggest:

References:
* https://gitlab.kitware.com/cmake/cmake/-/blob/001043ac3078c49651f6af0f1ff1b31ef71a7665/Source/cmStandardIncludes.h#L56
* https://fossies.org/linux/perl/win32/win32.h
* https://github.com/llvm-git-prototype/llvm/blob/master/lldb/include/lldb/Host/windows/PosixApi.h#L76