### PR TITLE
Extract credProtect from credman response

### DIFF
--- a/fuzz/fuzz_credman.c
+++ b/fuzz/fuzz_credman.c
@@ -226,7 +226,7 @@ get_rk_list(struct param *p)
 	fido_dev_t *dev;
 	fido_credman_rk_t *rk;
 	const fido_cred_t *cred;
-	int type;
+	int val;
 
 	set_wire_data(p->rk_wire_data.body, p->rk_wire_data.len);
 
@@ -247,8 +247,8 @@ get_rk_list(struct param *p)
 			assert(i >= fido_credman_rk_count(rk));
 			continue;
 		}
-		type = fido_cred_type(cred);
-		consume(&type, sizeof(type));
+		val = fido_cred_type(cred);
+		consume(&val, sizeof(val));
 		consume(fido_cred_id_ptr(cred), fido_cred_id_len(cred));
 		consume(fido_cred_pubkey_ptr(cred), fido_cred_pubkey_len(cred));
 		consume(fido_cred_user_id_ptr(cred),
@@ -257,6 +257,8 @@ get_rk_list(struct param *p)
 		    xstrlen(fido_cred_user_name(cred)));
 		consume(fido_cred_display_name(cred),
 		    xstrlen(fido_cred_display_name(cred)));
+		val = fido_cred_prot(cred);
+		consume(&val, sizeof(val));
 	}
 
 	fido_credman_rk_free(&rk);

--- a/src/credman.c
+++ b/src/credman.c
@@ -251,9 +251,8 @@ credman_parse_rk(const cbor_item_t *key, const cbor_item_t *val, void *arg)
 		cred->type = cred->attcred.type; /* XXX */
 		return (0);
 	case 10:
-		if (cbor_decode_uint64(val, &prot) < 0 || prot > INT_MAX)
-			return (-1);
-		if (fido_cred_set_prot(cred, (int)prot) < 0)
+		if (cbor_decode_uint64(val, &prot) < 0 || prot > INT_MAX ||
+		    fido_cred_set_prot(cred, (int)prot) != FIDO_OK)
 			return (-1);
 		return (0);
 	default:

--- a/src/credman.c
+++ b/src/credman.c
@@ -230,7 +230,8 @@ fido_credman_get_dev_metadata(fido_dev_t *dev, fido_credman_metadata_t *metadata
 static int
 credman_parse_rk(const cbor_item_t *key, const cbor_item_t *val, void *arg)
 {
-	fido_cred_t *cred = arg;
+	fido_cred_t	*cred = arg;
+	uint64_t	 prot;
 
 	if (cbor_isa_uint(key) == false ||
 	    cbor_int_get_width(key) != CBOR_INT_8) {
@@ -248,6 +249,12 @@ credman_parse_rk(const cbor_item_t *key, const cbor_item_t *val, void *arg)
 		    &cred->attcred.pubkey) < 0)
 			return (-1);
 		cred->type = cred->attcred.type; /* XXX */
+		return (0);
+	case 10:
+		if (cbor_decode_uint64(val, &prot) < 0 || prot > INT_MAX)
+			return (-1);
+		if (fido_cred_set_prot(cred, (int)prot) < 0)
+			return (-1);
 		return (0);
 	default:
 		fido_log_debug("%s: cbor type", __func__);

--- a/tools/credman.c
+++ b/tools/credman.c
@@ -101,6 +101,7 @@ print_rk(const fido_credman_rk_t *rk, size_t idx)
 	char *id = NULL;
 	char *user_id = NULL;
 	const char *type;
+	const char *prot;
 
 	if ((cred = fido_credman_rk(rk, idx)) == NULL)
 		errx(1, "fido_credman_rk");
@@ -124,8 +125,23 @@ print_rk(const fido_credman_rk_t *rk, size_t idx)
 		break;
 	}
 
-	printf("%02u: %s %s (%s) %s\n", (unsigned)idx, id,
-	    fido_cred_display_name(cred), user_id, type);
+	switch (fido_cred_prot(cred)) {
+	case FIDO_CRED_PROT_UV_OPTIONAL:
+		prot = "PROT_UV_OPTIONAL";
+		break;
+	case FIDO_CRED_PROT_UV_OPTIONAL_WITH_ID:
+		prot = "PROT_UV_OPTIONAL_WITH_ID";
+		break;
+	case FIDO_CRED_PROT_UV_REQUIRED:
+		prot = "PROT_UV_REQUIRED";
+		break;
+	default:
+		prot = "PROT_UNKNOWN";
+		break;
+	}
+
+	printf("%02u: %s %s (%s) %s %s\n", (unsigned)idx, id,
+	    fido_cred_display_name(cred), user_id, type, prot);
 
 	free(user_id);
 	free(id);


### PR DESCRIPTION
The credProtect level of a resident credential is returned under the
key 0x0A (10) of a credential management response. With this commit,
the value is parsed and can be read with fido_cred_prot.