### PR TITLE
fuzz: wrap a few more libcrypto symbols

### DIFF
--- a/fuzz/wrap.c
+++ b/fuzz/wrap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Yubico AB. All rights reserved.
+ * Copyright (c) 2019-2021 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -60,6 +60,23 @@ WRAP(char *,
 	1
 )
 
+WRAP(int,
+	EVP_Cipher,
+	(EVP_CIPHER_CTX *ctx, unsigned char *out, const unsigned char *in,
+	    unsigned int inl),
+	-1,
+	(ctx, out, in, inl),
+	1
+)
+
+WRAP(int,
+	EVP_CIPHER_CTX_ctrl,
+	(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr),
+	0,
+	(ctx, type, arg, ptr),
+	1
+)
+
 WRAP(EVP_CIPHER_CTX *,
 	EVP_CIPHER_CTX_new,
 	(void),
@@ -68,7 +85,8 @@ WRAP(EVP_CIPHER_CTX *,
 	1
 )
 
-WRAP(int, EVP_EncryptInit_ex,
+WRAP(int,
+	EVP_EncryptInit_ex,
 	(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, ENGINE *impl,
 	    const unsigned char *key, const unsigned char *iv),
 	0,
@@ -90,6 +108,15 @@ WRAP(int,
 	    const unsigned char *in, int inl),
 	0,
 	(ctx, out, outl, in, inl),
+	1
+)
+
+WRAP(int,
+	EVP_CipherInit,
+	(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
+	    const unsigned char *key, const unsigned char *iv, int enc),
+	0,
+	(ctx, cipher, key, iv, enc),
 	1
 )
 
@@ -333,6 +360,14 @@ WRAP(EVP_PKEY_CTX *,
 	(int id, ENGINE *e),
 	NULL,
 	(id, e),
+	1
+)
+
+WRAP(int,
+	EVP_PKEY_derive,
+	(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *pkeylen),
+	0,
+	(ctx, key, pkeylen),
 	1
 )
 

--- a/fuzz/wrapped.sym
+++ b/fuzz/wrapped.sym
@@ -24,8 +24,11 @@ EC_KEY_get0_private_key
 EC_KEY_new_by_curve_name
 EC_POINT_get_affine_coordinates_GFp
 EC_POINT_new
+EVP_Cipher
+EVP_CIPHER_CTX_ctrl
 EVP_CIPHER_CTX_new
 EVP_CIPHER_CTX_set_padding
+EVP_CipherInit
 EVP_DecryptInit_ex
 EVP_DecryptUpdate
 EVP_DigestVerifyInit
@@ -35,6 +38,7 @@ EVP_MD_CTX_new
 EVP_PKEY_assign
 EVP_PKEY_CTX_new
 EVP_PKEY_CTX_new_id
+EVP_PKEY_derive
 EVP_PKEY_derive_init
 EVP_PKEY_derive_set_peer
 EVP_PKEY_get0_EC_KEY


### PR DESCRIPTION
N.B. please double-check that the return values listed in wrap.c are correct.