### PR TITLE
io: discard frames with wrong channel identifier

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -164,8 +164,8 @@ rx_preamble(fido_dev_t *d, uint8_t cmd, struct frame *fp, int ms)
 #ifdef FIDO_FUZZ
 		fp->cid = d->cid;
 #endif
-	} while (fp->cid == d->cid &&
-	    fp->body.init.cmd == (CTAP_FRAME_INIT | CTAP_KEEPALIVE));
+	} while (fp->cid != d->cid || (fp->cid == d->cid &&
+	    fp->body.init.cmd == (CTAP_FRAME_INIT | CTAP_KEEPALIVE)));
 
 	if (d->rx_len > sizeof(*fp))
 		return (-1);


### PR DESCRIPTION
If multiple applications are accessing a single device both would error
out since they'd intercept frames with the wrong channel identifier
(cid). Instead, discard all frames with the wrong cid and loop until we
receive the response to our message.