### PR TITLE
ecdh: explicit cast to silence warning with OpenSSL 3.0

### DIFF
--- a/src/ecdh.c
+++ b/src/ecdh.c
@@ -56,7 +56,7 @@ hkdf_sha256(uint8_t *key, char *info, fido_blob_t *secret)
 	    EVP_PKEY_CTX_set_hkdf_md(ctx, md) < 1 ||
 	    EVP_PKEY_CTX_set1_hkdf_salt(ctx, salt, sizeof(salt)) < 1 ||
 	    EVP_PKEY_CTX_set1_hkdf_key(ctx, secret->ptr, (int)secret->len) < 1 ||
-	    EVP_PKEY_CTX_add1_hkdf_info(ctx, info, (int)strlen(info)) < 1) {
+	    EVP_PKEY_CTX_add1_hkdf_info(ctx, (void *)info, (int)strlen(info)) < 1) {
 		fido_log_debug("%s: EVP_PKEY_CTX", __func__);
 		goto fail;
 	}


### PR DESCRIPTION
EVP_PKEY_CTX_add1_hkdf_info takes a const unsigned char * in OpenSSL 3, and a void * in OpenSSL 1.1. We pass a char *, so add an explicit cast to void * to satisfy both variations.