### PR TITLE
Ubuntu 20 can use the same instructions as 18,16?

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,7 +37,7 @@ The current release of *libfido2* is 1.5.0. Please consult Yubico's
 https://developers.yubico.com/libfido2/Releases[release page] for source
 and binary releases.
 
-==== Ubuntu 20.04 (Focal) and Ubuntu 18.04 (Bionic) and 16.04 (Xenial)
+==== Ubuntu
 
   $ sudo apt install software-properties-common
   $ sudo apt-add-repository ppa:yubico/stable

--- a/README.adoc
+++ b/README.adoc
@@ -37,13 +37,7 @@ The current release of *libfido2* is 1.5.0. Please consult Yubico's
 https://developers.yubico.com/libfido2/Releases[release page] for source
 and binary releases.
 
-==== Ubuntu 20.04 (Focal)
-
-  $ sudo apt install libfido2-1
-  $ sudo apt install libfido2-dev
-  $ sudo apt install libfido2-doc
-
-==== Ubuntu 18.04 (Bionic) and 16.04 (Xenial)
+==== Ubuntu 20.04 (Focal) and Ubuntu 18.04 (Bionic) and 16.04 (Xenial)
 
   $ sudo apt install software-properties-common
   $ sudo apt-add-repository ppa:yubico/stable


### PR DESCRIPTION
The Ubuntu package is still at 1.3.1 here:
https://packages.ubuntu.com/source/focal/libfido2