### PR TITLE
introduce fido_cred_set_id()

### DIFF
--- a/fuzz/export.gnu
+++ b/fuzz/export.gnu
@@ -147,6 +147,7 @@
 		fido_cred_set_clientdata_hash;
 		fido_cred_set_extensions;
 		fido_cred_set_fmt;
+		fido_cred_set_id;
 		fido_cred_set_options;
 		fido_cred_set_prot;
 		fido_cred_set_rk;

--- a/fuzz/fuzz_cred.c
+++ b/fuzz/fuzz_cred.c
@@ -391,6 +391,20 @@ test_touch(const struct param *p)
 	fido_dev_free(&dev);
 }
 
+static void
+test_misc(const struct param *p)
+{
+	fido_cred_t *cred = NULL;
+
+	if ((cred = fido_cred_new()) == NULL)
+		return;
+
+	/* reuse user id as credential id */
+	fido_cred_set_id(cred, p->user_id.body, p->user_id.len);
+	consume(fido_cred_id_ptr(cred), fido_cred_id_len(cred));
+	fido_cred_free(&cred);
+}
+
 void
 test(const struct param *p)
 {
@@ -400,6 +414,7 @@ test(const struct param *p)
 
 	test_cred(p);
 	test_touch(p);
+	test_misc(p);
 }
 
 void

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -183,6 +183,7 @@ list(APPEND MAN_ALIAS
 	fido_cred_set_authdata fido_cred_set_clientdata_hash
 	fido_cred_set_authdata fido_cred_set_extensions
 	fido_cred_set_authdata fido_cred_set_fmt
+	fido_cred_set_authdata fido_cred_set_id
 	fido_cred_set_authdata fido_cred_set_prot
 	fido_cred_set_authdata fido_cred_set_rk
 	fido_cred_set_authdata fido_cred_set_rp

--- a/man/fido_cred_set_authdata.3
+++ b/man/fido_cred_set_authdata.3
@@ -10,6 +10,7 @@
 .Nm fido_cred_set_authdata_raw ,
 .Nm fido_cred_set_x509 ,
 .Nm fido_cred_set_sig ,
+.Nm fido_cred_set_id ,
 .Nm fido_cred_set_clientdata ,
 .Nm fido_cred_set_clientdata_hash ,
 .Nm fido_cred_set_rp ,
@@ -39,6 +40,8 @@ typedef enum {
 .Fn fido_cred_set_x509 "fido_cred_t *cred" "const unsigned char *ptr" "size_t len"
 .Ft int
 .Fn fido_cred_set_sig "fido_cred_t *cred" "const unsigned char *ptr" "size_t len"
+.Ft int
+.Fn fido_cred_set_id "fido_cred_t *cred" "const unsigned char *ptr" "size_t len"
 .Ft int
 .Fn fido_cred_set_clientdata "fido_cred_t *cred" "const unsigned char *ptr" "size_t len"
 .Ft int
@@ -79,10 +82,11 @@ The
 .Fn fido_cred_set_authdata ,
 .Fn fido_cred_set_x509 ,
 .Fn fido_cred_set_sig ,
+.Fn fido_cred_set_id ,
 and
 .Fn fido_cred_set_clientdata_hash
 functions set the authenticator data, attestation certificate,
-signature and client data hash parts of
+signature, id, and client data hash parts of
 .Fa cred
 to
 .Fa ptr ,
@@ -100,6 +104,13 @@ must be a CBOR-encoded byte string, as obtained from
 .Fn fido_cred_authdata_ptr .
 Alternatively, a raw binary blob may be passed to
 .Fn fido_cred_set_authdata_raw .
+.Pp
+An application calling
+.Fn fido_cred_set_authdata
+does not need to call
+.Fn fido_cred_set_id .
+The latter is meant to be used in contexts where the
+credential's authenticator data is not available.
 .Pp
 The
 .Fn fido_cred_set_clientdata

--- a/src/cred.c
+++ b/src/cred.c
@@ -617,6 +617,15 @@ fail:
 }
 
 int
+fido_cred_set_id(fido_cred_t *cred, const unsigned char *ptr, size_t len)
+{
+	if (fido_blob_set(&cred->attcred.id, ptr, len) < 0)
+		return (FIDO_ERR_INVALID_ARGUMENT);
+
+	return (FIDO_OK);
+}
+
+int
 fido_cred_set_x509(fido_cred_t *cred, const unsigned char *ptr, size_t len)
 {
 	unsigned char *x509;

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -149,6 +149,7 @@
 		fido_cred_set_clientdata_hash;
 		fido_cred_set_extensions;
 		fido_cred_set_fmt;
+		fido_cred_set_id;
 		fido_cred_set_options;
 		fido_cred_set_prot;
 		fido_cred_set_rk;

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -147,6 +147,7 @@ _fido_cred_set_clientdata
 _fido_cred_set_clientdata_hash
 _fido_cred_set_extensions
 _fido_cred_set_fmt
+_fido_cred_set_id
 _fido_cred_set_options
 _fido_cred_set_prot
 _fido_cred_set_rk

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -148,6 +148,7 @@ fido_cred_set_clientdata
 fido_cred_set_clientdata_hash
 fido_cred_set_extensions
 fido_cred_set_fmt
+fido_cred_set_id
 fido_cred_set_options
 fido_cred_set_prot
 fido_cred_set_rk

--- a/src/fido.h
+++ b/src/fido.h
@@ -126,6 +126,7 @@ int fido_cred_set_clientdata(fido_cred_t *, const unsigned char *, size_t);
 int fido_cred_set_clientdata_hash(fido_cred_t *, const unsigned char *, size_t);
 int fido_cred_set_extensions(fido_cred_t *, int);
 int fido_cred_set_fmt(fido_cred_t *, const char *);
+int fido_cred_set_id(fido_cred_t *, const unsigned char *, size_t);
 int fido_cred_set_options(fido_cred_t *, bool, bool);
 int fido_cred_set_prot(fido_cred_t *, int);
 int fido_cred_set_rk(fido_cred_t *, fido_opt_t);


### PR DESCRIPTION
`fido_cred_set_id()` allows a credential's id to be set in contexts where authdata is unavailable but operations on a fido_cred_t are still desired (e.g. credential management).