### PR TITLE
Read report lengths from descriptor on Linux

### DIFF
--- a/src/hid_linux.c
+++ b/src/hid_linux.c
@@ -100,6 +100,50 @@ get_usage_info(const struct hidraw_report_descriptor *hrd, uint32_t *usage_page,
 	return (0);
 }
 
+static void
+get_report_lengths(const struct hidraw_report_descriptor *hrd,
+    uint16_t *report_in_len, uint16_t *report_out_len)
+{
+	const uint8_t	*ptr;
+	size_t		 len;
+	uint16_t	 cur_report_count = 0;
+
+	ptr = hrd->value;
+	len = hrd->size;
+
+	*report_in_len = 0;
+	*report_out_len = 0;
+
+	while (len > 0) {
+		const uint8_t tag = ptr[0];
+		ptr++;
+		len--;
+
+		uint8_t  key;
+		size_t   key_len;
+		uint32_t key_val;
+
+		if (get_key_len(tag, &key, &key_len) < 0 || key_len > len ||
+		    get_key_val(ptr, key_len, &key_val) < 0) {
+			return;
+		}
+
+		if (key == 0x94) {
+			cur_report_count = key_val;
+			fido_log_debug("%s: ReportCount(%d)", __func__, cur_report_count);
+		} else if (key == 0x80) {
+			*report_in_len = cur_report_count;
+			fido_log_debug("%s: Input", __func__);
+		} else if (key == 0x90) {
+			*report_out_len = cur_report_count;
+			fido_log_debug("%s: Output", __func__);
+		}
+
+		ptr += key_len;
+		len -= key_len;
+	}
+}
+
 static int
 get_report_descriptor(const char *path, struct hidraw_report_descriptor *hrd)
 {
@@ -299,7 +343,8 @@ fail:
 void *
 fido_hid_open(const char *path)
 {
-	struct ctx_linux *ctx;
+	struct ctx_linux		*ctx;
+	struct hidraw_report_descriptor	 hrd;
 
 	if ((ctx = calloc(1, sizeof(*ctx))) == NULL)
 		return (NULL);
@@ -311,6 +356,14 @@ fido_hid_open(const char *path)
 
 	ctx->report_in_len = CTAP_MAX_REPORT_LEN;
 	ctx->report_out_len = CTAP_MAX_REPORT_LEN;
+
+	/*
+	 * Don't fail when report sizes can't be extracted in order to maintain
+	 * backwards compatibility.
+	 */
+	if (get_report_descriptor(path, &hrd) >= 0)
+		get_report_lengths(&hrd, &ctx->report_in_len,
+		    &ctx->report_out_len);
 
 	return (ctx);
 }


### PR DESCRIPTION
Extracts input and output report lengths from the report descriptor
by parsing it manually.

Since the previous implementation did not parse the report lengths out
of the report descriptor, any failure causes a fallback to the default
64 bytes in order to ensure backward compatibility.

This has been tested manually with both a 64 byte and a 62 byte FIDO device.