### PR TITLE
udev: add Nitrokey 3C NFC

### DIFF
--- a/udev/70-u2f.rules
+++ b/udev/70-u2f.rules
@@ -136,6 +136,9 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct
 # Nitrokey FIDO2 by Flirc
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42b1", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
+# Nitrokey 3C NFC by Flirc
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42b2", TAG+="uaccess", GROUP="plugdev", MODE="0660"
+
 # Safetech SafeKey by Flirc
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42b3", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 

--- a/udev/fidodevs
+++ b/udev/fidodevs
@@ -88,6 +88,7 @@ product NXP		0xf143	GoTrust Idem Key
 
 product FLIRC		0x4287	Nitrokey FIDO U2F
 product FLIRC		0x42b1	Nitrokey FIDO2
+product FLIRC		0x42b2	Nitrokey 3C NFC
 product FLIRC		0x42b3	Safetech SafeKey
 
 product ALLADIN		0x0101	JaCarta U2F


### PR DESCRIPTION
Hi!

With this PR I would like to add Udev rule for Nitrokey 3C NFC.

cc @Nitrokey