### PR TITLE
pin: add fido_dev_get_uv_retry_count()

### DIFF
--- a/fuzz/export.gnu
+++ b/fuzz/export.gnu
@@ -162,6 +162,7 @@
 		fido_dev_get_assert;
 		fido_dev_get_cbor_info;
 		fido_dev_get_retry_count;
+		fido_dev_get_uv_retry_count;
 		fido_dev_get_touch_begin;
 		fido_dev_get_touch_status;
 		fido_dev_has_pin;

--- a/fuzz/fuzz_mgmt.c
+++ b/fuzz/fuzz_mgmt.c
@@ -342,6 +342,23 @@ dev_get_retry_count(const struct param *p)
 	fido_dev_free(&dev);
 }
 
+static void
+dev_get_uv_retry_count(const struct param *p)
+{
+	fido_dev_t *dev;
+	int n = 0;
+
+	set_wire_data(p->retry_wire_data.body, p->retry_wire_data.len);
+
+	if ((dev = prepare_dev()) == NULL)
+		return;
+
+	fido_dev_get_uv_retry_count(dev, &n);
+	consume(&n, sizeof(n));
+	fido_dev_close(dev);
+	fido_dev_free(&dev);
+}
+
 void
 test(const struct param *p)
 {
@@ -354,6 +371,7 @@ test(const struct param *p)
 	dev_set_pin(p);
 	dev_change_pin(p);
 	dev_get_retry_count(p);
+	dev_get_uv_retry_count(p);
 }
 
 void

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -198,6 +198,7 @@ list(APPEND MAN_ALIAS
 	fido_dev_open fido_dev_supports_cred_prot
 	fido_dev_open fido_dev_supports_pin
 	fido_dev_set_pin fido_dev_get_retry_count
+	fido_dev_set_pin fido_dev_get_uv_retry_count
 	fido_dev_set_pin fido_dev_reset
 	rs256_pk_new rs256_pk_free
 	rs256_pk_new rs256_pk_from_ptr

--- a/man/fido_dev_set_pin.3
+++ b/man/fido_dev_set_pin.3
@@ -8,6 +8,7 @@
 .Sh NAME
 .Nm fido_dev_set_pin ,
 .Nm fido_dev_get_retry_count ,
+.Nm fido_dev_get_uv_retry_count ,
 .Nm fido_dev_reset
 .Nd FIDO 2 device management functions
 .Sh SYNOPSIS
@@ -16,6 +17,8 @@
 .Fn fido_dev_set_pin "fido_dev_t *dev" "const char *pin" "const char *oldpin"
 .Ft int
 .Fn fido_dev_get_retry_count "fido_dev_t *dev" "int *retries"
+.Ft int
+.Fn fido_dev_get_uv_retry_count "fido_dev_t *dev" "int *retries"
 .Ft int
 .Fn fido_dev_reset "fido_dev_t *dev"
 .Sh DESCRIPTION
@@ -51,6 +54,16 @@ before lock-out, where
 is an addressable pointer.
 .Pp
 The
+.Fn fido_dev_get_uv_retry_count
+function fills
+.Fa retries
+with the number of built-in UV retries left in
+.Fa dev
+before built-in UV is disabled, where
+.Fa retries
+is an addressable pointer.
+.Pp
+The
 .Fn fido_dev_reset
 function performs a reset on
 .Fa dev ,
@@ -60,6 +73,7 @@ device.
 Please note that
 .Fn fido_dev_set_pin ,
 .Fn fido_dev_get_retry_count ,
+.Fn fido_dev_get_uv_retry_count ,
 and
 .Fn fido_dev_reset
 are synchronous and will block if necessary.
@@ -67,6 +81,7 @@ are synchronous and will block if necessary.
 The error codes returned by
 .Fn fido_dev_set_pin ,
 .Fn fido_dev_get_retry_count ,
+.Fn fido_dev_get_uv_retry_count ,
 and
 .Fn fido_dev_reset
 are defined in

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -162,6 +162,7 @@
 		fido_dev_get_assert;
 		fido_dev_get_cbor_info;
 		fido_dev_get_retry_count;
+		fido_dev_get_uv_retry_count;
 		fido_dev_get_touch_begin;
 		fido_dev_get_touch_status;
 		fido_dev_has_pin;

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -160,6 +160,7 @@ _fido_dev_free
 _fido_dev_get_assert
 _fido_dev_get_cbor_info
 _fido_dev_get_retry_count
+_fido_dev_get_uv_retry_count
 _fido_dev_get_touch_begin
 _fido_dev_get_touch_status
 _fido_dev_has_pin

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -161,6 +161,7 @@ fido_dev_free
 fido_dev_get_assert
 fido_dev_get_cbor_info
 fido_dev_get_retry_count
+fido_dev_get_uv_retry_count
 fido_dev_get_touch_begin
 fido_dev_get_touch_status
 fido_dev_has_pin

--- a/src/fido.h
+++ b/src/fido.h
@@ -130,6 +130,7 @@ int fido_dev_close(fido_dev_t *);
 int fido_dev_get_assert(fido_dev_t *, fido_assert_t *, const char *);
 int fido_dev_get_cbor_info(fido_dev_t *, fido_cbor_info_t *);
 int fido_dev_get_retry_count(fido_dev_t *, int *);
+int fido_dev_get_uv_retry_count(fido_dev_t *, int *);
 int fido_dev_get_touch_begin(fido_dev_t *);
 int fido_dev_get_touch_status(fido_dev_t *, int *, int);
 int fido_dev_info_manifest(fido_dev_info_t *, size_t, size_t *);

--- a/tools/token.c
+++ b/tools/token.c
@@ -232,6 +232,11 @@ token_info(int argc, char **argv, char *path)
 	else
 		printf("pin retries: %d\n", retrycnt);
 
+	if (fido_dev_get_uv_retry_count(dev, &retrycnt) != FIDO_OK)
+		printf("uv retries: undefined\n");
+	else
+		printf("uv retries: %d\n", retrycnt);
+
 	bio_info(dev);
 
 	fido_cbor_info_free(&ci);


### PR DESCRIPTION
This retrieves the number of built-in UV attempts before built-in UV is
disabled on the device.