### PR TITLE
Add/Update Trustkey T110, T120, G310, G320

### DIFF
--- a/udev/70-u2f.rules
+++ b/udev/70-u2f.rules
@@ -184,22 +184,22 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2c97", ATTRS{idProduct
 # Hypersecu HyperFIDO by Hypersecu Information Systems, Inc.
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2ccf", ATTRS{idProduct}=="0880", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
-# TrustKey Solutions FIDO2 TrustKey G310 by eWBM Co., Ltd. (Trustkey Solutions)
+# TrustKey Solutions FIDO2 G310 by eWBM Co., Ltd.
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="4a1a", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
-# TrustKey Solutions FIDO2 TrustKey G320 by eWBM Co., Ltd. (Trustkey Solutions)
+# TrustKey Solutions FIDO2 G320 by eWBM Co., Ltd.
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="4c2a", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
-# eWBM FIDO2 Goldengate G500 by eWBM Co., Ltd. (Trustkey Solutions)
+# eWBM FIDO2 Goldengate G500 by eWBM Co., Ltd.
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="5c2f", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
-# TrustKey Solutions FIDO2 TrustKey T110 by eWBM Co., Ltd. (Trustkey Solutions)
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="a7f9", TAG+="uaccess", GROUP="plugdev", MODE="0660"
-
-# TrustKey Solutions FIDO2 TrustKey T120 by eWBM Co., Ltd. (Trustkey Solutions)
+# TrustKey Solutions FIDO2 T120 by eWBM Co., Ltd.
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="a6e9", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
-# eWBM FIDO2 Goldengate G450 by eWBM Co., Ltd. (Trustkey Solutions)
+# TrustKey Solutions FIDO2 T110 by eWBM Co., Ltd.
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="a7f9", TAG+="uaccess", GROUP="plugdev", MODE="0660"
+
+# eWBM FIDO2 Goldengate G450 by eWBM Co., Ltd.
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="f47c", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
 # Longmai mFIDO by Unknown vendor

--- a/udev/70-u2f.rules
+++ b/udev/70-u2f.rules
@@ -184,16 +184,22 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2c97", ATTRS{idProduct
 # Hypersecu HyperFIDO by Hypersecu Information Systems, Inc.
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2ccf", ATTRS{idProduct}=="0880", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
-# eWBM FIDO2 Goldengate 310 by eWBM Co., Ltd.
+# TrustKey Solutions FIDO2 TrustKey G310 by eWBM Co., Ltd. (Trustkey Solutions)
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="4a1a", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
-# eWBM FIDO2 Goldengate 320 by eWBM Co., Ltd.
+# TrustKey Solutions FIDO2 TrustKey G320 by eWBM Co., Ltd. (Trustkey Solutions)
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="4c2a", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
-# eWBM FIDO2 Goldengate 500 by eWBM Co., Ltd.
+# eWBM FIDO2 Goldengate G500 by eWBM Co., Ltd. (Trustkey Solutions)
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="5c2f", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
-# eWBM FIDO2 Goldengate 450 by eWBM Co., Ltd.
+# TrustKey Solutions FIDO2 TrustKey T110 by eWBM Co., Ltd. (Trustkey Solutions)
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="a7f9", TAG+="uaccess", GROUP="plugdev", MODE="0660"
+
+# TrustKey Solutions FIDO2 TrustKey T120 by eWBM Co., Ltd. (Trustkey Solutions)
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="a6e9", TAG+="uaccess", GROUP="plugdev", MODE="0660"
+
+# eWBM FIDO2 Goldengate G450 by eWBM Co., Ltd. (Trustkey Solutions)
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="f47c", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
 # Longmai mFIDO by Unknown vendor

--- a/udev/fidodevs
+++ b/udev/fidodevs
@@ -26,7 +26,7 @@ vendor PLUGUP		0x2581	Plug‐up
 vendor BLUINK		0x2abe	Bluink Ltd
 vendor LEDGER		0x2c97	LEDGER
 vendor HYPERSECU	0x2ccf	Hypersecu Information Systems, Inc.
-vendor EWBM		0x311f	eWBM Co., Ltd.
+vendor EWBM		0x311f	eWBM Co., Ltd. (Trustkey Solutions)
 vendor UNKNOWN1		0x4c4d	Unknown vendor
 vendor SATOSHI		0x534c	SatoshiLabs
 
@@ -110,10 +110,12 @@ product LEDGER		0x4015	Ledger Nano X Legacy
 
 product HYPERSECU	0x0880	Hypersecu HyperFIDO
 
-product EWBM		0x4a1a	eWBM FIDO2 Goldengate 310
-product EWBM		0x4c2a	eWBM FIDO2 Goldengate 320
-product EWBM		0x5c2f	eWBM FIDO2 Goldengate 500
-product EWBM		0xf47c	eWBM FIDO2 Goldengate 450
+product EWBM		0x4a1a	TrustKey Solutions FIDO2 TrustKey G310
+product EWBM		0x4c2a	TrustKey Solutions FIDO2 TrustKey G320
+product EWBM		0x5c2f	eWBM FIDO2 Goldengate G500
+product EWBM		0xa7f9	TrustKey Solutions FIDO2 TrustKey T110
+product EWBM		0xa6e9	TrustKey Solutions FIDO2 TrustKey T120
+product EWBM		0xf47c	eWBM FIDO2 Goldengate G450
 
 product UNKNOWN1	0xf703	Longmai mFIDO
 

--- a/udev/fidodevs
+++ b/udev/fidodevs
@@ -26,7 +26,7 @@ vendor PLUGUP		0x2581	Plug‐up
 vendor BLUINK		0x2abe	Bluink Ltd
 vendor LEDGER		0x2c97	LEDGER
 vendor HYPERSECU	0x2ccf	Hypersecu Information Systems, Inc.
-vendor EWBM		0x311f	eWBM Co., Ltd. (Trustkey Solutions)
+vendor EWBM		0x311f	eWBM Co., Ltd.
 vendor UNKNOWN1		0x4c4d	Unknown vendor
 vendor SATOSHI		0x534c	SatoshiLabs
 
@@ -110,11 +110,11 @@ product LEDGER		0x4015	Ledger Nano X Legacy
 
 product HYPERSECU	0x0880	Hypersecu HyperFIDO
 
-product EWBM		0x4a1a	TrustKey Solutions FIDO2 TrustKey G310
-product EWBM		0x4c2a	TrustKey Solutions FIDO2 TrustKey G320
+product EWBM		0x4a1a	TrustKey Solutions FIDO2 G310
+product EWBM		0x4c2a	TrustKey Solutions FIDO2 G320
 product EWBM		0x5c2f	eWBM FIDO2 Goldengate G500
-product EWBM		0xa7f9	TrustKey Solutions FIDO2 TrustKey T110
-product EWBM		0xa6e9	TrustKey Solutions FIDO2 TrustKey T120
+product EWBM		0xa6e9	TrustKey Solutions FIDO2 T120
+product EWBM		0xa7f9	TrustKey Solutions FIDO2 T110
 product EWBM		0xf47c	eWBM FIDO2 Goldengate G450
 
 product UNKNOWN1	0xf703	Longmai mFIDO


### PR DESCRIPTION
According to https://www.trustkeysolutions.com/support/ two new products
T110 and T120 are added. The formerly eWBM G310, G320 are now under the
Trustkey brand.