### PR TITLE
Pass signal mask down into I/O functions.

### DIFF
--- a/regress/assert.c
+++ b/regress/assert.c
@@ -52,9 +52,10 @@ static const unsigned char sig[72] = {
 };
 
 static void *
-dummy_open(const char *path)
+dummy_open(const char *path, const sigset_t *sigmask)
 {
 	(void)path;
+	(void)sigmask;
 
 	return (FAKE_DEV_HANDLE);
 }
@@ -66,23 +67,27 @@ dummy_close(void *handle)
 }
 
 static int
-dummy_read(void *handle, unsigned char *buf, size_t len, int ms)
+dummy_read(void *handle, unsigned char *buf, size_t len, int ms,
+    const sigset_t *sigmask)
 {
 	(void)handle;
 	(void)buf;
 	(void)len;
 	(void)ms;
+	(void)sigmask;
 
 	abort();
 	/* NOTREACHED */
 }
 
 static int
-dummy_write(void *handle, const unsigned char *buf, size_t len)
+dummy_write(void *handle, const unsigned char *buf, size_t len,
+    const sigset_t *sigmask)
 {
 	(void)handle;
 	(void)buf;
 	(void)len;
+	(void)sigmask;
 
 	abort();
 	/* NOTREACHED */

--- a/regress/cred.c
+++ b/regress/cred.c
@@ -246,9 +246,10 @@ const char rp_id[] = "localhost";
 const char rp_name[] = "sweet home localhost";
 
 static void *
-dummy_open(const char *path)
+dummy_open(const char *path, const sigset_t *sigmask)
 {
 	(void)path;
+	(void)sigmask;
 
 	return (FAKE_DEV_HANDLE);
 }
@@ -260,23 +261,27 @@ dummy_close(void *handle)
 }
 
 static int
-dummy_read(void *handle, unsigned char *buf, size_t len, int ms)
+dummy_read(void *handle, unsigned char *buf, size_t len, int ms,
+    const sigset_t *sigmask)
 {
 	(void)handle;
 	(void)buf;
 	(void)len;
 	(void)ms;
+	(void)sigmask;
 
 	abort();
 	/* NOTREACHED */
 }
 
 static int
-dummy_write(void *handle, const unsigned char *buf, size_t len)
+dummy_write(void *handle, const unsigned char *buf, size_t len,
+    const sigset_t *sigmask)
 {
 	(void)handle;
 	(void)buf;
 	(void)len;
+	(void)sigmask;
 
 	abort();
 	/* NOTREACHED */

--- a/regress/dev.c
+++ b/regress/dev.c
@@ -19,9 +19,10 @@ static size_t	 wiredata_len;
 static int	 initialised;
 
 static void *
-dummy_open(const char *path)
+dummy_open(const char *path, const sigset_t *sigmask)
 {
 	(void)path;
+	(void)sigmask;
 
 	return (FAKE_DEV_HANDLE);
 }
@@ -33,11 +34,13 @@ dummy_close(void *handle)
 }
 
 static int
-dummy_read(void *handle, unsigned char *ptr, size_t len, int ms)
+dummy_read(void *handle, unsigned char *ptr, size_t len, int ms,
+    const sigset_t *sigmask)
 {
 	size_t n;
 
 	(void)ms;
+	(void)sigmask;
 
 	assert(handle == FAKE_DEV_HANDLE);
 	assert(ptr != NULL);
@@ -65,11 +68,13 @@ dummy_read(void *handle, unsigned char *ptr, size_t len, int ms)
 }
 
 static int
-dummy_write(void *handle, const unsigned char *ptr, size_t len)
+dummy_write(void *handle, const unsigned char *ptr, size_t len,
+    const sigset_t *sigmask)
 {
 	assert(handle == FAKE_DEV_HANDLE);
 	assert(ptr != NULL);
 	assert(len == REPORT_LEN);
+	(void)sigmask;
 
 	if (!initialised)
 		memcpy(&ctap_nonce, &ptr[8], sizeof(ctap_nonce));

--- a/src/dev.c
+++ b/src/dev.c
@@ -105,7 +105,7 @@ fido_dev_open_tx(fido_dev_t *dev, const char *path)
 		return (FIDO_ERR_INTERNAL);
 	}
 
-	if ((dev->io_handle = dev->io.open(path)) == NULL) {
+	if ((dev->io_handle = dev->io.open(path, dev->sigmaskp)) == NULL) {
 		fido_log_debug("%s: dev->io.open", __func__);
 		return (FIDO_ERR_INTERNAL);
 	}
@@ -525,6 +525,14 @@ fido_dev_free(fido_dev_t **dev_p)
 	free(dev);
 
 	*dev_p = NULL;
+}
+
+void
+fido_dev_sigmask(fido_dev_t *dev, const sigset_t *sigmask)
+{
+
+	dev->sigmask = *sigmask;
+	dev->sigmaskp = &dev->sigmask;
 }
 
 uint8_t

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -186,6 +186,7 @@
 		fido_dev_set_io_functions;
 		fido_dev_set_pin;
 		fido_dev_set_transport_functions;
+		fido_dev_sigmask;
 		fido_dev_supports_credman;
 		fido_dev_supports_cred_prot;
 		fido_dev_supports_pin;

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -184,6 +184,7 @@ _fido_dev_reset
 _fido_dev_set_io_functions
 _fido_dev_set_pin
 _fido_dev_set_transport_functions
+_fido_dev_sigmask
 _fido_dev_supports_credman
 _fido_dev_supports_cred_prot
 _fido_dev_supports_pin

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -185,6 +185,7 @@ fido_dev_reset
 fido_dev_set_io_functions
 fido_dev_set_pin
 fido_dev_set_transport_functions
+fido_dev_sigmask
 fido_dev_supports_credman
 fido_dev_supports_cred_prot
 fido_dev_supports_pin

--- a/src/extern.h
+++ b/src/extern.h
@@ -7,6 +7,7 @@
 #ifndef _EXTERN_H
 #define _EXTERN_H
 
+#include <signal.h>
 #include <stdint.h>
 
 #include "fido/types.h"
@@ -84,14 +85,14 @@ int fido_buf_read(const unsigned char **, size_t *, void *, size_t);
 int fido_buf_write(unsigned char **, size_t *, const void *, size_t);
 
 /* hid i/o */
-void *fido_hid_open(const char *);
+void *fido_hid_open(const char *, const sigset_t *);
 void  fido_hid_close(void *);
-int fido_hid_read(void *, unsigned char *, size_t, int);
-int fido_hid_write(void *, const unsigned char *, size_t);
+int fido_hid_read(void *, unsigned char *, size_t, int, const sigset_t *);
+int fido_hid_write(void *, const unsigned char *, size_t, const sigset_t *);
 int fido_hid_get_usage(const uint8_t *, size_t, uint32_t *);
 int fido_hid_get_report_len(const uint8_t *, size_t, size_t *, size_t *);
 int fido_hid_unix_open(const char *);
-int fido_hid_unix_wait(int, int);
+int fido_hid_unix_wait(int, short, int, const sigset_t *);
 size_t fido_hid_report_in_len(void *);
 size_t fido_hid_report_out_len(void *);
 

--- a/src/fido.h
+++ b/src/fido.h
@@ -53,6 +53,8 @@ void fido_dev_info_free(fido_dev_info_t **, size_t);
 void fido_init(int);
 void fido_set_log_handler(fido_log_handler_t *);
 
+void fido_dev_sigmask(fido_dev_t *, const sigset_t *);
+
 const unsigned char *fido_assert_authdata_ptr(const fido_assert_t *, size_t);
 const unsigned char *fido_assert_clientdata_hash_ptr(const fido_assert_t *);
 const unsigned char *fido_assert_hmac_secret_ptr(const fido_assert_t *, size_t);

--- a/src/fido/types.h
+++ b/src/fido/types.h
@@ -7,6 +7,7 @@
 #ifndef _FIDO_TYPES_H
 #define _FIDO_TYPES_H
 
+#include <signal.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -16,12 +17,12 @@ extern "C" {
 
 struct fido_dev;
 
-typedef void *fido_dev_io_open_t(const char *);
+typedef void *fido_dev_io_open_t(const char *, const sigset_t *);
 typedef void  fido_dev_io_close_t(void *);
-typedef int   fido_dev_io_read_t(void *, unsigned char *, size_t, int);
-typedef int   fido_dev_io_write_t(void *, const unsigned char *, size_t);
-typedef int   fido_dev_rx_t(struct fido_dev *, uint8_t, unsigned char *, size_t, int);
-typedef int   fido_dev_tx_t(struct fido_dev *, uint8_t, const unsigned char *, size_t);
+typedef int   fido_dev_io_read_t(void *, unsigned char *, size_t, int, const sigset_t *);
+typedef int   fido_dev_io_write_t(void *, const unsigned char *, size_t, const sigset_t *);
+typedef int   fido_dev_rx_t(struct fido_dev *, uint8_t, unsigned char *, size_t, int, const sigset_t *);
+typedef int   fido_dev_tx_t(struct fido_dev *, uint8_t, const unsigned char *, size_t, const sigset_t *);
 
 typedef struct fido_dev_io {
 	fido_dev_io_open_t  *open;
@@ -221,6 +222,8 @@ typedef struct fido_dev {
 	size_t                tx_len;    /* length of HID output reports */
 	int                   flags;     /* internal flags; see FIDO_DEV_* */
 	fido_dev_transport_t  transport; /* transport functions */
+	sigset_t              sigmask;   /* signal mask while blocking */
+	const sigset_t        *sigmaskp;
 } fido_dev_t;
 
 #else

--- a/src/hid_unix.c
+++ b/src/hid_unix.c
@@ -32,25 +32,6 @@ xstrerror(int errnum, char *buf, size_t len)
 		snprintf(buf, len - 1, "error %d", errnum);
 }
 
-static int
-timespec_to_ms(const struct timespec *ts, int upper_bound)
-{
-	int64_t x;
-	int64_t y;
-
-	if (ts->tv_sec < 0 || (uint64_t)ts->tv_sec > INT64_MAX / 1000LL ||
-	    ts->tv_nsec < 0 || (uint64_t)ts->tv_nsec / 1000000LL > INT64_MAX)
-		return (upper_bound);
-
-	x = ts->tv_sec * 1000LL;
-	y = ts->tv_nsec / 1000000LL;
-
-	if (INT64_MAX - x < y || x + y > upper_bound)
-		return (upper_bound);
-
-	return (int)(x + y);
-}
-
 int
 fido_hid_unix_open(const char *path)
 {
@@ -83,47 +64,62 @@ fido_hid_unix_open(const char *path)
 }
 
 int
-fido_hid_unix_wait(int fd, int ms)
+fido_hid_unix_wait(int fd, short events, int ms, const sigset_t *sigmask)
 {
 	char		ebuf[128];
 	struct timespec	ts_start;
 	struct timespec	ts_now;
 	struct timespec	ts_delta;
+	struct timespec	ts_deadline;
 	struct pollfd	pfd;
-	int		ms_remain;
 	int		r;
 
-	if (ms < 0)
-		return (0);
-
 	memset(&pfd, 0, sizeof(pfd));
-	pfd.events = POLLIN;
+	pfd.events = events;
 	pfd.fd = fd;
 
-	if (clock_gettime(CLOCK_MONOTONIC, &ts_start) != 0) {
-		xstrerror(errno, ebuf, sizeof(ebuf));
-		fido_log_debug("%s: clock_gettime: %s", __func__, ebuf);
-		return (-1);
+	if (ms > 0) {
+		if (clock_gettime(CLOCK_MONOTONIC, &ts_start) != 0) {
+			xstrerror(errno, ebuf, sizeof(ebuf));
+			fido_log_debug("%s: clock_gettime: %s", __func__,
+			    ebuf);
+			return (-1);
+		}
+		ts_delta.tv_sec = ms / 1000;
+		ts_delta.tv_nsec = (ms % 1000) * 1000000;
+		timespecadd(&ts_start, &ts_delta, &ts_deadline);
 	}
 
-	for (ms_remain = ms; ms_remain > 0;) {
-		if ((r = poll(&pfd, 1, ms_remain)) > 0)
+	for (;;) {
+		if (ms > 0) {
+			if (clock_gettime(CLOCK_MONOTONIC, &ts_now) != 0) {
+				xstrerror(errno, ebuf, sizeof(ebuf));
+				fido_log_debug("%s: clock_gettime: %s",
+				    __func__, ebuf);
+				return (-1);
+			}
+			if (timespeccmp(&ts_deadline, &ts_now, <=)) {
+				errno = ETIMEDOUT;
+				return (-1);
+			}
+			timespecsub(&ts_deadline, &ts_now, &ts_delta);
+			r = pollts(&pfd, 1, &ts_delta, sigmask);
+		} else if (ms == 0) {
+			ts_delta.tv_sec = 0;
+			ts_delta.tv_nsec = 0;
+			r = pollts(&pfd, 1, &ts_delta, sigmask);
+		} else {
+			r = pollts(&pfd, 1, NULL, sigmask);
+		}
+		if (r > 0)
 			return (0);
 		else if (r == 0)
 			break;
-		else if (errno != EINTR) {
+		else {
 			xstrerror(errno, ebuf, sizeof(ebuf));
 			fido_log_debug("%s: poll: %s", __func__, ebuf);
 			return (-1);
 		}
-		/* poll interrupted - subtract time already waited */
-		if (clock_gettime(CLOCK_MONOTONIC, &ts_now) != 0) {
-			xstrerror(errno, ebuf, sizeof(ebuf));
-			fido_log_debug("%s: clock_gettime: %s", __func__, ebuf);
-			return (-1);
-		}
-		timespecsub(&ts_now, &ts_start, &ts_delta);
-		ms_remain = ms - timespec_to_ms(&ts_delta, ms);
 	}
 
 	return (-1);


### PR DESCRIPTION
This is a draft proof-of-concept to pass the signal mask down into waits for I/O -- see https://github.com/Yubico/libfido2/issues/251 for details.

Caveats in this draft:

 - This changes the API and ABI of fido_dev_set_io_functions and fido_dev_set_transport_functions -- the functions now take a signal mask to set while waiting for I/O.

 - Formerly fido_hid_unix_wait would loop on EINTR, but that renders the whole exercise moot -- the point is to abort and pass the buck back to the caller.  Looping on EINTR also only happened when waiting in poll via fido_hid_unix_wait, not in read or write; it's not clear to me why this loop was added.