### PR TITLE
ci: use shallow git clones of libcbor,openssl,zlib

### DIFF
--- a/.actions/build-linux-i686-w64-mingw32-gcc
+++ b/.actions/build-linux-i686-w64-mingw32-gcc
@@ -18,9 +18,8 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 EOF
 
 # Build and install libcbor.
-git clone git://github.com/pjk/libcbor
+git clone --depth=1 git://github.com/pjk/libcbor -b v0.8.0
 cd libcbor
-git checkout v0.8.0
 mkdir build
 (cd build && cmake -DCMAKE_TOOLCHAIN_FILE=/tmp/mingw.cmake \
 	-DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/fakeroot ..)
@@ -29,9 +28,8 @@ sudo make -C build install
 cd ..
 
 # Build and install OpenSSL 1.1.1k.
-git clone git://github.com/openssl/openssl
+git clone --depth=1 git://github.com/openssl/openssl -b OpenSSL_1_1_1k
 cd openssl
-git checkout OpenSSL_1_1_1k
 ./Configure mingw --prefix=/fakeroot --openssldir=/fakeroot/openssl \
 	--cross-compile-prefix=i686-w64-mingw32-
 make -j"$(nproc)"
@@ -39,9 +37,8 @@ sudo make install_sw
 cd ..
 
 # Build and install zlib.
-git clone https://github.com/madler/zlib
+git clone --depth=1 https://github.com/madler/zlib -b v1.2.11
 cd zlib
-git checkout v1.2.11
 make -fwin32/Makefile.gcc PREFIX=i686-w64-mingw32-
 sudo make -fwin32/Makefile.gcc PREFIX=i686-w64-mingw32- DESTDIR=/fakeroot \
 	INCLUDE_PATH=/include LIBRARY_PATH=/lib BINARY_PATH=/bin install

--- a/.actions/fuzz-linux
+++ b/.actions/fuzz-linux
@@ -42,7 +42,7 @@ FAKEROOT="${FAKEROOT:-$(mktemp -d)}"
 cd "${FAKEROOT}"
 
 # libcbor
-git clone "${LIBCBOR_URL}" -b "${LIBCBOR_TAG}"
+git clone --depth=1 "${LIBCBOR_URL}" -b "${LIBCBOR_TAG}"
 cd libcbor
 patch -p0 -s < "${WORKDIR}/fuzz/README"
 mkdir build
@@ -54,7 +54,7 @@ make VERBOSE=1 -j"$(nproc)" -C build all install
 cd -
 
 # openssl
-git clone "${OPENSSL_URL}" -b "${OPENSSL_TAG}"
+git clone --depth=1 "${OPENSSL_URL}" -b "${OPENSSL_TAG}"
 cd openssl
 ./Configure linux-x86_64-clang "enable-$1" --prefix="${FAKEROOT}" \
     --openssldir="${FAKEROOT}/openssl"
@@ -62,7 +62,7 @@ make install_sw
 cd -
 
 # zlib
-git clone "${ZLIB_URL}" -b "${ZLIB_TAG}"
+git clone --depth=1 "${ZLIB_URL}" -b "${ZLIB_TAG}"
 cd zlib
 CFLAGS="${ZLIB_CFLAGS}" LDFLAGS="${ZLIB_CFLAGS}" ./configure \
     --prefix="${FAKEROOT}"


### PR DESCRIPTION
This slightly speeds up clone/checkout time.