### PR TITLE
Make report lengths configurable in rx/tx/backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,7 +411,7 @@ subdirs(man)
 
 if(NOT WIN32)
 	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-		if(NOT MSAN AND NOT LIBFUZZER)
+		if(NOT MSAN AND NOT LIBFUZZER AND NOT FUZZ)
 			subdirs(regress)
 		endif()
 	endif()

--- a/fuzz/mutator_aux.c
+++ b/fuzz/mutator_aux.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "fido.h"
 #include "mutator_aux.h"
 
 size_t LLVMFuzzerMutate(uint8_t *, size_t, size_t);
@@ -307,7 +308,7 @@ dev_read(void *handle, unsigned char *ptr, size_t len, int ms)
 	(void)ms;
 
 	assert(handle == (void *)0xdeadbeef);
-	assert(len == 64);
+	assert(len >= CTAP_MIN_REPORT_LEN && len <= CTAP_MAX_REPORT_LEN);
 
 	if (wire_data_len < len)
 		n = wire_data_len;
@@ -326,7 +327,8 @@ int
 dev_write(void *handle, const unsigned char *ptr, size_t len)
 {
 	assert(handle == (void *)0xdeadbeef);
-	assert(len == 64 + 1);
+	assert(len >= CTAP_MIN_REPORT_LEN + 1 &&
+	    len <= CTAP_MAX_REPORT_LEN + 1);
 
 	consume(ptr, len);
 

--- a/src/dev.c
+++ b/src/dev.c
@@ -106,6 +106,17 @@ find_manifest_func_node(dev_manifest_func_t f, dev_manifest_func_node_t **curr,
 	}
 }
 
+#ifdef FIDO_FUZZ
+static void
+set_random_report_len(fido_dev_t *dev)
+{
+	dev->report_in_len = CTAP_MIN_REPORT_LEN +
+	    uniform_random(CTAP_MAX_REPORT_LEN - CTAP_MIN_REPORT_LEN + 1);
+	dev->report_out_len = CTAP_MIN_REPORT_LEN +
+	    uniform_random(CTAP_MAX_REPORT_LEN - CTAP_MIN_REPORT_LEN + 1);
+}
+#endif
+
 static int
 fido_dev_open_tx(fido_dev_t *dev, const char *path)
 {
@@ -132,8 +143,12 @@ fido_dev_open_tx(fido_dev_t *dev, const char *path)
 	}
 
 	if (dev->fixed_rpt_size) {
+#ifdef FIDO_FUZZ
+		set_random_report_len(dev);
+#else
 		dev->report_in_len = CTAP_MAX_REPORT_LEN;
 		dev->report_out_len = CTAP_MAX_REPORT_LEN;
+#endif
 	} else {
 		dev->report_in_len = fido_hid_report_in_len(dev->io_handle);
 		dev->report_out_len = fido_hid_report_out_len(dev->io_handle);

--- a/src/extern.h
+++ b/src/extern.h
@@ -88,6 +88,8 @@ void *fido_hid_open(const char *);
 void  fido_hid_close(void *);
 int fido_hid_read(void *, unsigned char *, size_t, int);
 int fido_hid_write(void *, const unsigned char *, size_t);
+uint16_t fido_hid_report_in_len(void *);
+uint16_t fido_hid_report_out_len(void *);
 
 /* generic i/o */
 int fido_rx_cbor_status(fido_dev_t *, int);

--- a/src/extern.h
+++ b/src/extern.h
@@ -151,6 +151,11 @@ typedef int (*dev_manifest_func_t)(fido_dev_info_t *, size_t, size_t *);
 int fido_dev_register_manifest_func(const dev_manifest_func_t);
 void fido_dev_unregister_manifest_func(const dev_manifest_func_t);
 
+/* fuzzing instrumentation */
+#ifdef FIDO_FUZZ
+uint32_t uniform_random(uint32_t);
+#endif
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */

--- a/src/fido/param.h
+++ b/src/fido/param.h
@@ -50,8 +50,20 @@
 /* HID Broadcast channel ID. */
 #define CTAP_CID_BROADCAST		0xffffffff
 
-/* Expected size of a HID report in bytes. */
-#define CTAP_RPT_SIZE			64
+#define CTAP_INIT_HEADER_LEN		7
+#define CTAP_CONT_HEADER_LEN		5
+
+/*
+ * Maximal length of a CTAP HID report in bytes, excluding report ID (if
+ * required on the given platform).
+ */
+#define CTAP_MAX_REPORT_LEN		64
+
+/*
+ * Minimal HID report length needed to transmit an INIT header + one byte of
+ * payload data.
+ */
+#define CTAP_MIN_REPORT_LEN		(CTAP_INIT_HEADER_LEN + 1)
 
 /* Randomness device on UNIX-like platforms. */
 #ifndef FIDO_RANDOM_DEV

--- a/src/fido/types.h
+++ b/src/fido/types.h
@@ -213,6 +213,9 @@ typedef struct fido_dev {
 	char                 *path;      /* device path */
 	void                 *io_handle; /* abstract i/o handle */
 	fido_dev_io_t         io;        /* i/o functions */
+	bool                  fixed_rpt_size; /* i/o uses default report size */
+	uint16_t              report_in_len;  /* length of HID input reports */
+	uint16_t              report_out_len; /* length of HID output reports */
 	fido_dev_transport_t  transport; /* transport functions */
 } fido_dev_t;
 

--- a/src/hid_openbsd.c
+++ b/src/hid_openbsd.c
@@ -18,12 +18,11 @@
 #include "fido.h"
 
 #define MAX_UHID	64
-#define MAX_U2FHID_LEN	64
 
-struct hid_openbsd {
-	int fd;
-	size_t report_in_len;
-	size_t report_out_len;
+struct ctx_openbsd {
+	int		fd;
+	uint16_t	report_in_len;
+	uint16_t	report_out_len;
 };
 
 int
@@ -100,13 +99,13 @@ fido_hid_manifest(fido_dev_info_t *devlist, size_t ilen, size_t *olen)
  * sequence bits will be ignored as duplicate packets by the device.
  */
 static int
-terrible_ping_kludge(struct hid_openbsd *ctx)
+terrible_ping_kludge(struct ctx_openbsd *ctx)
 {
 	u_char data[256];
 	int i, n;
 	struct pollfd pfd;
 
-	if (sizeof(data) < ctx->report_out_len + 1)
+	if (sizeof(data) < ctx->report_out_len + 1u)
 		return -1;
 	for (i = 0; i < 4; i++) {
 		memset(data, 0, sizeof(data));
@@ -121,7 +120,7 @@ terrible_ping_kludge(struct hid_openbsd *ctx)
 		data[6] = 0;
 		data[7] = 1;
 		fido_log_debug("%s: send ping %d", __func__, i);
-		if (fido_hid_write(ctx, data, ctx->report_out_len + 1) == -1)
+		if (fido_hid_write(ctx, data, ctx->report_out_len + 1u) == -1)
 			return -1;
 		fido_log_debug("%s: wait reply", __func__);
 		memset(&pfd, 0, sizeof(pfd));
@@ -152,14 +151,14 @@ terrible_ping_kludge(struct hid_openbsd *ctx)
 void *
 fido_hid_open(const char *path)
 {
-	struct hid_openbsd *ret = NULL;
+	struct ctx_openbsd *ret = NULL;
 
 	if ((ret = calloc(1, sizeof(*ret))) == NULL ||
 	    (ret->fd = open(path, O_RDWR)) < 0) {
 		free(ret);
 		return (NULL);
 	}
-	ret->report_in_len = ret->report_out_len = MAX_U2FHID_LEN;
+	ret->report_in_len = ret->report_out_len = CTAP_MAX_REPORT_LEN;
 	fido_log_debug("%s: inlen = %zu outlen = %zu", __func__,
 	    ret->report_in_len, ret->report_out_len);
 
@@ -179,7 +178,7 @@ fido_hid_open(const char *path)
 void
 fido_hid_close(void *handle)
 {
-	struct hid_openbsd *ctx = (struct hid_openbsd *)handle;
+	struct ctx_openbsd *ctx = (struct ctx_openbsd *)handle;
 
 	close(ctx->fd);
 	free(ctx);
@@ -188,7 +187,7 @@ fido_hid_close(void *handle)
 int
 fido_hid_read(void *handle, unsigned char *buf, size_t len, int ms)
 {
-	struct hid_openbsd *ctx = (struct hid_openbsd *)handle;
+	struct ctx_openbsd *ctx = (struct ctx_openbsd *)handle;
 	ssize_t r;
 
 	(void)ms; /* XXX */
@@ -208,10 +207,10 @@ fido_hid_read(void *handle, unsigned char *buf, size_t len, int ms)
 int
 fido_hid_write(void *handle, const unsigned char *buf, size_t len)
 {
-	struct hid_openbsd *ctx = (struct hid_openbsd *)handle;
+	struct ctx_openbsd *ctx = (struct ctx_openbsd *)handle;
 	ssize_t r;
 
-	if (len != ctx->report_out_len + 1) {
+	if (len != ctx->report_out_len + 1u) {
 		fido_log_debug("%s: invalid len: got %zu, want %zu", __func__,
 		    len, ctx->report_out_len);
 		return (-1);
@@ -222,4 +221,20 @@ fido_hid_write(void *handle, const unsigned char *buf, size_t len)
 		return (-1);
 	}
 	return ((int)len);
+}
+
+uint16_t
+fido_hid_report_in_len(void *handle)
+{
+	struct ctx_openbsd *ctx = handle;
+
+	return (ctx->report_in_len);
+}
+
+uint16_t
+fido_hid_report_out_len(void *handle)
+{
+	struct ctx_openbsd *ctx = handle;
+
+	return (ctx->report_out_len);
 }


### PR DESCRIPTION
Currently, the lengths of the HID input/output reports are hardcoded as
64 bytes both in the backends and the rx/tx logic in io.c.

This commit makes the report lengths configurable in all these places
without affecting the public API. The report lengths are kept in
`report_{in,out}_len fields` in fido_dev_t and are obtained from the
included backends via fido_hid_report_{in,out}_len() functions. The use
of these functions is gated on a `fixed_rpt_size` flag in fido_dev_t
that could be exposed to custom i/o functions in a future commit.

While the report lengths become configurable with this commit, they are
still kept at the default 64 bytes in all backends. Future commits to
the individual backends will add the logic that extracts the report
lengths from the HID report descriptor.