### PR TITLE
assert: fix use of fido_dev_can_get_uv_token()

### DIFF
--- a/src/assert.c
+++ b/src/assert.c
@@ -132,7 +132,7 @@ fido_dev_get_assert_tx(fido_dev_t *dev, fido_assert_t *assert,
 		}
 
 	/* user verification */
-	if (fido_dev_can_get_uv_token(dev, pin, assert->uv))
+	if (pk != NULL && ecdh != NULL)
 		if ((r = cbor_add_uv_params(dev, cmd, &assert->cdh, pk, ecdh,
 		    pin, assert->rp_id, &argv[5], &argv[6])) != FIDO_OK) {
 			fido_log_debug("%s: cbor_add_uv_params", __func__);
@@ -297,7 +297,7 @@ fido_dev_get_assert(fido_dev_t *dev, fido_assert_t *assert, const char *pin)
 		return (u2f_authenticate(dev, assert, -1));
 	}
 
-	if (pin != NULL || assert->uv == FIDO_OPT_TRUE ||
+	if (fido_dev_can_get_uv_token(dev, pin, assert->uv) ||
 	    (assert->ext.mask & FIDO_EXT_HMAC_SECRET)) {
 		if ((r = fido_do_ecdh(dev, &pk, &ecdh)) != FIDO_OK) {
 			fido_log_debug("%s: fido_do_ecdh", __func__);

--- a/src/pin.c
+++ b/src/pin.c
@@ -212,11 +212,6 @@ ctap21_uv_token_tx(fido_dev_t *dev, const char *pin, const fido_blob_t *ecdh,
 	memset(argv, 0, sizeof(argv));
 
 	if (pin != NULL) {
-		if (ecdh == NULL) {
-			fido_log_debug("%s: ecdh", __func__);
-			r = FIDO_ERR_INVALID_ARGUMENT;
-			goto fail;
-		}
 		if ((p = fido_blob_new()) == NULL || fido_blob_set(p,
 		    (const unsigned char *)pin, strlen(pin)) < 0) {
 			fido_log_debug("%s: fido_blob_set", __func__);
@@ -228,12 +223,6 @@ ctap21_uv_token_tx(fido_dev_t *dev, const char *pin, const fido_blob_t *ecdh,
 			goto fail;
 		}
 		subcmd = 9;
-	}
-
-	if (pk == NULL) {
-		fido_log_debug("%s: pk", __func__);
-		r = FIDO_ERR_INVALID_ARGUMENT;
-		goto fail;
 	}
 
 	if ((argv[0] = cbor_encode_pin_opt(dev)) == NULL ||
@@ -326,11 +315,12 @@ uv_token_wait(fido_dev_t *dev, uint8_t cmd, const char *pin,
 {
 	int r;
 
+	if (ecdh == NULL || pk == NULL)
+		return (FIDO_ERR_INVALID_ARGUMENT);
 	if (fido_dev_supports_permissions(dev))
 		r = ctap21_uv_token_tx(dev, pin, ecdh, pk, cmd, rpid);
 	else
 		r = ctap20_uv_token_tx(dev, pin, ecdh, pk);
-
 	if (r != FIDO_OK)
 		return (r);
 


### PR DESCRIPTION
calling `fido_dev_can_get_uv_token()` from the module's `tx()` function is typically ok, but assertions are a special case: we obtain a ecdh shared secret in the very beginning, and hold on to it while making multiple trips to the authenticator, so that we can gather all the assertions and decrypt any hmac secrets. we should therefore move the call to `fido_dev_can_get_uv_token()` from `tx()` to the outer `fido_dev_get_assert()`, where the call to `fido_do_ecdh()` takes place.