### PR TITLE
Split *_verify_sig into EVP_PKEY components

### DIFF
--- a/src/assert.c
+++ b/src/assert.c
@@ -477,13 +477,13 @@ fido_assert_verify(const fido_assert_t *assert, size_t idx, int cose_alg,
 
 	switch (cose_alg) {
 	case COSE_ES256:
-		ok = es256_verify_sig(&dgst, pk, &stmt->sig);
+		ok = es256_pk_verify_sig(&dgst, pk, &stmt->sig);
 		break;
 	case COSE_RS256:
-		ok = rs256_verify_sig(&dgst, pk, &stmt->sig);
+		ok = rs256_pk_verify_sig(&dgst, pk, &stmt->sig);
 		break;
 	case COSE_EDDSA:
-		ok = eddsa_verify_sig(&dgst, pk, &stmt->sig);
+		ok = eddsa_pk_verify_sig(&dgst, pk, &stmt->sig);
 		break;
 	default:
 		fido_log_debug("%s: unsupported cose_alg %d", __func__,

--- a/src/cred.c
+++ b/src/cred.c
@@ -442,15 +442,15 @@ fido_cred_verify_self(const fido_cred_t *cred)
 
 	switch (cred->attcred.type) {
 	case COSE_ES256:
-		ok = es256_verify_sig(&dgst, &cred->attcred.pubkey.es256,
+		ok = es256_pk_verify_sig(&dgst, &cred->attcred.pubkey.es256,
 		    &cred->attstmt.sig);
 		break;
 	case COSE_RS256:
-		ok = rs256_verify_sig(&dgst, &cred->attcred.pubkey.rs256,
+		ok = rs256_pk_verify_sig(&dgst, &cred->attcred.pubkey.rs256,
 		    &cred->attstmt.sig);
 		break;
 	case COSE_EDDSA:
-		ok = eddsa_verify_sig(&dgst, &cred->attcred.pubkey.eddsa,
+		ok = eddsa_pk_verify_sig(&dgst, &cred->attcred.pubkey.eddsa,
 		    &cred->attstmt.sig);
 		break;
 	default:

--- a/src/extern.h
+++ b/src/extern.h
@@ -200,11 +200,14 @@ int fido_get_random(void *, size_t);
 int fido_sha256(fido_blob_t *, const u_char *, size_t);
 
 /* crypto */
-int es256_verify_sig(const fido_blob_t *, const es256_pk_t *,
+int es256_verify_sig(const fido_blob_t *, EVP_PKEY *, const fido_blob_t *);
+int rs256_verify_sig(const fido_blob_t *, EVP_PKEY *, const fido_blob_t *);
+int eddsa_verify_sig(const fido_blob_t *, EVP_PKEY *, const fido_blob_t *);
+int es256_pk_verify_sig(const fido_blob_t *, const es256_pk_t *,
     const fido_blob_t *);
-int rs256_verify_sig(const fido_blob_t *, const rs256_pk_t *,
+int rs256_pk_verify_sig(const fido_blob_t *, const rs256_pk_t *,
     const fido_blob_t *);
-int eddsa_verify_sig(const fido_blob_t *, const eddsa_pk_t *,
+int eddsa_pk_verify_sig(const fido_blob_t *, const eddsa_pk_t *,
     const fido_blob_t *);
 int fido_get_signed_hash(int, fido_blob_t *, const fido_blob_t *,
     const fido_blob_t *);


### PR DESCRIPTION
Split *_verify_sig into *_pk_verify_sig (takes a *_pk_t) and *_verify_sig (takes a EVP_PKEY). This will allow *_verify_sig to be
used on attestation signatures as well (in an upcoming PR).