### PR TITLE
config: allow requests without uv on ctap 2.1 keys

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -58,7 +58,8 @@ config_tx(fido_dev_t *dev, uint8_t subcmd, cbor_item_t **paramv, size_t paramc,
 	}
 
 	/* pinProtocol, pinAuth */
-	if (pin != NULL || fido_dev_supports_permissions(dev)) {
+	if (pin != NULL || (fido_dev_supports_permissions(dev) &&
+	    fido_dev_has_uv(dev))) {
 		if ((argv[1] = cbor_flatten_vector(paramv, paramc)) == NULL) {
 			fido_log_debug("%s: cbor_flatten_vector", __func__);
 			goto fail;


### PR DESCRIPTION
ctap 2.1 keys support uv permissions, but may not have a pin configured; found the hard way by kostas@.