### PR TITLE
cred: rework verify_sig

### DIFF
--- a/man/fido_cred_verify.3
+++ b/man/fido_cred_verify.3
@@ -47,7 +47,6 @@ The attestation type implemented by
 .Fn fido_cred_verify
 is
 .Em Basic Attestation .
-The attestation key pair is assumed to be of the type ES256.
 Other attestation formats and types are not supported.
 .Sh RETURN VALUES
 The error codes returned by


### PR DESCRIPTION
Rework verify_sig (used by fido_cred_verify) to accept key types other than ES256, while making the code OpenSSL 3.0 compatible.

Diff from Dmitry Belyavskiy (@beldmit).