### PR TITLE
cmake: remove code duplication

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,22 +81,28 @@ list(APPEND COMPAT_SOURCES
 	../openbsd-compat/timingsafe_bcmp.c
 )
 
+if(WIN32)
+	list(APPEND BASE_LIBRARIES wsock32 ws2_32 bcrypt setupapi hid)
+elseif(APPLE)
+	list(APPEND BASE_LIBRARIES "-framework CoreFoundation" "-framework IOKit")
+endif()
+
+list(APPEND TARGET_LIBRARIES
+	${CBOR_LIBRARIES}
+	${CRYPTO_LIBRARIES}
+	${UDEV_LIBRARIES}
+	${BASE_LIBRARIES}
+	${HIDAPI_LIBRARIES}
+	${ZLIB_LIBRARIES}
+)
+
 # static library
 if(BUILD_STATIC_LIBS)
 	add_library(fido2 STATIC ${FIDO_SOURCES} ${COMPAT_SOURCES})
-	target_link_libraries(fido2 ${CBOR_LIBRARIES} ${CRYPTO_LIBRARIES}
-		${UDEV_LIBRARIES} ${BASE_LIBRARIES} ${HIDAPI_LIBRARIES} ${ZLIB_LIBRARIES})
-	if(WIN32)
-		if(MINGW)
-			target_link_libraries(fido2 wsock32 ws2_32 bcrypt setupapi hid)
-		else()
-			target_link_libraries(fido2 wsock32 ws2_32 bcrypt SetupAPI hid)
-			set_target_properties(fido2 PROPERTIES OUTPUT_NAME fido2_static)
-		endif()
-	elseif(APPLE)
-		target_link_libraries(fido2 "-framework CoreFoundation"
-			"-framework IOKit")
+	if(WIN32 AND NOT MINGW)
+		set_target_properties(fido2 PROPERTIES OUTPUT_NAME fido2_static)
 	endif()
+	target_link_libraries(fido2 ${TARGET_LIBRARIES})
 	install(TARGETS fido2 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
@@ -104,22 +110,9 @@ endif()
 # dynamic library
 if(BUILD_SHARED_LIBS)
 	add_library(fido2_shared SHARED ${FIDO_SOURCES} ${COMPAT_SOURCES})
-	target_link_libraries(fido2_shared ${CBOR_LIBRARIES} ${CRYPTO_LIBRARIES}
-		${UDEV_LIBRARIES} ${BASE_LIBRARIES} ${HIDAPI_LIBRARIES} ${ZLIB_LIBRARIES})
-	if(WIN32)
-		if(MINGW)
-			target_link_libraries(fido2_shared wsock32 ws2_32 bcrypt
-				setupapi hid)
-		else()
-			target_link_libraries(fido2_shared wsock32 ws2_32 bcrypt
-				SetupAPI hid)
-		endif()
-	elseif(APPLE)
-		target_link_libraries(fido2_shared "-framework CoreFoundation"
-			"-framework IOKit")
-	endif()
 	set_target_properties(fido2_shared PROPERTIES OUTPUT_NAME fido2
 		VERSION ${FIDO_VERSION} SOVERSION ${FIDO_MAJOR})
+	target_link_libraries(fido2_shared ${TARGET_LIBRARIES})
 	install(TARGETS fido2_shared
 		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
populate TARGET_LIBRARIES once and use it in the definition of the static and shared lib targets, instead of duplicating the contents of TARGET_LIBRARIES in both places.