### PR TITLE
restore compatibility with openssl 1.0

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -40,8 +40,11 @@ jobs:
       env:
         CC: ${{ matrix.cc }}
       run: |
-        # ubuntu 16.04 does not package libcbor
+        # ubuntu 16.04 does not package libcbor, and github actions's
+        # ubuntu 16.04 image comes with openssl 1.1.1 by default.
         if [ "$(lsb_release --short --release)" = "16.04" ]; then
+          sudo apt-get install -y --allow-downgrades \
+            openssl=1.0.2g-1ubuntu4.19 libssl-dev=1.0.2g-1ubuntu4.19
           sudo apt-add-repository ppa:yubico/stable
         fi
         sudo apt -q update

--- a/openbsd-compat/hkdf.c
+++ b/openbsd-compat/hkdf.c
@@ -1,0 +1,124 @@
+/* $OpenBSD: hkdf.c,v 1.4 2019/11/21 20:02:20 tim Exp $ */
+/* Copyright (c) 2014, Google Inc.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+ * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "openbsd-compat.h"
+#include "fido.h"
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+#include <assert.h>
+#include <string.h>
+
+#include <openssl/err.h>
+#include <openssl/hmac.h>
+
+#define CRYPTOerror(r)	CRYPTOerr(ERR_LIB_CRYPTO, (r))
+
+/* https://tools.ietf.org/html/rfc5869#section-2 */
+int
+HKDF(uint8_t *out_key, size_t out_len, const EVP_MD *digest,
+    const uint8_t *secret, size_t secret_len, const uint8_t *salt,
+    size_t salt_len, const uint8_t *info, size_t info_len)
+{
+	uint8_t prk[EVP_MAX_MD_SIZE];
+	size_t prk_len;
+
+	if (!HKDF_extract(prk, &prk_len, digest, secret, secret_len, salt,
+	    salt_len))
+		return 0;
+	if (!HKDF_expand(out_key, out_len, digest, prk, prk_len, info,
+	    info_len))
+		return 0;
+
+	return 1;
+}
+
+/* https://tools.ietf.org/html/rfc5869#section-2.2 */
+int
+HKDF_extract(uint8_t *out_key, size_t *out_len,
+    const EVP_MD *digest, const uint8_t *secret, size_t secret_len,
+    const uint8_t *salt, size_t salt_len)
+{
+	unsigned int len;
+
+	/*
+	 * If salt is not given, HashLength zeros are used. However, HMAC does
+	 * that internally already so we can ignore it.
+	 */
+	if (salt_len > INT_MAX || HMAC(digest, salt, (int)salt_len, secret,
+	    secret_len, out_key, &len) == NULL) {
+		CRYPTOerror(ERR_R_CRYPTO_LIB);
+		return 0;
+	}
+	*out_len = len;
+	return 1;
+}
+
+/* https://tools.ietf.org/html/rfc5869#section-2.3 */
+int
+HKDF_expand(uint8_t *out_key, size_t out_len,
+    const EVP_MD *digest, const uint8_t *prk, size_t prk_len,
+    const uint8_t *info, size_t info_len)
+{
+	const size_t digest_len = EVP_MD_size(digest);
+	uint8_t previous[EVP_MAX_MD_SIZE];
+	size_t n, done = 0;
+	unsigned int i;
+	int ret = 0;
+	HMAC_CTX hmac;
+
+	/* Expand key material to desired length. */
+	n = (out_len + digest_len - 1) / digest_len;
+	if (out_len + digest_len < out_len || n > 255 || prk_len > INT_MAX) {
+		CRYPTOerror(EVP_R_TOO_LARGE);
+		return 0;
+	}
+
+	HMAC_CTX_init(&hmac);
+	if (!HMAC_Init_ex(&hmac, prk, (int)prk_len, digest, NULL))
+		goto out;
+
+	for (i = 0; i < n; i++) {
+		uint8_t ctr = i + 1;
+		size_t todo;
+
+		if (i != 0 && (!HMAC_Init_ex(&hmac, NULL, 0, NULL, NULL) ||
+		    !HMAC_Update(&hmac, previous, digest_len)))
+			goto out;
+
+		if (!HMAC_Update(&hmac, info, info_len) ||
+		    !HMAC_Update(&hmac, &ctr, 1) ||
+		    !HMAC_Final(&hmac, previous, NULL))
+			goto out;
+
+		todo = digest_len;
+		if (done + todo > out_len)
+			todo = out_len - done;
+
+		memcpy(out_key + done, previous, todo);
+		done += todo;
+	}
+
+	ret = 1;
+
+ out:
+	HMAC_CTX_cleanup(&hmac);
+	explicit_bzero(previous, sizeof(previous));
+	if (ret != 1)
+		CRYPTOerror(ERR_R_CRYPTO_LIB);
+	return ret;
+}
+#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */

--- a/openbsd-compat/hkdf.h
+++ b/openbsd-compat/hkdf.h
@@ -1,0 +1,65 @@
+/* $OpenBSD: hkdf.h,v 1.2 2018/04/03 13:33:53 tb Exp $ */
+/* Copyright (c) 2014, Google Inc.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+ * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+
+#ifndef OPENSSL_HEADER_HKDF_H
+#define OPENSSL_HEADER_HKDF_H
+
+#include <openssl/evp.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*
+ * HKDF computes HKDF (as specified by RFC 5869) of initial keying
+ * material |secret| with |salt| and |info| using |digest|, and
+ * outputs |out_len| bytes to |out_key|. It returns one on success and
+ * zero on error.
+ *
+ * HKDF is an Extract-and-Expand algorithm. It does not do any key
+ * stretching, and as such, is not suited to be used alone to generate
+ * a key from a password.
+ */
+
+int HKDF(uint8_t *out_key, size_t out_len, const struct env_md_st *digest,
+    const uint8_t *secret, size_t secret_len, const uint8_t *salt,
+    size_t salt_len, const uint8_t *info, size_t info_len);
+
+/*
+ * HKDF_extract computes a HKDF PRK (as specified by RFC 5869) from
+ * initial keying material |secret| and salt |salt| using |digest|,
+ * and outputs |out_len| bytes to |out_key|. The maximum output size
+ * is |EVP_MAX_MD_SIZE|.  It returns one on success and zero on error.
+ */
+int HKDF_extract(uint8_t *out_key, size_t *out_len,
+    const struct env_md_st *digest, const uint8_t *secret,
+    size_t secret_len, const uint8_t *salt, size_t salt_len);
+
+/*
+ * HKDF_expand computes a HKDF OKM (as specified by RFC 5869) of
+ * length |out_len| from the PRK |prk| and info |info| using |digest|,
+ * and outputs the result to |out_key|. It returns one on success and
+ * zero on error.
+ */
+int HKDF_expand(uint8_t *out_key, size_t out_len,
+    const EVP_MD *digest, const uint8_t *prk, size_t prk_len,
+    const uint8_t *info,  size_t info_len);
+
+
+#if defined(__cplusplus)
+}  /* extern C */
+#endif
+
+#endif  /* OPENSSL_HEADER_HKDF_H */

--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -81,6 +81,8 @@ int timingsafe_bcmp(const void *, const void *, size_t);
 #include <openssl/opensslv.h>
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
+#include <stdint.h>
+#include "hkdf.h"
 #define EVP_PKEY_get0_EC_KEY(x) ((x)->pkey.ec)
 #define EVP_PKEY_get0_RSA(x) ((x)->pkey.rsa)
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,7 @@ list(APPEND COMPAT_SOURCES
 	../openbsd-compat/explicit_bzero.c
 	../openbsd-compat/explicit_bzero_win32.c
 	../openbsd-compat/freezero.c
+	../openbsd-compat/hkdf.c
 	../openbsd-compat/recallocarray.c
 	../openbsd-compat/strlcat.c
 	../openbsd-compat/timingsafe_bcmp.c

--- a/src/ecdh.c
+++ b/src/ecdh.c
@@ -8,14 +8,14 @@
 #include <openssl/sha.h>
 #if defined(LIBRESSL_VERSION_NUMBER)
 #include <openssl/hkdf.h>
-#else
+#elif OPENSSL_VERSION_NUMBER >= 0x10100000L
 #include <openssl/kdf.h>
 #endif
 
 #include "fido.h"
 #include "fido/es256.h"
 
-#if defined(LIBRESSL_VERSION_NUMBER)
+#if defined(LIBRESSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10100000L
 static int
 hkdf_sha256(uint8_t *key, const char *info, const fido_blob_t *secret)
 {
@@ -74,7 +74,7 @@ fail:
 
 	return ok;
 }
-#endif
+#endif /* defined(LIBRESSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10100000L */
 
 static int
 kdf(uint8_t prot, fido_blob_t *key, /* const */ fido_blob_t *secret)


### PR DESCRIPTION
OpenSSL 1.0 has been unsupported since the end of 2019 [1]. We do, however, allow libfido2 to be built with OpenSSL 1.0. This PR repairs and augments the compatibility bits needed for OpenSSL 1.0 support.

[1] https://www.openssl.org/blog/blog/2019/11/07/3.0-update/