### PR TITLE
dev: add fido_dev_supports_credman()

### DIFF
--- a/fuzz/export.gnu
+++ b/fuzz/export.gnu
@@ -185,6 +185,7 @@
 		fido_dev_set_io_functions;
 		fido_dev_set_pin;
 		fido_dev_set_transport_functions;
+		fido_dev_supports_credman;
 		fido_dev_supports_cred_prot;
 		fido_dev_supports_pin;
 		fido_hid_get_report_len;

--- a/fuzz/fuzz_credman.c
+++ b/fuzz/fuzz_credman.c
@@ -227,6 +227,8 @@ prepare_dev(void)
 	consume(&x, sizeof(x));
 	x = fido_dev_supports_cred_prot(dev);
 	consume(&x, sizeof(x));
+	x = fido_dev_supports_credman(dev);
+	consume(&x, sizeof(x));
 
 	return dev;
 }

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -194,6 +194,7 @@ list(APPEND MAN_ALIAS
 	fido_dev_open fido_dev_minor
 	fido_dev_open fido_dev_new
 	fido_dev_open fido_dev_protocol
+	fido_dev_open fido_dev_supports_credman
 	fido_dev_open fido_dev_supports_cred_prot
 	fido_dev_open fido_dev_supports_pin
 	fido_dev_set_pin fido_dev_get_retry_count

--- a/man/fido_dev_open.3
+++ b/man/fido_dev_open.3
@@ -14,6 +14,7 @@
 .Nm fido_dev_force_fido2 ,
 .Nm fido_dev_force_u2f ,
 .Nm fido_dev_is_fido2 ,
+.Nm fido_dev_supports_credman ,
 .Nm fido_dev_supports_cred_prot ,
 .Nm fido_dev_supports_pin ,
 .Nm fido_dev_has_pin ,
@@ -41,6 +42,8 @@
 .Fn fido_dev_force_u2f "fido_dev_t *dev"
 .Ft bool
 .Fn fido_dev_is_fido2 "const fido_dev_t *dev"
+.Ft bool
+.Fn fido_dev_supports_credman "const fido_dev_t *dev"
 .Ft bool
 .Fn fido_dev_supports_cred_prot "const fido_dev_t *dev"
 .Ft bool
@@ -124,6 +127,14 @@ function returns
 if
 .Fa dev
 is a FIDO 2 device.
+.Pp
+The
+.Fn fido_dev_supports_credman
+function returns
+.Dv true
+if
+.Fa dev
+supports FIDO 2.1 Credential Management.
 .Pp
 The
 .Fn fido_dev_supports_cred_prot

--- a/src/dev.c
+++ b/src/dev.c
@@ -72,6 +72,10 @@ fido_dev_set_flags(fido_dev_t *dev, const fido_cbor_info_t *info)
 				dev->flags |= FIDO_DEV_PIN_SET;
 			else
 				dev->flags |= FIDO_DEV_PIN_UNSET;
+		} else if (strcmp(ptr[i], "credMgmt") == 0 ||
+			   strcmp(ptr[i], "credentialMgmtPreview") == 0) {
+			if (val[i] == true)
+				dev->flags |= FIDO_DEV_CREDMAN;
 		}
 }
 
@@ -575,6 +579,12 @@ bool
 fido_dev_supports_cred_prot(const fido_dev_t *dev)
 {
 	return (dev->flags & FIDO_DEV_CRED_PROT);
+}
+
+bool
+fido_dev_supports_credman(const fido_dev_t *dev)
+{
+	return (dev->flags & FIDO_DEV_CREDMAN);
 }
 
 void

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -185,6 +185,7 @@
 		fido_dev_set_io_functions;
 		fido_dev_set_pin;
 		fido_dev_set_transport_functions;
+		fido_dev_supports_credman;
 		fido_dev_supports_cred_prot;
 		fido_dev_supports_pin;
 		fido_init;

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -183,6 +183,7 @@ _fido_dev_reset
 _fido_dev_set_io_functions
 _fido_dev_set_pin
 _fido_dev_set_transport_functions
+_fido_dev_supports_credman
 _fido_dev_supports_cred_prot
 _fido_dev_supports_pin
 _fido_init

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -184,6 +184,7 @@ fido_dev_reset
 fido_dev_set_io_functions
 fido_dev_set_pin
 fido_dev_set_transport_functions
+fido_dev_supports_credman
 fido_dev_supports_cred_prot
 fido_dev_supports_pin
 fido_init

--- a/src/extern.h
+++ b/src/extern.h
@@ -165,6 +165,7 @@ uint32_t uniform_random(uint32_t);
 #define FIDO_DEV_PIN_SET	0x01
 #define FIDO_DEV_PIN_UNSET	0x02
 #define FIDO_DEV_CRED_PROT	0x04
+#define FIDO_DEV_CREDMAN	0x08
 
 /* miscellanea */
 #define FIDO_DUMMY_CLIENTDATA	""

--- a/src/fido.h
+++ b/src/fido.h
@@ -183,6 +183,7 @@ bool fido_dev_has_pin(const fido_dev_t *);
 bool fido_dev_is_fido2(const fido_dev_t *);
 bool fido_dev_supports_pin(const fido_dev_t *);
 bool fido_dev_supports_cred_prot(const fido_dev_t *);
+bool fido_dev_supports_credman(const fido_dev_t *);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
This function can be used to query the authenticator support for FIDO
2.1 Credential Management.