### PR TITLE
retire fido_dev_can_get_uv_token()

### DIFF
--- a/src/assert.c
+++ b/src/assert.c
@@ -82,6 +82,7 @@ fido_dev_get_assert_tx(fido_dev_t *dev, fido_assert_t *assert,
     const es256_pk_t *pk, const fido_blob_t *ecdh, const char *pin)
 {
 	fido_blob_t	 f;
+	fido_opt_t	 uv = assert->uv;
 	cbor_item_t	*argv[7];
 	const uint8_t	 cmd = CTAP_CBOR_ASSERT;
 	int		 r;
@@ -122,20 +123,22 @@ fido_dev_get_assert_tx(fido_dev_t *dev, fido_assert_t *assert,
 			goto fail;
 		}
 
-	/* options */
-	if (assert->up != FIDO_OPT_OMIT || assert->uv != FIDO_OPT_OMIT)
-		if ((argv[4] = cbor_encode_assert_opt(assert->up,
-		    assert->uv)) == NULL) {
-			fido_log_debug("%s: cbor_encode_assert_opt", __func__);
-			r = FIDO_ERR_INTERNAL;
-			goto fail;
-		}
-
 	/* user verification */
-	if (fido_dev_can_get_uv_token(dev, pin, assert->uv))
+	if (pin != NULL || (uv == FIDO_OPT_TRUE &&
+	    fido_dev_supports_permissions(dev))) {
 		if ((r = cbor_add_uv_params(dev, cmd, &assert->cdh, pk, ecdh,
 		    pin, assert->rp_id, &argv[5], &argv[6])) != FIDO_OK) {
 			fido_log_debug("%s: cbor_add_uv_params", __func__);
+			goto fail;
+		}
+		uv = FIDO_OPT_OMIT;
+	}
+
+	/* options */
+	if (assert->up != FIDO_OPT_OMIT || uv != FIDO_OPT_OMIT)
+		if ((argv[4] = cbor_encode_assert_opt(assert->up, uv)) == NULL) {
+			fido_log_debug("%s: cbor_encode_assert_opt", __func__);
+			r = FIDO_ERR_INTERNAL;
 			goto fail;
 		}
 
@@ -302,7 +305,8 @@ fido_dev_get_assert(fido_dev_t *dev, fido_assert_t *assert, const char *pin)
 		return (u2f_authenticate(dev, assert, -1));
 	}
 
-	if (fido_dev_can_get_uv_token(dev, pin, assert->uv) ||
+	if (pin != NULL || (assert->uv == FIDO_OPT_TRUE &&
+	    fido_dev_supports_permissions(dev)) ||
 	    (assert->ext.mask & FIDO_EXT_HMAC_SECRET)) {
 		if ((r = fido_do_ecdh(dev, &pk, &ecdh)) != FIDO_OK) {
 			fido_log_debug("%s: fido_do_ecdh", __func__);

--- a/src/config.c
+++ b/src/config.c
@@ -58,7 +58,7 @@ config_tx(fido_dev_t *dev, uint8_t subcmd, cbor_item_t **paramv, size_t paramc,
 	}
 
 	/* pinProtocol, pinAuth */
-	if (fido_dev_can_get_uv_token(dev, pin, FIDO_OPT_OMIT)) {
+	if (pin != NULL || fido_dev_supports_permissions(dev)) {
 		if ((argv[1] = cbor_flatten_vector(paramv, paramc)) == NULL) {
 			fido_log_debug("%s: cbor_flatten_vector", __func__);
 			goto fail;

--- a/src/cred.c
+++ b/src/cred.c
@@ -47,6 +47,7 @@ fido_dev_make_cred_tx(fido_dev_t *dev, fido_cred_t *cred, const char *pin)
 {
 	fido_blob_t	 f;
 	fido_blob_t	*ecdh = NULL;
+	fido_opt_t	 uv = cred->uv;
 	es256_pk_t	*pk = NULL;
 	cbor_item_t	*argv[9];
 	const uint8_t	 cmd = CTAP_CBOR_MAKECRED;
@@ -88,17 +89,9 @@ fido_dev_make_cred_tx(fido_dev_t *dev, fido_cred_t *cred, const char *pin)
 			goto fail;
 		}
 
-	/* options */
-	if (cred->rk != FIDO_OPT_OMIT || cred->uv != FIDO_OPT_OMIT)
-		if ((argv[6] = cbor_encode_cred_opt(cred->rk,
-		    cred->uv)) == NULL) {
-			fido_log_debug("%s: cbor_encode_cred_opt", __func__);
-			r = FIDO_ERR_INTERNAL;
-			goto fail;
-		}
-
 	/* user verification */
-	if (fido_dev_can_get_uv_token(dev, pin, cred->uv)) {
+	if (pin != NULL || (uv == FIDO_OPT_TRUE &&
+	    fido_dev_supports_permissions(dev))) {
 		if ((r = fido_do_ecdh(dev, &pk, &ecdh)) != FIDO_OK) {
 			fido_log_debug("%s: fido_do_ecdh", __func__);
 			goto fail;
@@ -108,7 +101,16 @@ fido_dev_make_cred_tx(fido_dev_t *dev, fido_cred_t *cred, const char *pin)
 			fido_log_debug("%s: cbor_add_uv_params", __func__);
 			goto fail;
 		}
+		uv = FIDO_OPT_OMIT;
 	}
+
+	/* options */
+	if (cred->rk != FIDO_OPT_OMIT || uv != FIDO_OPT_OMIT)
+		if ((argv[6] = cbor_encode_cred_opt(cred->rk, uv)) == NULL) {
+			fido_log_debug("%s: cbor_encode_cred_opt", __func__);
+			r = FIDO_ERR_INTERNAL;
+			goto fail;
+		}
 
 	/* framing and transmission */
 	if (cbor_build_frame(cmd, argv, nitems(argv), &f) < 0 ||

--- a/src/credman.c
+++ b/src/credman.c
@@ -119,7 +119,7 @@ credman_tx(fido_dev_t *dev, uint8_t subcmd, const fido_blob_t *param,
 	}
 
 	/* pinProtocol, pinAuth */
-	if (fido_dev_can_get_uv_token(dev, pin, uv)) {
+	if (pin != NULL || uv == FIDO_OPT_TRUE) {
 		if (credman_prepare_hmac(subcmd, param, &argv[1], &hmac) < 0) {
 			fido_log_debug("%s: credman_prepare_hmac", __func__);
 			goto fail;
@@ -208,7 +208,7 @@ credman_get_metadata_wait(fido_dev_t *dev, fido_credman_metadata_t *metadata,
 	int r;
 
 	if ((r = credman_tx(dev, CMD_CRED_METADATA, NULL, pin, NULL,
-	    FIDO_OPT_OMIT)) != FIDO_OK ||
+	    FIDO_OPT_TRUE)) != FIDO_OK ||
 	    (r = credman_rx_metadata(dev, metadata, ms)) != FIDO_OK)
 		return (r);
 
@@ -388,7 +388,7 @@ credman_get_rk_wait(fido_dev_t *dev, const char *rp_id, fido_credman_rk_t *rk,
 	rp_dgst.len = sizeof(dgst);
 
 	if ((r = credman_tx(dev, CMD_RK_BEGIN, &rp_dgst, pin, rp_id,
-	    FIDO_OPT_OMIT)) != FIDO_OK ||
+	    FIDO_OPT_TRUE)) != FIDO_OK ||
 	    (r = credman_rx_rk(dev, rk, ms)) != FIDO_OK)
 		return (r);
 
@@ -426,7 +426,7 @@ credman_del_rk_wait(fido_dev_t *dev, const unsigned char *cred_id,
 		return (FIDO_ERR_INVALID_ARGUMENT);
 
 	if ((r = credman_tx(dev, CMD_DELETE_CRED, &cred, pin, NULL,
-	    FIDO_OPT_OMIT)) != FIDO_OK ||
+	    FIDO_OPT_TRUE)) != FIDO_OK ||
 	    (r = fido_rx_cbor_status(dev, ms)) != FIDO_OK)
 		goto fail;
 
@@ -589,7 +589,7 @@ credman_get_rp_wait(fido_dev_t *dev, fido_credman_rp_t *rp, const char *pin,
 	int r;
 
 	if ((r = credman_tx(dev, CMD_RP_BEGIN, NULL, pin, NULL,
-	    FIDO_OPT_OMIT)) != FIDO_OK ||
+	    FIDO_OPT_TRUE)) != FIDO_OK ||
 	    (r = credman_rx_rp(dev, rp, ms)) != FIDO_OK)
 		return (r);
 

--- a/src/extern.h
+++ b/src/extern.h
@@ -177,7 +177,6 @@ int fido_dev_get_uv_token(fido_dev_t *, uint8_t, const char *,
 uint64_t fido_dev_maxmsgsize(const fido_dev_t *);
 int fido_do_ecdh(fido_dev_t *, es256_pk_t **, fido_blob_t **);
 bool fido_dev_supports_permissions(const fido_dev_t *);
-bool fido_dev_can_get_uv_token(const fido_dev_t *, const char *, fido_opt_t);
 
 /* misc */
 void fido_assert_reset_rx(fido_assert_t *);

--- a/src/largeblob.c
+++ b/src/largeblob.c
@@ -600,10 +600,11 @@ largeblob_set_array(fido_dev_t *dev, const cbor_item_t *item, const char *pin)
 		goto fail;
 	}
 	totalsize = cbor.len + sizeof(dgst) - 16; /* the first 16 bytes only */
-	if (fido_dev_can_get_uv_token(dev, pin, FIDO_OPT_OMIT) == true &&
-	    (r = largeblob_get_uv_token(dev, pin, &token)) != FIDO_OK) {
-		fido_log_debug("%s: largeblob_get_uv_token", __func__);
-		goto fail;
+	if (pin != NULL || fido_dev_supports_permissions(dev)) {
+		if ((r = largeblob_get_uv_token(dev, pin, &token)) != FIDO_OK) {
+			fido_log_debug("%s: largeblob_get_uv_token", __func__);
+			goto fail;
+		}
 	}
 	for (size_t offset = 0; offset < cbor.len; offset += chunklen) {
 		if ((chunklen = cbor.len - offset) > maxchunklen)

--- a/src/pin.c
+++ b/src/pin.c
@@ -688,17 +688,3 @@ fail:
 
 	return (r);
 }
-
-bool
-fido_dev_can_get_uv_token(const fido_dev_t *dev, const char *pin, fido_opt_t uv)
-{
-	if (pin != NULL)
-		return (true);
-	if (fido_dev_supports_permissions(dev)) {
-		if (uv != FIDO_OPT_OMIT)
-			return (uv == FIDO_OPT_TRUE);
-		return (fido_dev_has_uv(dev));
-	}
-
-	return (false);
-}

--- a/src/pin.c
+++ b/src/pin.c
@@ -157,7 +157,13 @@ ctap20_uv_token_tx(fido_dev_t *dev, const char *pin, const fido_blob_t *ecdh,
 	memset(&f, 0, sizeof(f));
 	memset(argv, 0, sizeof(argv));
 
-	if (pin == NULL || (p = fido_blob_new()) == NULL || fido_blob_set(p,
+	if (pin == NULL) {
+		fido_log_debug("%s: NULL pin", __func__);
+		r = FIDO_ERR_PIN_REQUIRED;
+		goto fail;
+	}
+
+	if ((p = fido_blob_new()) == NULL || fido_blob_set(p,
 	    (const unsigned char *)pin, strlen(pin)) < 0) {
 		fido_log_debug("%s: fido_blob_set", __func__);
 		r = FIDO_ERR_INVALID_ARGUMENT;

--- a/src/pin.c
+++ b/src/pin.c
@@ -209,7 +209,7 @@ ctap21_uv_token_tx(fido_dev_t *dev, const char *pin, const fido_blob_t *ecdh,
 	fido_blob_t	*p = NULL;
 	fido_blob_t	*phe = NULL;
 	cbor_item_t	*argv[10];
-	uint8_t		 subcmd = 6;
+	uint8_t		 subcmd;
 	int		 r;
 
 	memset(&f, 0, sizeof(f));
@@ -226,7 +226,14 @@ ctap21_uv_token_tx(fido_dev_t *dev, const char *pin, const fido_blob_t *ecdh,
 			fido_log_debug("%s: pin_sha256_enc", __func__);
 			goto fail;
 		}
-		subcmd = 9;
+		subcmd = 9; /* getPinUvAuthTokenUsingPinWithPermissions */
+	} else {
+		if (fido_dev_has_uv(dev) == false) {
+			fido_log_debug("%s: fido_dev_has_uv", __func__);
+			r = FIDO_ERR_PIN_REQUIRED;
+			goto fail;
+		}
+		subcmd = 6; /* getPinUvAuthTokenUsingUvWithPermissions */
 	}
 
 	if ((argv[0] = cbor_encode_pin_opt(dev)) == NULL ||


### PR DESCRIPTION
`fido_dev_can_get_uv_token()` centralised the logic determining whether to retrieve a uv token from the authenticator. As it happens, CTAP 2.1 is nuanced enough that holding such logic in a single place becomes impractical. This PR replaces `fido_dev_can_get_uv_token()` with ad-hoc language. Discussed with and feedback from @LDVG.