### PR TITLE
pkg-config: revert 4b9ff83

### DIFF
--- a/src/libfido2.pc.in
+++ b/src/libfido2.pc.in
@@ -8,6 +8,5 @@ Description: A FIDO2 library
 URL: https://github.com/yubico/libfido2
 Version: @FIDO_VERSION@
 Requires: libcrypto
-Requires.private: libcbor, zlib
 Libs: -L${libdir} -lfido2
 Cflags: -I${includedir}


### PR DESCRIPTION
While there may be a point in defining 'Requires.private', it is ultimately the territory of package maintainers and wasn't the commit's intention; 'Libs.private' was intended.

Due to CMake's architecture and the concept of a separate "generator", expanding 'Libs.private' from within CMakeLists.txt isn't trivial. While there are some acrobatics we could do, they are likely to produce innacurate results.