### PR TITLE
Explicitly truncate log entries to silence gcc

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -33,14 +33,14 @@ log_on_stderr(const char *str)
 static void
 do_log(const char *suffix, const char *fmt, va_list args)
 {
-	char line[LINELEN], body[LINELEN - 3];
+	char line[LINELEN], body[LINELEN];
 
 	vsnprintf(body, sizeof(body), fmt, args);
 
 	if (suffix != NULL)
-		snprintf(line, sizeof(line), "%s: %s\n", body, suffix);
+		snprintf(line, sizeof(line), "%.180s: %.70s\n", body, suffix);
 	else
-		snprintf(line, sizeof(line), "%s\n", body);
+		snprintf(line, sizeof(line), "%.180s\n", body);
 
 	log_handler(line);
 }


### PR DESCRIPTION
log.c's do_log() contains a silent (and harmless) snprintf() truncation. This truncation triggers gcc's `-Wformat-truncation` when combined with `-O3 -D_FORTIFY_SOURCE=2` and glibc headers, as reported in #318; `-O3` is [enabled by CMake](https://github.com/Kitware/CMake/blob/a24a4e18af1d40d6bf81045c5955aa08b5e51797/Modules/Compiler/GNU.cmake#L58) on CMAKE_BUILD_TYPE=Release builds, while we [set](https://github.com/Yubico/libfido2/blob/d3ed2bfc1172074f81ce04973f33db532c4ec141/CMakeLists.txt#L268) `-D_FORTIFY_SOURCE=2` on CMAKE_BUILD_TYPE=Release builds. This PR embeds the truncation in the format string, making it explicit and suppressing the warning. I haven't checked why the warning does not happen with `-O2`.

Edit: accuracy