### PR TITLE
rs256: make rs256_verify_sig OpenSSL 3.0 compatible

### DIFF
--- a/src/rs256.c
+++ b/src/rs256.c
@@ -11,32 +11,6 @@
 #include "fido.h"
 #include "fido/rs256.h"
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-static int
-RSA_bits(const RSA *r)
-{
-	return (BN_num_bits(r->n));
-}
-
-static int
-RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
-{
-	r->n = n;
-	r->e = e;
-	r->d = d;
-
-	return (1);
-}
-
-static void
-RSA_get0_key(const RSA *r, const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
-{
-	*n = r->n;
-	*e = r->e;
-	*d = r->d;
-}
-#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
-
 static int
 decode_bignum(const cbor_item_t *item, void *ptr, size_t len)
 {

--- a/src/rs256.c
+++ b/src/rs256.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Yubico AB. All rights reserved.
+ * Copyright (c) 2018-2021 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -10,6 +10,55 @@
 
 #include "fido.h"
 #include "fido/rs256.h"
+
+#if defined(LIBRESSL_VERSION_NUMBER)
+static EVP_MD *
+rs256_get_EVP_MD(void)
+{
+	const EVP_MD *from;
+	EVP_MD *to = NULL;
+
+	if ((from = EVP_sha256()) != NULL && (to = malloc(sizeof(*to))) != NULL)
+		memcpy(to, from, sizeof(*to));
+
+	return (to);
+}
+
+static void
+rs256_free_EVP_MD(EVP_MD *md)
+{
+	freezero(md, sizeof(*md));
+}
+#elif OPENSSL_VERSION_NUMBER >= 0x30000000
+static EVP_MD *
+rs256_get_EVP_MD(void)
+{
+	return (EVP_MD_fetch(NULL, "SHA2-256", NULL));
+}
+
+static void
+rs256_free_EVP_MD(EVP_MD *md)
+{
+	EVP_MD_free(md);
+}
+#else
+static EVP_MD *
+rs256_get_EVP_MD(void)
+{
+	const EVP_MD *md;
+
+	if ((md = EVP_sha256()) == NULL)
+		return (NULL);
+
+	return (EVP_MD_meth_dup(md));
+}
+
+static void
+rs256_free_EVP_MD(EVP_MD *md)
+{
+	EVP_MD_meth_free(md);
+}
+#endif /* LIBRESSL_VERSION_NUMBER */
 
 static int
 decode_bignum(const cbor_item_t *item, void *ptr, size_t len)
@@ -178,32 +227,39 @@ rs256_verify_sig(const fido_blob_t *dgst, const rs256_pk_t *pk,
     const fido_blob_t *sig)
 {
 	EVP_PKEY	*pkey = NULL;
-	RSA		*rsa = NULL;
+	EVP_PKEY_CTX	*pctx = NULL;
+	EVP_MD		*md = NULL;
 	int		 ok = -1;
 
-	/* RSA_verify needs unsigned ints */
-	if (dgst->len > UINT_MAX || sig->len > UINT_MAX) {
-		fido_log_debug("%s: dgst->len=%zu, sig->len=%zu", __func__,
-		    dgst->len, sig->len);
-		return (-1);
-	}
-
-	if ((pkey = rs256_pk_to_EVP_PKEY(pk)) == NULL ||
-	    (rsa = EVP_PKEY_get0_RSA(pkey)) == NULL) {
-		fido_log_debug("%s: pk -> ec", __func__);
+	if ((md = rs256_get_EVP_MD()) == NULL) {
+		fido_log_debug("%s: rs256_get_EVP_MD", __func__);
 		goto fail;
 	}
 
-	if (RSA_verify(NID_sha256, dgst->ptr, (unsigned int)dgst->len, sig->ptr,
-	    (unsigned int)sig->len, rsa) != 1) {
-		fido_log_debug("%s: RSA_verify", __func__);
+	if ((pkey = rs256_pk_to_EVP_PKEY(pk)) == NULL) {
+		fido_log_debug("%s:  rs256_pk_to_EVP_PKEY", __func__);
+		goto fail;
+	}
+
+	if ((pctx = EVP_PKEY_CTX_new(pkey, NULL)) == NULL ||
+	    EVP_PKEY_verify_init(pctx) != 1 ||
+	    EVP_PKEY_CTX_set_rsa_padding(pctx, RSA_PKCS1_PADDING) != 1 ||
+	    EVP_PKEY_CTX_set_signature_md(pctx, md) != 1) {
+		fido_log_debug("%s: EVP_PKEY_CTX", __func__);
+		goto fail;
+	}
+
+	if (EVP_PKEY_verify(pctx, sig->ptr, sig->len, dgst->ptr,
+	    dgst->len) != 1) {
+		fido_log_debug("%s: EVP_PKEY_verify", __func__);
 		goto fail;
 	}
 
 	ok = 0;
 fail:
-	if (pkey != NULL)
-		EVP_PKEY_free(pkey);
+	EVP_PKEY_free(pkey);
+	EVP_PKEY_CTX_free(pctx);
+	rs256_free_EVP_MD(md);
 
 	return (ok);
 }


### PR DESCRIPTION
Use the EVP_PKEY_verify family of functions to make rs256_verify_sig compatible with OpenSSL 3.0. Diff from Dmitry Belyavskiy (@beldmit).
