### PR TITLE
hid_osx: Use CFRunLoopGetCurrent?

### DIFF
--- a/src/hid_osx.c
+++ b/src/hid_osx.c
@@ -328,7 +328,7 @@ removal_callback(void *context, IOReturn result, void *sender)
 	(void)result;
 	(void)sender;
 
-	CFRunLoopStop(CFRunLoopGetMain());
+	CFRunLoopStop(CFRunLoopGetCurrent());
 }
 
 static int
@@ -440,7 +440,7 @@ fido_hid_open(const char *path)
 	IOHIDDeviceRegisterInputReportCallback(ctx->ref, ctx->report,
 	    (long)ctx->report_in_len, &report_callback, ctx);
 	IOHIDDeviceRegisterRemovalCallback(ctx->ref, &removal_callback, ctx);
-	IOHIDDeviceScheduleWithRunLoop(ctx->ref, CFRunLoopGetMain(),
+	IOHIDDeviceScheduleWithRunLoop(ctx->ref, CFRunLoopGetCurrent(),
 	    ctx->loop_id);
 
 	ok = 0;
@@ -472,7 +472,7 @@ fido_hid_close(void *handle)
 	IOHIDDeviceRegisterInputReportCallback(ctx->ref, ctx->report,
 	    (long)ctx->report_in_len, NULL, ctx);
 	IOHIDDeviceRegisterRemovalCallback(ctx->ref, NULL, NULL);
-	IOHIDDeviceUnscheduleFromRunLoop(ctx->ref, CFRunLoopGetMain(),
+	IOHIDDeviceUnscheduleFromRunLoop(ctx->ref, CFRunLoopGetCurrent(),
 	    ctx->loop_id);
 
 	if (IOHIDDeviceClose(ctx->ref,

--- a/src/hid_osx.c
+++ b/src/hid_osx.c
@@ -328,7 +328,7 @@ removal_callback(void *context, IOReturn result, void *sender)
 	(void)result;
 	(void)sender;
 
-	CFRunLoopStop(CFRunLoopGetMain());
+	CFRunLoopStop(CFRunLoopGetCurrent());
 }
 
 static int
@@ -505,6 +505,10 @@ fido_hid_read(void *handle, unsigned char *buf, size_t len, int ms)
 
 	if (ms == -1)
 		ms = 5000; /* wait 5 seconds by default */
+
+	if (CFRunLoopGetCurrent() != CFRunLoopGetMain())
+		fido_log_debug("%s: CFRunLoopGetCurrent != CFRunLoopGetMain",
+		    __func__);
 
 	CFRunLoopRunInMode(ctx->loop_id, (double)ms/1000.0, true);
 

--- a/src/hid_osx.c
+++ b/src/hid_osx.c
@@ -328,7 +328,7 @@ removal_callback(void *context, IOReturn result, void *sender)
 	(void)result;
 	(void)sender;
 
-	CFRunLoopStop(CFRunLoopGetCurrent());
+	CFRunLoopStop(CFRunLoopGetMain());
 }
 
 static int
@@ -505,10 +505,6 @@ fido_hid_read(void *handle, unsigned char *buf, size_t len, int ms)
 
 	if (ms == -1)
 		ms = 5000; /* wait 5 seconds by default */
-
-	if (CFRunLoopGetCurrent() != CFRunLoopGetMain())
-		fido_log_debug("%s: CFRunLoopGetCurrent != CFRunLoopGetMain",
-		    __func__);
 
 	CFRunLoopRunInMode(ctx->loop_id, (double)ms/1000.0, true);
 

--- a/src/hid_osx.c
+++ b/src/hid_osx.c
@@ -328,7 +328,7 @@ removal_callback(void *context, IOReturn result, void *sender)
 	(void)result;
 	(void)sender;
 
-	CFRunLoopStop(CFRunLoopGetCurrent());
+	CFRunLoopStop(CFRunLoopGetMain());
 }
 
 static int
@@ -440,7 +440,7 @@ fido_hid_open(const char *path)
 	IOHIDDeviceRegisterInputReportCallback(ctx->ref, ctx->report,
 	    (long)ctx->report_in_len, &report_callback, ctx);
 	IOHIDDeviceRegisterRemovalCallback(ctx->ref, &removal_callback, ctx);
-	IOHIDDeviceScheduleWithRunLoop(ctx->ref, CFRunLoopGetCurrent(),
+	IOHIDDeviceScheduleWithRunLoop(ctx->ref, CFRunLoopGetMain(),
 	    ctx->loop_id);
 
 	ok = 0;
@@ -472,7 +472,7 @@ fido_hid_close(void *handle)
 	IOHIDDeviceRegisterInputReportCallback(ctx->ref, ctx->report,
 	    (long)ctx->report_in_len, NULL, ctx);
 	IOHIDDeviceRegisterRemovalCallback(ctx->ref, NULL, NULL);
-	IOHIDDeviceUnscheduleFromRunLoop(ctx->ref, CFRunLoopGetCurrent(),
+	IOHIDDeviceUnscheduleFromRunLoop(ctx->ref, CFRunLoopGetMain(),
 	    ctx->loop_id);
 
 	if (IOHIDDeviceClose(ctx->ref,


### PR DESCRIPTION
I was having trouble using the latest libfido2 library with [go-libfido2](https://github.com/keys-pub/go-libfido2). I was getting an FIDO_ERR_RX on fido_dev_open (though only on the second or subsequent opens).

I tracked it down the failures starting happening after this commit: https://github.com/Yubico/libfido2/commit/2d0a839184d2caaf89bb9e0e5c1cc34b9ef33fc4

It seems like the change to use `CFRunLoopGetMain` instead of `CFRunLoopGetCurrent` breaks the usage of the library under cgo.

I'm still investigating the use of RunLoops with IOHIDDeviceScheduleWithRunLoop and what the right thing to do is, but I thought I would submit this in case anyone else was encountering issues. Also I don't know if this is an issue with go/cgo either.