### PR TITLE
es256: define es256_pk_from_EVP_PKEY

### DIFF
--- a/fuzz/export.gnu
+++ b/fuzz/export.gnu
@@ -7,6 +7,7 @@
 		eddsa_pk_to_EVP_PKEY;
 		es256_pk_free;
 		es256_pk_from_EC_KEY;
+		es256_pk_from_EVP_PKEY;
 		es256_pk_from_ptr;
 		es256_pk_new;
 		es256_pk_to_EVP_PKEY;

--- a/fuzz/fuzz_assert.c
+++ b/fuzz/fuzz_assert.c
@@ -291,6 +291,27 @@ verify_assert(int type, const unsigned char *cdh_ptr, size_t cdh_len,
 }
 
 /*
+ * Do a dummy conversion to exercise es256_pk_from_EVP_PKEY().
+ */
+static void
+es256_convert(const es256_pk_t *k)
+{
+	EVP_PKEY *pkey = NULL;
+	es256_pk_t *pk = NULL;
+	int r;
+
+	if ((pkey = es256_pk_to_EVP_PKEY(k)) == NULL ||
+	    (pk = es256_pk_new()) == NULL)
+		goto out;
+
+	r = es256_pk_from_EVP_PKEY(pk, pkey);
+	consume(&r, sizeof(r));
+out:
+	es256_pk_free(&pk);
+	EVP_PKEY_free(pkey);
+}
+
+/*
  * Do a dummy conversion to exercise rs256_pk_from_EVP_PKEY().
  */
 static void
@@ -358,6 +379,8 @@ test(const struct param *p)
 
 		es256_pk_from_ptr(es256_pk, p->es256.body, p->es256.len);
 		pk = es256_pk;
+
+		es256_convert(pk);
 
 		break;
 	case 1:

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -48,6 +48,7 @@ list(APPEND MAN_ALIAS
 	eddsa_pk_new eddsa_pk_to_EVP_PKEY
 	es256_pk_new es256_pk_free
 	es256_pk_new es256_pk_from_EC_KEY
+	es256_pk_new es256_pk_from_EVP_PKEY
 	es256_pk_new es256_pk_from_ptr
 	es256_pk_new es256_pk_to_EVP_PKEY
 	fido_assert_new fido_assert_authdata_len

--- a/man/es256_pk_new.3
+++ b/man/es256_pk_new.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2018 Yubico AB. All rights reserved.
+.\" Copyright (c) 2018-2021 Yubico AB. All rights reserved.
 .\" Use of this source code is governed by a BSD-style
 .\" license that can be found in the LICENSE file.
 .\"
@@ -9,6 +9,7 @@
 .Nm es256_pk_new ,
 .Nm es256_pk_free ,
 .Nm es256_pk_from_EC_KEY ,
+.Nm es256_pk_from_EVP_KEY ,
 .Nm es256_pk_from_ptr ,
 .Nm es256_pk_to_EVP_PKEY
 .Nd FIDO 2 COSE ES256 API
@@ -21,6 +22,8 @@
 .Fn es256_pk_free "es256_pk_t **pkp"
 .Ft int
 .Fn es256_pk_from_EC_KEY "es256_pk_t *pk" "const EC_KEY *ec"
+.Ft int
+.Fn es256_pk_from_EVP_PKEY "es256_pk_t *pk" "const EVP_PKEY *pkey"
 .Ft int
 .Fn es256_pk_from_ptr "es256_pk_t *pk" "const void *ptr" "size_t len"
 .Ft EVP_PKEY *
@@ -79,6 +82,16 @@ No references to
 are kept.
 .Pp
 The
+.Fn es256_pk_from_EVP_KEY
+function fills
+.Fa pk
+with the contents of
+.Fa pkey .
+No references to
+.Fa pkey
+are kept.
+.Pp
+The
 .Fn es256_pk_from_ptr
 function fills
 .Fa pk
@@ -110,7 +123,8 @@ If an error occurs,
 returns NULL.
 .Sh RETURN VALUES
 The
-.Fn es256_pk_from_EC_KEY
+.Fn es256_pk_from_EC_KEY ,
+.Fn es256_pk_from_EVP_KEY ,
 and
 .Fn es256_pk_from_ptr
 functions return

--- a/regress/assert.c
+++ b/regress/assert.c
@@ -589,6 +589,26 @@ rs256_PKEY(void)
 	EVP_PKEY_free(pkey);
 }
 
+/* es256 <-> EVP_PKEY transformations */
+static void
+es256_PKEY(void)
+{
+	es256_pk_t *pk1, *pk2;
+	EVP_PKEY *pkey;
+
+	pk1 = alloc_es256_pk();
+	pk2 = alloc_es256_pk();
+
+	assert(es256_pk_from_ptr(pk1, es256_pk, sizeof(es256_pk)) == FIDO_OK);
+	assert((pkey = es256_pk_to_EVP_PKEY(pk1)) != NULL);
+	assert(es256_pk_from_EVP_PKEY(pk2, pkey) == FIDO_OK);
+	assert(memcmp(pk1, pk2, sizeof(*pk1)) == 0);
+
+	free_es256_pk(pk1);
+	free_es256_pk(pk2);
+	EVP_PKEY_free(pkey);
+}
+
 int
 main(void)
 {
@@ -607,6 +627,7 @@ main(void)
 	wrong_options();
 	bad_cbor_serialize();
 	rs256_PKEY();
+	es256_PKEY();
 
 	exit(0);
 }

--- a/src/es256.c
+++ b/src/es256.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Yubico AB. All rights reserved.
+ * Copyright (c) 2018-2021 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -361,6 +361,18 @@ fail:
 	}
 
 	return (ok);
+}
+
+int
+es256_pk_from_EVP_PKEY(es256_pk_t *pk, const EVP_PKEY *pkey)
+{
+	EC_KEY *ec;
+
+	if (EVP_PKEY_base_id(pkey) != EVP_PKEY_EC ||
+	    (ec = EVP_PKEY_get0(pkey)) == NULL)
+		return (FIDO_ERR_INVALID_ARGUMENT);
+
+	return (es256_pk_from_EC_KEY(pk, ec));
 }
 
 EVP_PKEY *

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -7,6 +7,7 @@
 		eddsa_pk_to_EVP_PKEY;
 		es256_pk_free;
 		es256_pk_from_EC_KEY;
+		es256_pk_from_EVP_PKEY;
 		es256_pk_from_ptr;
 		es256_pk_new;
 		es256_pk_to_EVP_PKEY;

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -5,6 +5,7 @@ _eddsa_pk_new
 _eddsa_pk_to_EVP_PKEY
 _es256_pk_free
 _es256_pk_from_EC_KEY
+_es256_pk_from_EVP_PKEY
 _es256_pk_from_ptr
 _es256_pk_new
 _es256_pk_to_EVP_PKEY

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -6,6 +6,7 @@ eddsa_pk_new
 eddsa_pk_to_EVP_PKEY
 es256_pk_free
 es256_pk_from_EC_KEY
+es256_pk_from_EVP_PKEY
 es256_pk_from_ptr
 es256_pk_new
 es256_pk_to_EVP_PKEY

--- a/src/fido/es256.h
+++ b/src/fido/es256.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Yubico AB. All rights reserved.
+ * Copyright (c) 2018-2021 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -27,6 +27,7 @@ void es256_pk_free(es256_pk_t **);
 EVP_PKEY *es256_pk_to_EVP_PKEY(const es256_pk_t *);
 
 int es256_pk_from_EC_KEY(es256_pk_t *, const EC_KEY *);
+int es256_pk_from_EVP_PKEY(es256_pk_t *, const EVP_PKEY *);
 int es256_pk_from_ptr(es256_pk_t *, const void *, size_t);
 
 #ifdef _FIDO_INTERNAL


### PR DESCRIPTION
The EC_KEY C type has been deprecated in OpenSSL 3.0, with EVP_PKEY as its successor. As such, define es256_pk_from_EVP_PKEY so that applications can migrate from es256_pk_from_EC_KEY.

Discussed with Dmitry Belyavskiy (@beldmit).