### PR TITLE
udev: Add CanoKey and Update to correct vendor

### DIFF
--- a/udev/70-u2f.rules
+++ b/udev/70-u2f.rules
@@ -130,19 +130,19 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1ea8", ATTRS{idProduct
 # GoTrust Idem Key by NXP Semiconductors
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="f143", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
-# Nitrokey FIDO U2F by Flirc
+# Nitrokey FIDO U2F by Clay Logic
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
-# Nitrokey FIDO2 by Flirc
+# Nitrokey FIDO2 by Clay Logic
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42b1", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
-# Nitrokey 3C NFC by Flirc
+# Nitrokey 3C NFC by Clay Logic
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42b2", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
-# Safetech SafeKey by Flirc
+# Safetech SafeKey by Clay Logic
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42b3", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
-# CanoKey by Flirc
+# CanoKey by Clay Logic
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42d4", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
 # JaCarta U2F by Aladdin Software Security R.D.

--- a/udev/70-u2f.rules
+++ b/udev/70-u2f.rules
@@ -142,6 +142,9 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct
 # Safetech SafeKey by Flirc
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42b3", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
+# CanoKey by Flirc
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42d4", TAG+="uaccess", GROUP="plugdev", MODE="0660"
+
 # JaCarta U2F by Aladdin Software Security R.D.
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="24dc", ATTRS{idProduct}=="0101", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 

--- a/udev/fidodevs
+++ b/udev/fidodevs
@@ -90,6 +90,7 @@ product FLIRC		0x4287	Nitrokey FIDO U2F
 product FLIRC		0x42b1	Nitrokey FIDO2
 product FLIRC		0x42b2	Nitrokey 3C NFC
 product FLIRC		0x42b3	Safetech SafeKey
+product FLIRC		0x42d4	CanoKey
 
 product ALLADIN		0x0101	JaCarta U2F
 product ALLADIN		0x0501	JaCarta U2F

--- a/udev/fidodevs
+++ b/udev/fidodevs
@@ -20,7 +20,7 @@ vendor OPENMOKO		0x1d50	OpenMoko, Inc.
 vendor NEOWAVE		0x1e0d	NEOWAVE
 vendor EXCELSECU	0x1ea8	Shenzhen Excelsecu Data Technology Co., Ltd.
 vendor NXP		0x1fc9	NXP Semiconductors
-vendor FLIRC		0x20a0	Flirc
+vendor CLAYLOGIC	0x20a0	Clay Logic
 vendor ALLADIN		0x24dc	Aladdin Software Security R.D.
 vendor PLUGUP		0x2581	Plug‐up
 vendor BLUINK		0x2abe	Bluink Ltd
@@ -86,11 +86,11 @@ product EXCELSECU	0xfc25	ExcelSecu FIDO2 Security Key
 
 product NXP		0xf143	GoTrust Idem Key
 
-product FLIRC		0x4287	Nitrokey FIDO U2F
-product FLIRC		0x42b1	Nitrokey FIDO2
-product FLIRC		0x42b2	Nitrokey 3C NFC
-product FLIRC		0x42b3	Safetech SafeKey
-product FLIRC		0x42d4	CanoKey
+product CLAYLOGIC	0x4287	Nitrokey FIDO U2F
+product CLAYLOGIC	0x42b1	Nitrokey FIDO2
+product CLAYLOGIC	0x42b2	Nitrokey 3C NFC
+product CLAYLOGIC	0x42b3	Safetech SafeKey
+product CLAYLOGIC	0x42d4	CanoKey
 
 product ALLADIN		0x0101	JaCarta U2F
 product ALLADIN		0x0501	JaCarta U2F


### PR DESCRIPTION
Hi, with this PR a udev rule for a new fido device `Canokey` is added. Please check @Canokeys for more info!

Also, the vendor is changed from `Flirc` to `Clay Logic` as `Clay Logic` is the correct holder of the vendorID.