### PR TITLE
Extract and use report lengths contained in HID report descriptor

### DIFF
--- a/src/fido/param.h
+++ b/src/fido/param.h
@@ -50,8 +50,13 @@
 /* HID Broadcast channel ID. */
 #define CTAP_CID_BROADCAST		0xffffffff
 
-/* Expected size of a HID report in bytes. */
-#define CTAP_RPT_SIZE			64
+/*
+ * Maximal length of a CTAP HID report in bytes, excluding report ID (if
+ * required on the given platform).
+ */
+#define MAX_CTAP_REPORT_LEN		64
+#define CTAP_INIT_HEADER_LEN		7
+#define CTAP_CONT_HEADER_LEN		5
 
 /* Randomness device on UNIX-like platforms. */
 #ifndef FIDO_RANDOM_DEV

--- a/src/fido/types.h
+++ b/src/fido/types.h
@@ -206,13 +206,20 @@ struct fido_ctap_info {
 	uint8_t  flags;    /* capabilities flags; see FIDO_CAP_* */
 })
 
+typedef struct fido_dev_io_info {
+	void	*io_handle;		/* opaque i/o handle */
+	uint16_t report_in_len;		/* length of the HID input report */
+	uint16_t report_out_len;	/* length of the HID output report */
+} fido_dev_io_info_t;
+
 typedef struct fido_dev {
 	uint64_t              nonce;     /* issued nonce */
 	fido_ctap_info_t      attr;      /* device attributes */
 	uint32_t              cid;       /* assigned channel id */
 	char                 *path;      /* device path */
-	void                 *io_handle; /* abstract i/o handle */
+	fido_dev_io_info_t   *io_info;   /* extra info needed to perform i/o */
 	fido_dev_io_t         io;        /* i/o functions */
+	bool                  legacy_io; /* i/o relies on default report size */
 	fido_dev_transport_t  transport; /* transport functions */
 } fido_dev_t;
 

--- a/src/hid_hidapi.c
+++ b/src/hid_hidapi.c
@@ -99,6 +99,10 @@ fido_hid_open(const char *path)
 	}
 
 	io_info->io_handle = hid_dev_handle;
+	/*
+	 * hidapi does not provide access to the report descriptor, hence the
+	 * default report sizes are used.
+	 */
 	io_info->report_in_len = MAX_CTAP_REPORT_LEN;
 	io_info->report_out_len = MAX_CTAP_REPORT_LEN;
 


### PR DESCRIPTION
This PR is meant to address #165 by replacing the hardcoded HID report length of 64 bytes by the lengths reported in the FIDO devices HID report descriptor.

It is broken up into an initial commit that replaces the hardcoded HID report length with configurable input and output report lengths, while still using the default report length in all backends. This is meant to simplify the review process. This commit also adapts the regression tests and fuzzers accordingly.

The later commits implement the extraction of the report lengths from the report descriptor for the various backends. Here, the status of the individual commits is as follows:

- [x]  Windows: Builds and performs as expected as confirmed by a manual test with both a 64-byte and a 62-byte report FIDO device.
- [x] Linux: Builds and performs as expected as confirmed by a manual test with both a 64-byte and a 62-byte report FIDO device.
- [ ] macOS: Does build in the CI, but I haven't been able to test it since I do not have access to a physical device running macOS.
- [ ] hidapi: Is fundamentally incompatible with devices with unknown HID report sizes since it does not extract the report lengths from the report descriptor on all platforms. The respective commit adds a note about this, but this may warrant mentioning in the README (or elsewhere).
- [ ] OpenBSD: Not implemented yet. I lack experience with OpenBSD and do not know which library I should use to fetch the HID report descriptor or report lengths for both USB and Bluetooth HID devices.