### PR TITLE
assert: tweak 8715f33

### DIFF
--- a/src/assert.c
+++ b/src/assert.c
@@ -132,7 +132,7 @@ fido_dev_get_assert_tx(fido_dev_t *dev, fido_assert_t *assert,
 		}
 
 	/* user verification */
-	if (pk != NULL && ecdh != NULL)
+	if (fido_dev_can_get_uv_token(dev, pin, assert->uv))
 		if ((r = cbor_add_uv_params(dev, cmd, &assert->cdh, pk, ecdh,
 		    pin, assert->rp_id, &argv[5], &argv[6])) != FIDO_OK) {
 			fido_log_debug("%s: cbor_add_uv_params", __func__);


### PR DESCRIPTION
we need to call fido_dev_can_get_uv_token() prior to
cbor_add_uv_params(), or we break the hmac-secret w/o pin/uv case.
in 8715f33, i assumed that hmac-secret implied pin/uv. perhaps that
used to be the case, but it is no longer true.