### PR TITLE
support attestation format 'none'

### DIFF
--- a/examples/cred.c
+++ b/examples/cred.c
@@ -86,6 +86,16 @@ verify_cred(int type, const char *fmt, const unsigned char *authdata_ptr,
 	if (uv && (r = fido_cred_set_uv(cred, FIDO_OPT_TRUE)) != FIDO_OK)
 		errx(1, "fido_cred_set_uv: %s (0x%x)", fido_strerr(r), r);
 
+	/* fmt */
+	r = fido_cred_set_fmt(cred, fmt);
+	if (r != FIDO_OK)
+		errx(1, "fido_cred_set_fmt: %s (0x%x)", fido_strerr(r), r);
+
+	if (!strcmp(fido_cred_fmt(cred), "none")) {
+		warnx("no attestation data, skipping credential verification");
+		goto out;
+	}
+
 	/* x509 */
 	r = fido_cred_set_x509(cred, x509_ptr, x509_len);
 	if (r != FIDO_OK)
@@ -96,15 +106,11 @@ verify_cred(int type, const char *fmt, const unsigned char *authdata_ptr,
 	if (r != FIDO_OK)
 		errx(1, "fido_cred_set_sig: %s (0x%x)", fido_strerr(r), r);
 
-	/* fmt */
-	r = fido_cred_set_fmt(cred, fmt);
-	if (r != FIDO_OK)
-		errx(1, "fido_cred_set_fmt: %s (0x%x)", fido_strerr(r), r);
-
 	r = fido_cred_verify(cred);
 	if (r != FIDO_OK)
 		errx(1, "fido_cred_verify: %s (0x%x)", fido_strerr(r), r);
 
+out:
 	if (key_out != NULL) {
 		/* extract the credential pubkey */
 		if (type == COSE_ES256) {

--- a/man/fido_cred_set_authdata.3
+++ b/man/fido_cred_set_authdata.3
@@ -240,18 +240,19 @@ by default, allowing the authenticator to use its default settings.
 .Pp
 The
 .Fn fido_cred_set_fmt
-function sets the format of
+function sets the attestation format of
 .Fa cred
 to
 .Fa fmt ,
 where
 .Fa fmt
-must be either
+must be
 .Vt "packed"
-.Pq the format used in FIDO2
-or
+.Pq the format used in FIDO2 ,
 .Vt "fido-u2f"
-.Pq the format used by U2F .
+.Pq the format used by U2F ,
+or
+.Vt "none" .
 A copy of
 .Fa fmt
 is made, and no references to the passed pointer are kept.

--- a/man/fido_cred_verify.3
+++ b/man/fido_cred_verify.3
@@ -7,7 +7,7 @@
 .Os
 .Sh NAME
 .Nm fido_cred_verify
-.Nd verifies the signature of a FIDO 2 credential
+.Nd verifies the attestation signature of a FIDO 2 credential
 .Sh SYNOPSIS
 .In fido.h
 .Ft int
@@ -15,7 +15,7 @@
 .Sh DESCRIPTION
 The
 .Fn fido_cred_verify
-function verifies whether the signature contained in
+function verifies whether the attestation signature contained in
 .Fa cred
 matches the attributes of the credential.
 Before using
@@ -54,6 +54,11 @@ The error codes returned by
 .Fn fido_cred_verify
 are defined in
 .In fido/err.h .
+If
+.Fa cred
+does not contain attestation data, then
+.Dv FIDO_ERR_INVALID_ARGUMENT
+is returned.
 If
 .Fa cred
 passes verification, then

--- a/regress/cred.c
+++ b/regress/cred.c
@@ -630,6 +630,25 @@ junk_cdh(void)
 }
 
 static void
+junk_fmt(void)
+{
+	fido_cred_t *c;
+
+	c = alloc_cred();
+	assert(fido_cred_set_type(c, COSE_ES256) == FIDO_OK);
+	assert(fido_cred_set_clientdata_hash(c, cdh, sizeof(cdh)) == FIDO_OK);
+	assert(fido_cred_set_rp(c, rp_id, rp_name) == FIDO_OK);
+	assert(fido_cred_set_authdata(c, authdata, sizeof(authdata)) == FIDO_OK);
+	assert(fido_cred_set_rk(c, FIDO_OPT_FALSE) == FIDO_OK);
+	assert(fido_cred_set_uv(c, FIDO_OPT_FALSE) == FIDO_OK);
+	assert(fido_cred_set_x509(c, x509, sizeof(x509)) == FIDO_OK);
+	assert(fido_cred_set_sig(c, sig, sizeof(sig)) == FIDO_OK);
+	assert(fido_cred_set_fmt(c, "junk") == FIDO_ERR_INVALID_ARGUMENT);
+	assert(fido_cred_verify(c) == FIDO_ERR_INVALID_ARGUMENT);
+	free_cred(c);
+}
+
+static void
 junk_rp_id(void)
 {
 	fido_cred_t *c;
@@ -911,6 +930,30 @@ raw_authdata(void)
 	free_cred(c);
 }
 
+static void
+fmt_none(void)
+{
+	fido_cred_t *c;
+
+	c = alloc_cred();
+	assert(fido_cred_set_type(c, COSE_ES256) == FIDO_OK);
+	assert(fido_cred_set_clientdata_hash(c, cdh, sizeof(cdh)) == FIDO_OK);
+	assert(fido_cred_set_rp(c, rp_id, rp_name) == FIDO_OK);
+	assert(fido_cred_set_authdata(c, authdata, sizeof(authdata)) == FIDO_OK);
+	assert(fido_cred_set_rk(c, FIDO_OPT_FALSE) == FIDO_OK);
+	assert(fido_cred_set_uv(c, FIDO_OPT_FALSE) == FIDO_OK);
+	assert(fido_cred_set_fmt(c, "none") == FIDO_OK);
+	assert(fido_cred_verify(c) == FIDO_ERR_INVALID_ARGUMENT);
+	assert(fido_cred_prot(c) == 0);
+	assert(fido_cred_pubkey_len(c) == sizeof(pubkey));
+	assert(memcmp(fido_cred_pubkey_ptr(c), pubkey, sizeof(pubkey)) == 0);
+	assert(fido_cred_id_len(c) == sizeof(id));
+	assert(memcmp(fido_cred_id_ptr(c), id, sizeof(id)) == 0);
+	assert(fido_cred_aaguid_len(c) == sizeof(aaguid));
+	assert(memcmp(fido_cred_aaguid_ptr(c), aaguid, sizeof(aaguid)) == 0);
+	free_cred(c);
+}
+
 int
 main(void)
 {
@@ -926,6 +969,7 @@ main(void)
 	no_sig();
 	no_fmt();
 	junk_cdh();
+	junk_fmt();
 	junk_rp_id();
 	junk_rp_name();
 	junk_authdata();
@@ -938,6 +982,7 @@ main(void)
 	unsorted_keys();
 	wrong_credprot();
 	raw_authdata();
+	fmt_none();
 
 	exit(0);
 }

--- a/src/cbor.c
+++ b/src/cbor.c
@@ -895,7 +895,8 @@ cbor_decode_fmt(const cbor_item_t *item, char **fmt)
 		return (-1);
 	}
 
-	if (strcmp(type, "packed") && strcmp(type, "fido-u2f")) {
+	if (strcmp(type, "packed") && strcmp(type, "fido-u2f") &&
+	    strcmp(type, "none")) {
 		fido_log_debug("%s: type=%s", __func__, type);
 		free(type);
 		return (-1);


### PR DESCRIPTION
support attestation format 'none', specified in https://www.w3.org/TR/webauthn-2/#sctn-none-attestation.