### PR TITLE
Remove references to and CI support for Ubuntu 16.04 (Xenial)

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -28,25 +28,12 @@ jobs:
             cc: clang-10
           - os: ubuntu-18.04
             cc: i686-w64-mingw32-gcc-7
-          - os: ubuntu-16.04
-            cc: gcc-5
-          - os: ubuntu-16.04
-            cc: clang-8
-          - os: ubuntu-16.04
-            cc: i686-w64-mingw32-gcc-5
     steps:
     - uses: actions/checkout@v2
     - name: dependencies
       env:
         CC: ${{ matrix.cc }}
       run: |
-        # ubuntu 16.04 does not package libcbor, and github actions's
-        # ubuntu 16.04 image comes with openssl 1.1.1 by default.
-        if [ "$(lsb_release --short --release)" = "16.04" ]; then
-          sudo apt-get install -y --allow-downgrades \
-            openssl=1.0.2g-1ubuntu4.19 libssl-dev=1.0.2g-1ubuntu4.19
-          sudo apt-add-repository ppa:yubico/stable
-        fi
         sudo apt -q update
         sudo apt install -q -y libcbor-dev libudev-dev libz-dev \
           original-awk mandoc

--- a/README.adoc
+++ b/README.adoc
@@ -53,9 +53,9 @@ and binary releases.
   $ sudo apt install libfido2-doc
 
 Alternatively, newer versions of *libfido2* are available in Yubico's PPA.
-Follow the instructions for Ubuntu 18.04 (Bionic) and 16.04 (Xenial) below.
+Follow the instructions for Ubuntu 18.04 (Bionic) below.
 
-==== Ubuntu 18.04 (Bionic) and 16.04 (Xenial)
+==== Ubuntu 18.04 (Bionic)
 
   $ sudo apt install software-properties-common
   $ sudo apt-add-repository ppa:yubico/stable


### PR DESCRIPTION
Remove references to and CI support for Ubuntu 16.04 (Xenial), which reached "end of standard support" in April 2021.