### PR TITLE
fido2-token: ensure a blob path is provided in token_get()

### DIFF
--- a/tools/token.c
+++ b/tools/token.c
@@ -299,7 +299,7 @@ token_get(int argc, char **argv, char *path)
 	argc -= optind;
 	argv += optind;
 
-	if (blob == 0 || argc == 0)
+	if (blob == 0 || argc != 2)
 		usage();
 
 	return blob_get(path, key, name, id, argv[0]);


### PR DESCRIPTION
otherwise `fido2-token -Gbn rp_id /dev/hidraw2` will fetch the blob from _and_ write it to /dev/hidraw2. fido2-token.c and its argc/argv handling need a revamp after 1.7.0; PRs welcome.