### PR TITLE
workflows: enable ubuntu-20.04 + clang-10 builds again

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -11,8 +11,8 @@ jobs:
         include:
           - os: ubuntu-20.04
             cc: gcc-10
-#         - os: ubuntu-20.04
-#           cc: clang-10
+          - os: ubuntu-20.04
+            cc: clang-10
           - os: ubuntu-20.04
             cc: i686-w64-mingw32-gcc-9
           - os: ubuntu-18.04

--- a/.github/workflows/linux_fuzz.yml
+++ b/.github/workflows/linux_fuzz.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         cc: [clang-10]
         sanitizer: [msan, asan]
     steps:


### PR DESCRIPTION
GitHub appears to have fixed their environments. Refer to pull requests
actions/virtual-environments#1729 and actions/virtual-environments#1667.

This reverts commit f9d4642255efb1cf3e2ba8d4cd47f85462a6bcc8.