### PR TITLE
winhello: support credential generation with hmac secret

### DIFF
--- a/src/winhello.c
+++ b/src/winhello.c
@@ -604,7 +604,7 @@ translate_fido_cred(struct winhello_cred *ctx, fido_cred_t *cred,
 	}
 	if (pack_cred_ext(&opt->Extensions, &cred->ext) < 0) {
 		fido_log_debug("%s: pack_cred_ext", __func__);
-		return FIDO_ERR_INTERNAL;
+		return FIDO_ERR_UNSUPPORTED_EXTENSION;
 	}
 	if (set_uv(&opt->dwUserVerificationRequirement, cred->uv, pin) < 0) {
 		fido_log_debug("%s: set_uv", __func__);


### PR DESCRIPTION
Please note that Microsoft's `webauthn.h` allows a credential to be created with the `hmac-secret` extension enabled, but does not allow subsequent assertions to obtain the secret.