### PR TITLE
src/hid_win.c: add missing #include <wchar.h>

### DIFF
--- a/src/hid_win.c
+++ b/src/hid_win.c
@@ -18,6 +18,7 @@
 #include <devpropdef.h>
 #include <hidclass.h>
 #include <hidsdi.h>
+#include <wchar.h>
 
 #include "fido.h"
 


### PR DESCRIPTION
This fixes an `undefined symbol wcsncmp' on Cygwin.