### PR TITLE
random: move random generation to own source file, check return of getrandom()

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ list(APPEND FIDO_SOURCES
 	iso7816.c
 	log.c
 	pin.c
+	random.c
 	reset.c
 	rs256.c
 	u2f.c

--- a/src/extern.h
+++ b/src/extern.h
@@ -134,6 +134,7 @@ void fido_cred_reset_rx(fido_cred_t *);
 void fido_cred_reset_tx(fido_cred_t *);
 int fido_check_rp_id(const char *, const unsigned char *);
 int fido_check_flags(uint8_t, fido_opt_t, fido_opt_t);
+int fido_get_random(void *, size_t);
 
 /* crypto */
 int fido_verify_sig_es256(const fido_blob_t *, const es256_pk_t *,

--- a/src/random.c
+++ b/src/random.c
@@ -53,8 +53,11 @@ fido_get_random(void *buf, size_t len)
 int
 fido_get_random(void *buf, size_t len)
 {
-	if (getrandom(buf, len, 0) < 0)
+	ssize_t	r;
+
+	if ((r = getrandom(buf, len, 0)) < 0 || (size_t)r != len)
 		return (-1);
+
 	return (0);
 }
 #elif defined(HAVE_DEV_URANDOM)
@@ -67,8 +70,7 @@ fido_get_random(void *buf, size_t len)
 
 	if ((fd = open(FIDO_RANDOM_DEV, O_RDONLY)) < 0)
 		goto fail;
-	if ((r = read(fd, buf, len)) < 0 ||
-	    (size_t)r != len)
+	if ((r = read(fd, buf, len)) < 0 || (size_t)r != len)
 		goto fail;
 
 	ok = 0;

--- a/src/random.c
+++ b/src/random.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2018 Yubico AB. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#ifdef HAVE_SYS_RANDOM_H
+#include <sys/random.h>
+#endif
+
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#include "fido.h"
+
+#if defined(_WIN32)
+#include <windows.h>
+
+#include <winternl.h>
+#include <winerror.h>
+#include <stdio.h>
+#include <bcrypt.h>
+#include <sal.h>
+
+int
+fido_get_random(void *buf, size_t len)
+{
+	NTSTATUS status;
+
+	status = BCryptGenRandom(NULL, buf, (ULONG)len,
+	    BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+
+	if (!NT_SUCCESS(status))
+		return (-1);
+
+	return (0);
+}
+#elif defined(HAVE_ARC4RANDOM_BUF)
+int
+fido_get_random(void *buf, size_t len)
+{
+	arc4random_buf(buf, len);
+	return (0);
+}
+#elif defined(HAVE_GETRANDOM)
+int
+fido_get_random(void *buf, size_t len)
+{
+	if (getrandom(buf, len, 0) < 0)
+		return (-1);
+	return (0);
+}
+#elif defined(HAVE_DEV_URANDOM)
+int
+fido_get_random(void *buf, size_t len)
+{
+	int	fd = -1;
+	int	ok = -1;
+	ssize_t	r;
+
+	if ((fd = open(FIDO_RANDOM_DEV, O_RDONLY)) < 0)
+		goto fail;
+	if ((r = read(fd, buf, len)) < 0 ||
+	    (size_t)r != len)
+		goto fail;
+
+	ok = 0;
+fail:
+	if (fd != -1)
+		close(fd);
+
+	return (ok);
+}
+#else
+#error "please provide an implementation of fido_get_random() for your platform"
+#endif /* _WIN32 */


### PR DESCRIPTION
Moving the random generation will be useful for cases where we will need to
generate random byte sequences for different use-cases than the nonce.

Checking the return value of `getrandom()` ensures that we got the correct
number of random bytes returned from the function (e.g if the call was 
interrupted by a signal handler).