### PR TITLE
es256: make es256_verify_sig OpenSSL 3.0 compatible

### DIFF
--- a/src/es256.c
+++ b/src/es256.c
@@ -458,32 +458,26 @@ es256_verify_sig(const fido_blob_t *dgst, const es256_pk_t *pk,
     const fido_blob_t *sig)
 {
 	EVP_PKEY	*pkey = NULL;
-	EC_KEY		*ec = NULL;
+	EVP_PKEY_CTX	*pctx = NULL;
 	int		 ok = -1;
 
-	/* ECDSA_verify needs ints */
-	if (dgst->len > INT_MAX || sig->len > INT_MAX) {
-		fido_log_debug("%s: dgst->len=%zu, sig->len=%zu", __func__,
-		    dgst->len, sig->len);
-		return (-1);
-	}
-
 	if ((pkey = es256_pk_to_EVP_PKEY(pk)) == NULL ||
-	    (ec = EVP_PKEY_get0_EC_KEY(pkey)) == NULL) {
+	    (pctx = EVP_PKEY_CTX_new(pkey, NULL)) == NULL) {
 		fido_log_debug("%s: pk -> ec", __func__);
 		goto fail;
 	}
 
-	if (ECDSA_verify(0, dgst->ptr, (int)dgst->len, sig->ptr,
-	    (int)sig->len, ec) != 1) {
-		fido_log_debug("%s: ECDSA_verify", __func__);
+	if (EVP_PKEY_verify_init(pctx) != 1 ||
+	    EVP_PKEY_verify(pctx, sig->ptr, sig->len, dgst->ptr,
+	    dgst->len) != 1) {
+		fido_log_debug("%s: EVP_PKEY_verify", __func__);
 		goto fail;
 	}
 
 	ok = 0;
 fail:
-	if (pkey != NULL)
-		EVP_PKEY_free(pkey);
+	EVP_PKEY_free(pkey);
+	EVP_PKEY_CTX_free(pctx);
 
 	return (ok);
 }


### PR DESCRIPTION
Use the EVP_PKEY_verify family of functions to make es256_verify_sig compatible with OpenSSL 3.0. Diff from Dmitry Belyavskiy (@beldmit).