### PR TITLE
udev: Add alternative ID for GoTrust Idem Key

### DIFF
--- a/udev/70-u2f.rules
+++ b/udev/70-u2f.rules
@@ -205,6 +205,9 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct
 # eWBM FIDO2 Goldengate G450 by eWBM Co., Ltd.
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="f47c", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
+# Idem Key by GoTrustID Inc.
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="32a3", ATTRS{idProduct}=="3201", TAG+="uaccess", GROUP="plugdev", MODE="0660"
+
 # Longmai mFIDO by Unknown vendor
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="4c4d", ATTRS{idProduct}=="f703", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 

--- a/udev/fidodevs
+++ b/udev/fidodevs
@@ -27,6 +27,7 @@ vendor BLUINK		0x2abe	Bluink Ltd
 vendor LEDGER		0x2c97	LEDGER
 vendor HYPERSECU	0x2ccf	Hypersecu Information Systems, Inc.
 vendor EWBM		0x311f	eWBM Co., Ltd.
+vendor GOTRUST		0x32a3	GoTrustID Inc.
 vendor UNKNOWN1		0x4c4d	Unknown vendor
 vendor SATOSHI		0x534c	SatoshiLabs
 
@@ -117,6 +118,8 @@ product EWBM		0x5c2f	eWBM FIDO2 Goldengate G500
 product EWBM		0xa6e9	TrustKey Solutions FIDO2 T120
 product EWBM		0xa7f9	TrustKey Solutions FIDO2 T110
 product EWBM		0xf47c	eWBM FIDO2 Goldengate G450
+
+product GOTRUST		0x3201	Idem Key
 
 product UNKNOWN1	0xf703	Longmai mFIDO
 


### PR DESCRIPTION
https://www.gotrustid.com/faqs-of-idem-key
https://download.gotrustid.com/Idem/IdemKey/70-u2f.rules

Signed-off-by: Michal Suchanek <msuchanek@suse.de>

Only based on the rules file - not tested.