### PR TITLE
Introduce function fido_cred_sigcount()

### DIFF
--- a/fuzz/export.gnu
+++ b/fuzz/export.gnu
@@ -96,6 +96,7 @@
 		fido_cred_display_name;
 		fido_cred_exclude;
 		fido_cred_flags;
+		fido_cred_sigcount;
 		fido_cred_fmt;
 		fido_cred_free;
 		fido_cred_id_len;

--- a/fuzz/fuzz_cred.c
+++ b/fuzz/fuzz_cred.c
@@ -280,6 +280,7 @@ verify_cred(int type, const unsigned char *cdh_ptr, size_t cdh_len,
 {
 	fido_cred_t *cred;
 	uint8_t flags;
+	uint32_t sigcount;
 
 	if ((cred = fido_cred_new()) == NULL)
 		return;
@@ -323,6 +324,8 @@ verify_cred(int type, const unsigned char *cdh_ptr, size_t cdh_len,
 
 	flags = fido_cred_flags(cred);
 	consume(&flags, sizeof(flags));
+	sigcount = fido_cred_sigcount(cred);
+	consume(&sigcount, sizeof(sigcount));
 	type = fido_cred_type(cred);
 	consume(&type, sizeof(type));
 

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -123,6 +123,7 @@ list(APPEND MAN_ALIAS
 	fido_cred_new fido_cred_clientdata_hash_ptr
 	fido_cred_new fido_cred_display_name
 	fido_cred_new fido_cred_flags
+	fido_cred_new fido_cred_sigcount
 	fido_cred_new fido_cred_fmt
 	fido_cred_new fido_cred_free
 	fido_cred_new fido_cred_id_len

--- a/man/fido_cred_new.3
+++ b/man/fido_cred_new.3
@@ -33,7 +33,8 @@
 .Nm fido_cred_user_id_len ,
 .Nm fido_cred_x5c_len ,
 .Nm fido_cred_type ,
-.Nm fido_cred_flags
+.Nm fido_cred_flags ,
+.Nm fido_cred_sigcount
 .Nd FIDO 2 credential API
 .Sh SYNOPSIS
 .In fido.h
@@ -93,6 +94,8 @@
 .Fn fido_cred_type "const fido_cred_t *cred"
 .Ft uint8_t
 .Fn fido_cred_flags "const fido_cred_t *cred"
+.Ft uint32_t
+.Fn fido_cred_sigcount "const fido_cred_t *cred"
 .Sh DESCRIPTION
 FIDO 2 credentials are abstracted in
 .Em libfido2
@@ -207,6 +210,11 @@ function returns the COSE algorithm of
 The
 .Fn fido_cred_flags
 function returns the authenticator data flags of
+.Fa cred .
+.Pp
+The
+.Fn fido_cred_sigcount
+function returns the authenticator data signature counter of
 .Fa cred .
 .Sh RETURN VALUES
 The authenticator data returned by

--- a/src/cred.c
+++ b/src/cred.c
@@ -871,6 +871,12 @@ fido_cred_flags(const fido_cred_t *cred)
 	return (cred->authdata.flags);
 }
 
+uint32_t
+fido_cred_sigcount(const fido_cred_t *cred)
+{
+	return (cred->authdata.sigcount);
+}
+
 const unsigned char *
 fido_cred_clientdata_hash_ptr(const fido_cred_t *cred)
 {

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -96,6 +96,7 @@
 		fido_cred_display_name;
 		fido_cred_exclude;
 		fido_cred_flags;
+		fido_cred_sigcount;
 		fido_cred_fmt;
 		fido_cred_free;
 		fido_cred_id_len;

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -94,6 +94,7 @@ _fido_cred_clientdata_hash_ptr
 _fido_cred_display_name
 _fido_cred_exclude
 _fido_cred_flags
+_fido_cred_sigcount
 _fido_cred_fmt
 _fido_cred_free
 _fido_cred_id_len

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -95,6 +95,7 @@ fido_cred_clientdata_hash_ptr
 fido_cred_display_name
 fido_cred_exclude
 fido_cred_flags
+fido_cred_sigcount
 fido_cred_fmt
 fido_cred_free
 fido_cred_id_len

--- a/src/fido.h
+++ b/src/fido.h
@@ -174,6 +174,7 @@ size_t fido_cred_x5c_len(const fido_cred_t *);
 uint8_t  fido_assert_flags(const fido_assert_t *, size_t);
 uint32_t fido_assert_sigcount(const fido_assert_t *, size_t);
 uint8_t  fido_cred_flags(const fido_cred_t *);
+uint32_t fido_cred_sigcount(const fido_cred_t *);
 uint8_t  fido_dev_protocol(const fido_dev_t *);
 uint8_t  fido_dev_major(const fido_dev_t *);
 uint8_t  fido_dev_minor(const fido_dev_t *);


### PR DESCRIPTION
This function can be used to get the authenticator data signature
counter of a credential, e.g. for reconstructing the authdata payload
when verifying the credential.