### PR TITLE
New function fido_assert_set_hmac_secret.

### DIFF
--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -72,6 +72,7 @@ list(APPEND MAN_ALIAS
 	fido_assert_set_authdata fido_assert_set_count
 	fido_assert_set_authdata fido_assert_set_extensions
 	fido_assert_set_authdata fido_assert_set_hmac_salt
+	fido_assert_set_authdata fido_assert_set_hmac_secret
 	fido_assert_set_authdata fido_assert_set_rp
 	fido_assert_set_authdata fido_assert_set_sig
 	fido_assert_set_authdata fido_assert_set_up

--- a/man/fido_assert_set_authdata.3
+++ b/man/fido_assert_set_authdata.3
@@ -39,6 +39,7 @@ typedef enum {
 .Fn fido_assert_set_extensions "fido_assert_t *assert" "int flags"
 .Ft int
 .Fn fido_assert_set_hmac_salt "fido_assert_t *assert" "const unsigned char *ptr" "size_t len"
+.Ft int
 .Fn fido_assert_set_hmac_secret "fido_assert_t *assert" "const unsigned char *ptr" "size_t len"
 .Ft int
 .Fn fido_assert_set_up "fido_assert_t *assert" "fido_opt_t up"

--- a/man/fido_assert_set_authdata.3
+++ b/man/fido_assert_set_authdata.3
@@ -12,6 +12,7 @@
 .Nm fido_assert_set_count ,
 .Nm fido_assert_set_extensions ,
 .Nm fido_assert_set_hmac_salt ,
+.Nm fido_assert_set_hmac_secret ,
 .Nm fido_assert_set_up ,
 .Nm fido_assert_set_uv ,
 .Nm fido_assert_set_rp ,
@@ -38,6 +39,7 @@ typedef enum {
 .Fn fido_assert_set_extensions "fido_assert_t *assert" "int flags"
 .Ft int
 .Fn fido_assert_set_hmac_salt "fido_assert_t *assert" "const unsigned char *ptr" "size_t len"
+.Fn fido_assert_set_hmac_secret "fido_assert_t *assert" "const unsigned char *ptr" "size_t len"
 .Ft int
 .Fn fido_assert_set_up "fido_assert_t *assert" "fido_opt_t up"
 .Ft int
@@ -100,9 +102,10 @@ Alternatively, a raw binary blob may be passed to
 .Fn fido_assert_set_authdata_raw .
 .Pp
 The
-.Fn fido_assert_set_clientdata_hash
+.Fn fido_assert_set_clientdata_hash ,
+.Fn fido_assert_set_hmac_salt ,
 and
-.Fn fido_assert_set_hmac_salt
+.Fn fido_assert_set_hmac_secret
 functions set the client data hash and hmac-salt parts of
 .Fa assert
 to
@@ -178,6 +181,11 @@ set of functions can be found in the
 .Pa examples/assert.c
 file shipped with
 .Em libfido2 .
+.Pp
+.Fn fido_assert_set_hmac_secret
+is not normally useful in a FIDO client or server \(em it is provided
+to enable testing other functionality that relies on retrieving the
+HMAC secret from an assertion obtained from an authenticator.
 .Sh RETURN VALUES
 The
 .Nm

--- a/src/assert.c
+++ b/src/assert.c
@@ -634,6 +634,19 @@ fido_assert_set_hmac_salt(fido_assert_t *assert, const unsigned char *salt,
 }
 
 int
+fido_assert_set_hmac_secret(fido_assert_t *assert, size_t idx,
+    const unsigned char *secret, size_t secret_len)
+{
+	if (idx >= assert->stmt_len ||
+	    (secret_len != 32 && secret_len != 64) ||
+	    (fido_blob_set(&assert->stmt[idx].hmac_secret, secret, secret_len)
+		< 0))
+		return (FIDO_ERR_INVALID_ARGUMENT);
+
+	return (FIDO_OK);
+}
+
+int
 fido_assert_set_rp(fido_assert_t *assert, const char *id)
 {
 	if (assert->rp_id != NULL) {

--- a/src/assert.c
+++ b/src/assert.c
@@ -637,10 +637,9 @@ int
 fido_assert_set_hmac_secret(fido_assert_t *assert, size_t idx,
     const unsigned char *secret, size_t secret_len)
 {
-	if (idx >= assert->stmt_len ||
-	    (secret_len != 32 && secret_len != 64) ||
-	    (fido_blob_set(&assert->stmt[idx].hmac_secret, secret, secret_len)
-		< 0))
+	if (idx >= assert->stmt_len || (secret_len != 32 && secret_len != 64) ||
+	    fido_blob_set(&assert->stmt[idx].hmac_secret, secret,
+	    secret_len) < 0)
 		return (FIDO_ERR_INVALID_ARGUMENT);
 
 	return (FIDO_OK);

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -30,6 +30,7 @@
 		fido_assert_set_count;
 		fido_assert_set_extensions;
 		fido_assert_set_hmac_salt;
+		fido_assert_set_hmac_secret;
 		fido_assert_set_options;
 		fido_assert_set_rp;
 		fido_assert_set_sig;

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -28,6 +28,7 @@ _fido_assert_set_clientdata_hash
 _fido_assert_set_count
 _fido_assert_set_extensions
 _fido_assert_set_hmac_salt
+_fido_assert_set_hmac_secret
 _fido_assert_set_options
 _fido_assert_set_rp
 _fido_assert_set_sig

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -29,6 +29,7 @@ fido_assert_set_clientdata_hash
 fido_assert_set_count
 fido_assert_set_extensions
 fido_assert_set_hmac_salt
+fido_assert_set_hmac_secret
 fido_assert_set_options
 fido_assert_set_rp
 fido_assert_set_sig

--- a/src/fido.h
+++ b/src/fido.h
@@ -99,6 +99,8 @@ int fido_assert_set_clientdata_hash(fido_assert_t *, const unsigned char *,
 int fido_assert_set_count(fido_assert_t *, size_t);
 int fido_assert_set_extensions(fido_assert_t *, int);
 int fido_assert_set_hmac_salt(fido_assert_t *, const unsigned char *, size_t);
+int fido_assert_set_hmac_secret(fido_assert_t *, size_t, const unsigned char *,
+    size_t);
 int fido_assert_set_options(fido_assert_t *, bool, bool);
 int fido_assert_set_rp(fido_assert_t *, const char *);
 int fido_assert_set_up(fido_assert_t *, fido_opt_t);


### PR DESCRIPTION
Useful for testing applications that use the hmac-secret.

fix https://github.com/Yubico/libfido2/issues/256