### PR TITLE
windows: build with msvc's static analyser (/analyze)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: build
-      run: .\windows\build.ps1 -WinSDK '10.0.19041.0'
+      run: .\windows\build.ps1 -WinSDK '10.0.19041.0' -Fido2Flags '/analyze'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,8 @@ if(MSVC)
 			# initializer;
 		"C4706" # assignment within conditional expression;
 		"C4996" # The POSIX name for this item is deprecated. Instead,
-			# use the ISO C and C++ conformant name
+			# use the ISO C and C++ conformant name;
+		"C6287" # redundant code: the left and right subexpressions are identical
 		)
 	# The construction in the following 3 lines was taken from LibreSSL's
 	# CMakeLists.txt.

--- a/openbsd-compat/readpassphrase_win32.c
+++ b/openbsd-compat/readpassphrase_win32.c
@@ -79,7 +79,7 @@ readpassphrase(const char *prompt, char *outBuf, size_t outBufLen, int flags)
 		return NULL;
 	}
 
-	while (_kbhit()) _getch();
+	while (_kbhit()) (void)_getch();
 
 	wtmp = utf8_to_utf16(prompt);
 	if (wtmp == NULL)
@@ -92,7 +92,7 @@ readpassphrase(const char *prompt, char *outBuf, size_t outBufLen, int flags)
 		ch = (char)_getch();
 		
 		if (ch == '\r') {
-			if (_kbhit()) _getch(); /* read linefeed if its there */
+			if (_kbhit()) (void)_getch(); /* read linefeed if its there */
 			break;
 		} else if (ch == '\n') {
 			break;

--- a/src/hid.c
+++ b/src/hid.c
@@ -130,7 +130,8 @@ fido_dev_info_free(fido_dev_info_t **devlist_p, size_t n)
 		return;
 
 	for (size_t i = 0; i < n; i++) {
-		const fido_dev_info_t *di = &devlist[i];
+		const fido_dev_info_t *di;
+		di = &devlist[i];
 		free(di->path);
 		free(di->manufacturer);
 		free(di->product);

--- a/src/winhello.c
+++ b/src/winhello.c
@@ -746,7 +746,8 @@ winhello_cred_free(struct winhello_cred *ctx)
 	free(ctx->display_name);
 	free(ctx->opt.CredentialList.pCredentials);
 	for (size_t i = 0; i < ctx->opt.Extensions.cExtensions; i++) {
-		WEBAUTHN_EXTENSION *e = &ctx->opt.Extensions.pExtensions[i];
+		WEBAUTHN_EXTENSION *e;
+		e = &ctx->opt.Extensions.pExtensions[i];
 		free(e->pvExtension);
 	}
 	free(ctx->opt.Extensions.pExtensions);

--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -3,7 +3,8 @@ param(
 	[string]$GitPath = "C:\Program Files\Git\bin\git.exe",
 	[string]$SevenZPath = "C:\Program Files\7-Zip\7z.exe",
 	[string]$GPGPath = "C:\Program Files (x86)\GnuPG\bin\gpg.exe",
-	[string]$WinSDK = ""
+	[string]$WinSDK = "",
+	[string]$Fido2Flags = ""
 )
 
 $ErrorActionPreference = "Continue"
@@ -189,7 +190,7 @@ Function Build(${OUTPUT}, ${GENERATOR}, ${ARCH}, ${SHARED}, ${FLAGS}) {
 		-DZLIB_LIBRARY_DIRS="${OUTPUT}\lib" `
 		-DCRYPTO_INCLUDE_DIRS="${OUTPUT}\include" `
 		-DCRYPTO_LIBRARY_DIRS="${OUTPUT}\lib" `
-		-DCMAKE_C_FLAGS_RELEASE="${FLAGS} /Zi /guard:cf /sdl" `
+		-DCMAKE_C_FLAGS_RELEASE="${FLAGS} /Zi /guard:cf /sdl ${Fido2Flags}" `
 		-DCMAKE_INSTALL_PREFIX="${OUTPUT}" "${CMAKE_SYSTEM_VERSION}"
 	& $CMake --build . --config Release --verbose
 	& $CMake --build . --config Release --target install --verbose


### PR DESCRIPTION
We currently use LLVM's static analyser on our Linux and macOS builds. This PR adds equivalent functionality to our Windows build.