### PR TITLE
credman: introduce fido_credman_set_dev_rk()

### DIFF
--- a/fuzz/export.gnu
+++ b/fuzz/export.gnu
@@ -135,6 +135,7 @@
 		fido_credman_rp_id_hash_ptr;
 		fido_credman_rp_name;
 		fido_credman_rp_new;
+		fido_credman_set_dev_rk;
 		fido_cred_new;
 		fido_cred_prot;
 		fido_cred_pubkey_len;

--- a/fuzz/fuzz_credman.c
+++ b/fuzz/fuzz_credman.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Yubico AB. All rights reserved.
+ * Copyright (c) 2019-2021 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -345,6 +345,35 @@ del_rk(const struct param *p)
 	fido_dev_free(&dev);
 }
 
+static void
+set_rk(const struct param *p)
+{
+	fido_dev_t *dev = NULL;
+	fido_cred_t *cred = NULL;
+	const char *pin = p->pin;
+	int r0, r1, r2;
+
+	set_wire_data(p->del_wire_data.body, p->del_wire_data.len);
+
+	if ((dev = prepare_dev()) == NULL)
+		return;
+	if ((cred = fido_cred_new()) == NULL)
+		goto out;
+	r0 = fido_cred_set_id(cred, p->cred_id.body, p->cred_id.len);
+	r1 = fido_cred_set_user(cred, p->cred_id.body, p->cred_id.len, p->rp_id,
+	    NULL, NULL);
+	if (strlen(pin) == 0)
+		pin = NULL;
+	r2 = fido_credman_set_dev_rk(dev, cred, pin);
+	consume(&r0, sizeof(r0));
+	consume(&r1, sizeof(r1));
+	consume(&r2, sizeof(r2));
+out:
+	fido_dev_close(dev);
+	fido_dev_free(&dev);
+	fido_cred_free(&cred);
+}
+
 void
 test(const struct param *p)
 {
@@ -356,6 +385,7 @@ test(const struct param *p)
 	get_rp_list(p);
 	get_rk_list(p);
 	del_rk(p);
+	set_rk(p);
 }
 
 void

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -177,6 +177,7 @@ list(APPEND MAN_ALIAS
 	fido_credman_metadata_new fido_credman_rp_id_hash_ptr
 	fido_credman_metadata_new fido_credman_rp_name
 	fido_credman_metadata_new fido_credman_rp_new
+	fido_credman_metadata_new fido_credman_set_dev_rk
 	fido_cred_set_authdata fido_cred_set_authdata_raw
 	fido_cred_set_authdata fido_cred_set_blob
 	fido_cred_set_authdata fido_cred_set_clientdata

--- a/man/fido2-token.1
+++ b/man/fido2-token.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2018 Yubico AB. All rights reserved.
+.\" Copyright (c) 2018-2021 Yubico AB. All rights reserved.
 .\" Use of this source code is governed by a BSD-style
 .\" license that can be found in the LICENSE file.
 .\"
@@ -101,6 +101,15 @@
 .Fl n Ar rp_id
 .Op Fl i Ar cred_id
 .Ar blob_path
+.Ar device
+.Nm
+.Fl S
+.Fl c
+.Op Fl d
+.Fl i Ar cred_id
+.Fl k Ar user_id
+.Fl n Ar name
+.Fl p Ar display_name
 .Ar device
 .Nm
 .Fl V
@@ -284,6 +293,25 @@ the credential ID must be specified using
 where
 .Ar cred_id
 is a base64-encoded blob.
+A PIN or equivalent user-verification gesture is required.
+.It Fl S Fl c Fl i Ar cred_id Fl k Ar user_id Fl n Ar name Fl p Ar display_name Ar device
+Sets the
+.Ar name
+and
+.Ar display_name
+attributes of the resident credential identified by
+.Ar cred_id
+and
+.Ar user_id ,
+where
+.Ar name
+and
+.Ar display_name
+are UTF-8 strings and
+.Ar cred_id
+and
+.Ar user_id
+are base64-encoded blobs.
 A PIN or equivalent user-verification gesture is required.
 .It Fl S Fl e Ar device
 Performs a new biometric enrollment on

--- a/man/fido_credman_metadata_new.3
+++ b/man/fido_credman_metadata_new.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2019 Yubico AB. All rights reserved.
+.\" Copyright (c) 2019-2021 Yubico AB. All rights reserved.
 .\" Use of this source code is governed by a BSD-style
 .\" license that can be found in the LICENSE file.
 .\"
@@ -23,6 +23,7 @@
 .Nm fido_credman_rp_id_hash_len ,
 .Nm fido_credman_get_dev_metadata ,
 .Nm fido_credman_get_dev_rk ,
+.Nm fido_credman_set_dev_rk ,
 .Nm fido_credman_del_dev_rk ,
 .Nm fido_credman_get_dev_rp
 .Nd FIDO 2 credential management API
@@ -64,14 +65,16 @@
 .Ft int
 .Fn fido_credman_get_dev_rk "fido_dev_t *dev" "const char *rp_id" "fido_credman_rk_t *rk" "const char *pin"
 .Ft int
-.Fn fido_credman_del_dev_rk "fido_dev_t *dev" const unsigned char *cred_id" "size_t cred_id_len" "const char *pin"
+.Fn fido_credman_set_dev_rk "fido_dev_t *dev" "fido_cred_t *cred" "const char *pin"
+.Ft int
+.Fn fido_credman_del_dev_rk "fido_dev_t *dev" "const unsigned char *cred_id" "size_t cred_id_len" "const char *pin"
 .Ft int
 .Fn fido_credman_get_dev_rp "fido_dev_t *dev" "fido_credman_rp_t *rp" "const char *pin"
 .Sh DESCRIPTION
 The credential management API of
 .Em libfido2
 allows resident credentials on a FIDO2 authenticator to be listed,
-inspected, and removed.
+inspected, modified, and removed.
 Please note that not all FIDO2 authenticators support credential
 management.
 To obtain information on what an authenticator supports, please
@@ -191,6 +194,23 @@ has an
 (index) value of 0.
 .Pp
 The
+.Fn fido_credman_set_dev_rk
+function updates the credential pointed to by
+.Fa cred
+in
+.Fa dev .
+The credential id and user id attributes of
+.Fa cred
+must be set.
+See
+.Xr fido_cred_set_id 3
+and
+.Xr fido_cred_set_user 3
+for details.
+Only a credential's user attributes (name, display name)
+may be updated at this time.
+.Pp
+The
 .Fn fido_credman_del_dev_rk
 function deletes the resident credential identified by
 .Fa cred_id
@@ -284,6 +304,7 @@ has an
 The
 .Fn fido_credman_get_dev_metadata ,
 .Fn fido_credman_get_dev_rk ,
+.Fn fido_credman_set_dev_rk ,
 .Fn fido_credman_del_dev_rk ,
 and
 .Fn  fido_credman_get_dev_rp

--- a/src/credman.c
+++ b/src/credman.c
@@ -112,6 +112,12 @@ credman_tx(fido_dev_t *dev, uint8_t subcmd, const fido_blob_t *param,
 	memset(&hmac, 0, sizeof(hmac));
 	memset(&argv, 0, sizeof(argv));
 
+	if (fido_dev_is_fido2(dev) == false) {
+		fido_log_debug("%s: fido_dev_is_fido2", __func__);
+		r = FIDO_ERR_INVALID_COMMAND;
+		goto fail;
+	}
+
 	/* subCommand */
 	if ((argv[0] = cbor_build_uint8(subcmd)) == NULL) {
 		fido_log_debug("%s: cbor encode", __func__);
@@ -219,9 +225,6 @@ int
 fido_credman_get_dev_metadata(fido_dev_t *dev, fido_credman_metadata_t *metadata,
     const char *pin)
 {
-	if (fido_dev_is_fido2(dev) == false)
-		return (FIDO_ERR_INVALID_COMMAND);
-
 	return (credman_get_metadata_wait(dev, metadata, pin, -1));
 }
 
@@ -407,9 +410,6 @@ int
 fido_credman_get_dev_rk(fido_dev_t *dev, const char *rp_id,
     fido_credman_rk_t *rk, const char *pin)
 {
-	if (fido_dev_is_fido2(dev) == false)
-		return (FIDO_ERR_INVALID_COMMAND);
-
 	return (credman_get_rk_wait(dev, rp_id, rk, pin, -1));
 }
 
@@ -441,9 +441,6 @@ int
 fido_credman_del_dev_rk(fido_dev_t *dev, const unsigned char *cred_id,
     size_t cred_id_len, const char *pin)
 {
-	if (fido_dev_is_fido2(dev) == false)
-		return (FIDO_ERR_INVALID_COMMAND);
-
 	return (credman_del_rk_wait(dev, cred_id, cred_id_len, pin, -1));
 }
 
@@ -607,9 +604,6 @@ credman_get_rp_wait(fido_dev_t *dev, fido_credman_rp_t *rp, const char *pin,
 int
 fido_credman_get_dev_rp(fido_dev_t *dev, fido_credman_rp_t *rp, const char *pin)
 {
-	if (fido_dev_is_fido2(dev) == false)
-		return (FIDO_ERR_INVALID_COMMAND);
-
 	return (credman_get_rp_wait(dev, rp, pin, -1));
 }
 

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -136,6 +136,7 @@
 		fido_credman_rp_id_hash_ptr;
 		fido_credman_rp_name;
 		fido_credman_rp_new;
+		fido_credman_set_dev_rk;
 		fido_cred_new;
 		fido_cred_prot;
 		fido_cred_pubkey_len;

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -134,6 +134,7 @@ _fido_credman_rp_id_hash_len
 _fido_credman_rp_id_hash_ptr
 _fido_credman_rp_name
 _fido_credman_rp_new
+_fido_credman_set_dev_rk
 _fido_cred_new
 _fido_cred_prot
 _fido_cred_pubkey_len

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -135,6 +135,7 @@ fido_credman_rp_id_hash_len
 fido_credman_rp_id_hash_ptr
 fido_credman_rp_name
 fido_credman_rp_new
+fido_credman_set_dev_rk
 fido_cred_new
 fido_cred_prot
 fido_cred_pubkey_len

--- a/src/fido/credman.h
+++ b/src/fido/credman.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Yubico AB. All rights reserved.
+ * Copyright (c) 2019-2021 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -71,6 +71,7 @@ int fido_credman_get_dev_metadata(fido_dev_t *, fido_credman_metadata_t *,
 int fido_credman_get_dev_rk(fido_dev_t *, const char *, fido_credman_rk_t *,
     const char *);
 int fido_credman_get_dev_rp(fido_dev_t *, fido_credman_rp_t *, const char *);
+int fido_credman_set_dev_rk(fido_dev_t *, fido_cred_t *, const char *);
 
 size_t fido_credman_rk_count(const fido_credman_rk_t *);
 size_t fido_credman_rp_count(const fido_credman_rp_t *);

--- a/tools/extern.h
+++ b/tools/extern.h
@@ -20,7 +20,7 @@ struct blob {
 	size_t len;
 };
 
-#define TOKEN_OPT	"CDGILPRSVabcdefi:k:l:n:ru"
+#define TOKEN_OPT	"CDGILPRSVabcdefi:k:l:n:p:ru"
 
 #define FLAG_DEBUG	0x01
 #define FLAG_QUIET	0x02
@@ -66,6 +66,8 @@ int cose_type(const char *, int *);
 int cred_make(int, char **);
 int cred_verify(int, char **);
 int credman_delete_rk(const char *, const char *);
+int credman_update_rk(const char *, const char *, const char *, const char *,
+    const char *);
 int credman_get_metadata(fido_dev_t *, const char *);
 int credman_list_rk(const char *, const char *);
 int credman_list_rp(const char *);

--- a/tools/fido2-token.c
+++ b/tools/fido2-token.c
@@ -27,6 +27,7 @@ usage(void)
 "       fido2-token -R [-d] device\n"
 "       fido2-token -S [-adefu] [-l pin_length] [-i template_id -n template_name] device\n"
 "       fido2-token -Sb [-k key_path] [-i cred_id -n rp_id] blob_path device\n"
+"       fido2-token -Sc -i cred_id -k user_id -n name -p display_name device\n"
 "       fido2-token -V\n"
 	);
 
@@ -59,6 +60,7 @@ main(int argc, char **argv)
 		case 'k':
 		case 'l':
 		case 'n':
+		case 'p':
 		case 'r':
 		case 'u':
 			break; /* ignore */

--- a/tools/token.c
+++ b/tools/token.c
@@ -350,8 +350,10 @@ token_set(int argc, char **argv, char *path)
 	char	*id = NULL;
 	char	*key = NULL;
 	char	*len = NULL;
+	char	*display_name = NULL;
 	char	*name = NULL;
 	int	 blob = 0;
+	int	 cred = 0;
 	int	 ch;
 	int	 enroll = 0;
 	int	 ea = 0;
@@ -368,6 +370,9 @@ token_set(int argc, char **argv, char *path)
 		case 'b':
 			blob = 1;
 			break;
+		case 'c':
+			cred = 1;
+			break;
 		case 'e':
 			enroll = 1;
 			break;
@@ -382,6 +387,9 @@ token_set(int argc, char **argv, char *path)
 			break;
 		case 'l':
 			len = optarg;
+			break;
+		case 'p':
+			display_name = optarg;
 			break;
 		case 'n':
 			name = optarg;
@@ -404,6 +412,14 @@ token_set(int argc, char **argv, char *path)
 		if (argc != 2)
 			usage();
 		return (blob_set(path, key, name, id, argv[0]));
+	}
+
+	if (cred) {
+		if (!id || !key)
+			usage();
+		if (!name && !display_name)
+			usage();
+		return (credman_update_rk(path, key, id, name, display_name));
 	}
 
 	if (enroll) {


### PR DESCRIPTION
A counterpart of `fido_credman_set_dev_rk()` to update/set certain parts of a resident credential (only name/displayName for now).