### PR TITLE
credman: allow requests without a pin/uv token through

### DIFF
--- a/src/credman.c
+++ b/src/credman.c
@@ -221,8 +221,6 @@ fido_credman_get_dev_metadata(fido_dev_t *dev, fido_credman_metadata_t *metadata
 {
 	if (fido_dev_is_fido2(dev) == false)
 		return (FIDO_ERR_INVALID_COMMAND);
-	if (!fido_dev_can_get_uv_token(dev, pin, FIDO_OPT_OMIT))
-		return (FIDO_ERR_INVALID_ARGUMENT);
 
 	return (credman_get_metadata_wait(dev, metadata, pin, -1));
 }
@@ -411,8 +409,6 @@ fido_credman_get_dev_rk(fido_dev_t *dev, const char *rp_id,
 {
 	if (fido_dev_is_fido2(dev) == false)
 		return (FIDO_ERR_INVALID_COMMAND);
-	if (!fido_dev_can_get_uv_token(dev, pin, FIDO_OPT_OMIT))
-		return (FIDO_ERR_INVALID_ARGUMENT);
 
 	return (credman_get_rk_wait(dev, rp_id, rk, pin, -1));
 }
@@ -447,8 +443,6 @@ fido_credman_del_dev_rk(fido_dev_t *dev, const unsigned char *cred_id,
 {
 	if (fido_dev_is_fido2(dev) == false)
 		return (FIDO_ERR_INVALID_COMMAND);
-	if (!fido_dev_can_get_uv_token(dev, pin, FIDO_OPT_OMIT))
-		return (FIDO_ERR_INVALID_ARGUMENT);
 
 	return (credman_del_rk_wait(dev, cred_id, cred_id_len, pin, -1));
 }
@@ -617,8 +611,6 @@ fido_credman_get_dev_rp(fido_dev_t *dev, fido_credman_rp_t *rp, const char *pin)
 {
 	if (fido_dev_is_fido2(dev) == false)
 		return (FIDO_ERR_INVALID_COMMAND);
-	if (fido_dev_can_get_uv_token(dev, pin, FIDO_OPT_OMIT) == false)
-		return (FIDO_ERR_INVALID_ARGUMENT);
 
 	return (credman_get_rp_wait(dev, rp, pin, -1));
 }

--- a/src/largeblob.c
+++ b/src/largeblob.c
@@ -861,7 +861,7 @@ fido_dev_largeblob_set_array(fido_dev_t *dev, const unsigned char *cbor_ptr,
 {
 	cbor_item_t *item = NULL;
 	struct cbor_load_result cbor_result;
-	int r = FIDO_ERR_INVALID_ARGUMENT;
+	int r;
 
 	if (cbor_ptr == NULL || cbor_len == 0) {
 		fido_log_debug("%s: invalid cbor_ptr=%p, cbor_len=%zu", __func__,

--- a/src/largeblob.c
+++ b/src/largeblob.c
@@ -541,8 +541,6 @@ largeblob_get_uv_token(fido_dev_t *dev, const char *pin, fido_blob_t **token)
 	int r;
 
 	*token = NULL;
-	if (!fido_dev_can_get_uv_token(dev, pin, FIDO_OPT_OMIT))
-		return FIDO_OK;
 	if ((*token = fido_blob_new()) == NULL)
 		return FIDO_ERR_INTERNAL;
 	if ((r = fido_do_ecdh(dev, &pk, &ecdh)) != FIDO_OK) {
@@ -602,7 +600,8 @@ largeblob_set_array(fido_dev_t *dev, const cbor_item_t *item, const char *pin)
 		goto fail;
 	}
 	totalsize = cbor.len + sizeof(dgst) - 16; /* the first 16 bytes only */
-	if ((r = largeblob_get_uv_token(dev, pin, &token)) != FIDO_OK) {
+	if (fido_dev_can_get_uv_token(dev, pin, FIDO_OPT_OMIT) == true &&
+	    (r = largeblob_get_uv_token(dev, pin, &token)) != FIDO_OK) {
 		fido_log_debug("%s: largeblob_get_uv_token", __func__);
 		goto fail;
 	}


### PR DESCRIPTION
so that the authenticator has a chance to reply with `FIDO_ERR_PIN_REQUIRED`, as per spec. this is a sensible thing to do on its own, but also required for `fido2-token` to work as expected with PIN authenticaton after https://github.com/Yubico/libfido2/commit/6c1d0886e2d8451b857505744b5b83583924c38b.