### PR TITLE
winhello: minor tweaks

### DIFF
--- a/src/winhello.c
+++ b/src/winhello.c
@@ -218,7 +218,7 @@ pack_rp(wchar_t **id, wchar_t **name, WEBAUTHN_RP_ENTITY_INFORMATION *out,
 		fido_log_debug("%s: id", __func__);
 		return -1;
 	}
-	if ((out->pwszName = *name = to_utf16(in->name)) == NULL) {
+	if (in->name && (out->pwszName = *name = to_utf16(in->name)) == NULL) {
 		fido_log_debug("%s: name", __func__);
 		return -1;
 	}

--- a/src/winhello.c
+++ b/src/winhello.c
@@ -504,7 +504,7 @@ translate_fido_assert(struct winhello_assert *ctx, fido_assert_t *assert,
 	WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS *opt;
 
 	/* not supported by webauthn.h */
-	if (assert->up != FIDO_OPT_OMIT) {
+	if (assert->up == FIDO_OPT_FALSE) {
 		fido_log_debug("%s: up %d", __func__, assert->up);
 		return FIDO_ERR_UNSUPPORTED_OPTION;
 	}


### PR DESCRIPTION
- allow NULL as an rp name (since it's optional);
- allow up=omit and up=true (which are winhello's default).