### PR TITLE
ci: restrict where cifuzz_oss runs, add more environments to linux_builds

### DIFF
--- a/.github/workflows/cifuzz_oss.yml
+++ b/.github/workflows/cifuzz_oss.yml
@@ -2,6 +2,7 @@ name: CIFuzz
 on: [pull_request]
 jobs:
   Fuzzing:
+    if: github.repository == 'Yubico/libfido2'
     runs-on: ubuntu-latest
     steps:
     - name: Build Fuzzers

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -8,14 +8,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
-        cc: [gcc-10, clang-10, i686-w64-mingw32-gcc-9]
+        include:
+          - os: ubuntu-20.04
+            cc: gcc-10
+          - os: ubuntu-20.04
+            cc: clang-10
+          - os: ubuntu-20.04
+            cc: i686-w64-mingw32-gcc-9
+          - os: ubuntu-18.04
+            cc: gcc-8
+          - os: ubuntu-18.04
+            cc: clang-10
+          - os: ubuntu-18.04
+            cc: i686-w64-mingw32-gcc-7
+          - os: ubuntu-16.04
+            cc: gcc-5
+          - os: ubuntu-16.04
+            cc: clang-8
+          - os: ubuntu-16.04
+            cc: i686-w64-mingw32-gcc-5
     steps:
     - uses: actions/checkout@v1
     - name: Dependencies
       env:
         CC: ${{ matrix.cc }}
       run: |
+        # ubuntu 16.04 does not package libcbor, use our ppa for that
+        if [ "$(lsb_release --short --release)" = "16.04" ]; then
+          sudo apt-add-repository ppa:yubico/stable
+        fi
         sudo apt -q update
         sudo apt install -q -y libcbor-dev libudev-dev original-awk mandoc
         if [ "${CC%-*}" == "clang" ]; then


### PR DESCRIPTION
Sadly, the format of the (sparse) build matrix is quite verbose. If anyone has any better idea on how to loop over valid OS/compiler combinations, that would be very helpful!