### PR TITLE
Replace SHA256_* with EVP_* equivalents

### DIFF
--- a/fuzz/wrap.c
+++ b/fuzz/wrap.c
@@ -136,30 +136,6 @@ WRAP(int,
 	1
 )
 
-WRAP(int,
-	SHA256_Init,
-	(SHA256_CTX *c),
-	0,
-	(c),
-	1
-)
-
-WRAP(int,
-	SHA256_Update,
-	(SHA256_CTX *c, const void *data, size_t len),
-	0,
-	(c, data, len),
-	1
-)
-
-WRAP(int,
-	SHA256_Final,
-	(unsigned char *md, SHA256_CTX *c),
-	0,
-	(md, c),
-	1
-)
-
 WRAP(RSA *,
 	EVP_PKEY_get0_RSA,
 	(EVP_PKEY *pkey),
@@ -198,6 +174,30 @@ WRAP(int,
 	    EVP_PKEY *pkey),
 	0,
 	(ctx, pctx, type, e, pkey),
+	1
+)
+
+WRAP(int,
+	EVP_DigestInit_ex,
+	(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl),
+	0,
+	(ctx, type, impl),
+	1
+)
+
+WRAP(int,
+	EVP_DigestUpdate,
+	(EVP_MD_CTX *ctx, const void *data, size_t count),
+	0,
+	(ctx, data, count),
+	1
+)
+
+WRAP(int,
+	EVP_DigestFinal_ex,
+	(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *isize),
+	0,
+	(ctx, md, isize),
 	1
 )
 

--- a/fuzz/wrapped.sym
+++ b/fuzz/wrapped.sym
@@ -31,6 +31,9 @@ EVP_CIPHER_CTX_set_padding
 EVP_CipherInit
 EVP_DecryptInit_ex
 EVP_DecryptUpdate
+EVP_DigestFinal_ex
+EVP_DigestInit_ex
+EVP_DigestUpdate
 EVP_DigestVerifyInit
 EVP_EncryptInit_ex
 EVP_EncryptUpdate
@@ -61,9 +64,6 @@ ioctl
 malloc
 RSA_set0_key
 SHA256
-SHA256_Final
-SHA256_Init
-SHA256_Update
 strdup
 udev_device_get_devnode
 udev_device_get_parent_with_subsystem_devtype


### PR DESCRIPTION
SHA256_{Init,Update,Final} are marked as deprecated in OpenSSL 3.0. Given that alternatives exist in OpenSSL 1.1 and LibreSSL, switch to them as a first step towards OpenSSL 3.0 integration. Joint work with Dmitry Belyavskiy (@beldmit).