### PR TITLE
Fail in fido_dev_open_tx on invalid report lengths

### DIFF
--- a/src/dev.c
+++ b/src/dev.c
@@ -158,16 +158,18 @@ fido_dev_open_tx(fido_dev_t *dev, const char *path)
 	    dev->report_in_len > CTAP_MAX_REPORT_LEN) {
 		fido_log_debug("%s: invalid report_in_len %hu", __func__,
 		    dev->report_in_len);
-		/* Fall back to default USB transfer report length. */
-		dev->report_in_len = CTAP_MAX_REPORT_LEN;
+		dev->io.close(dev->io_handle);
+		dev->io_handle = NULL;
+		return (FIDO_ERR_RX);
 	}
 
 	if (dev->report_out_len < CTAP_MIN_REPORT_LEN ||
 	    dev->report_out_len > CTAP_MAX_REPORT_LEN) {
 		fido_log_debug("%s: invalid report_out_len %hu", __func__,
 		    dev->report_out_len);
-		/* Fall back to default USB transfer report length. */
-		dev->report_out_len = CTAP_MAX_REPORT_LEN;
+		dev->io.close(dev->io_handle);
+		dev->io_handle = NULL;
+		return (FIDO_ERR_TX);
 	}
 
 	if (fido_tx(dev, cmd, &dev->nonce, sizeof(dev->nonce)) < 0) {


### PR DESCRIPTION
Since fido_dev_t and the backends separately maintain the report
lengths, fido_dev_open_tx cannot unilaterally fall back to 64 bytes and
has to fail if it encounters an invalid report length.

With this change, the backends no longer have to perform any checks on
report lengths extracted from the report descriptor. They may however
choose to do so to help them decide whether or not a device is a valid
FIDO device.