### PR TITLE
actions: build with CMAKE_BUILD_TYPE=Release

### DIFF
--- a/.actions/build-bsd
+++ b/.actions/build-bsd
@@ -24,10 +24,18 @@ sources:
   - ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}#$(git rev-parse HEAD)
 tasks:
   - build: |
+      if [ "\$(uname)" = "OpenBSD" ]; then
+        SUDO="doas -u root"
+      else
+        SUDO=sudo
+      fi
       cd libfido2
-      mkdir build
-      (cd build && cmake -DCMAKE_BUILD_TYPE=Debug ..)
-      make -j"\$(sysctl -n hw.ncpu)" -C build
+      for T in Debug Release; do
+        mkdir build-\$T
+        (cd build-\$T && cmake -DCMAKE_BUILD_TYPE=\$T ..)
+        make -j"\$(sysctl -n hw.ncpu)" -C build-\$T
+        \${SUDO} make -C build-\$T install
+      done
 EOF
 
 # start the build via POST to the build server

--- a/.actions/build-linux-clang
+++ b/.actions/build-linux-clang
@@ -7,7 +7,9 @@ SCAN=scan-build${CC#clang}
 (cd src && ./diff_exports.sh)
 
 # Build, analyze, and install libfido2.
-mkdir build
-(cd build && ${SCAN} --use-cc="${CC}" cmake -DCMAKE_BUILD_TYPE=Debug ..)
-${SCAN} --use-cc="${CC}" --status-bugs make -j"$(nproc)" -C build
-sudo make -C build install
+for T in Debug Release; do
+	mkdir build-$T
+	(cd build-$T && ${SCAN} --use-cc="${CC}" cmake -DCMAKE_BUILD_TYPE=$T ..)
+	${SCAN} --use-cc="${CC}" --status-bugs make -j"$(nproc)" -C build-$T
+	sudo make -C build-$T install
+done

--- a/.actions/build-linux-gcc
+++ b/.actions/build-linux-gcc
@@ -3,10 +3,12 @@
 ${CC} --version
 
 # Build and install libfido2.
-mkdir build
-(cd build && cmake -DCMAKE_BUILD_TYPE=Debug ..)
-make -j"$(nproc)" -C build
-sudo make -C build install
+for T in Debug Release; do
+	mkdir build-$T
+	(cd build-$T && cmake -DCMAKE_BUILD_TYPE=$T ..)
+	make -j"$(nproc)" -C build-$T
+	sudo make -C build-$T install
+done
 
 # Check udev/fidodevs.
 [ -x "$(which update-alternatives)" ] && {

--- a/.actions/build-osx-clang
+++ b/.actions/build-osx-clang
@@ -4,8 +4,10 @@ export PKG_CONFIG_PATH="$(brew --prefix openssl@1.1)/lib/pkgconfig"
 SCAN="$(brew --prefix llvm)/bin/scan-build"
 
 # Build, analyze, and install libfido2.
-mkdir build
-(cd build && ${SCAN} cmake -DCMAKE_BUILD_TYPE=Debug ..)
-${SCAN} --status-bugs make -j"$(sysctl -n hw.ncpu)" -C build
-make -C build man_symlink_html
-sudo make -C build install
+for T in Debug Release; do
+	mkdir build-$T
+	(cd build-$T && ${SCAN} cmake -DCMAKE_BUILD_TYPE=$T ..)
+	${SCAN} --status-bugs make -j"$(sysctl -n hw.ncpu)" -C build-$T
+	make -C build-$T man_symlink_html
+	sudo make -C build-$T install
+done


### PR DESCRIPTION
For every CI workflow (except Windows), build libfido2 twice: once with CMAKE_BUILD_TYPE=Debug and once with CMAKE_BUILD_TYPE=Release. Please note that this PR depends on #319.