### PR TITLE
Verify attestation according to attestation statement algorithm

### DIFF
--- a/src/cbor.c
+++ b/src/cbor.c
@@ -1386,7 +1386,6 @@ decode_attstmt_entry(const cbor_item_t *key, const cbor_item_t *val, void *arg)
 {
 	fido_attstmt_t	*attstmt = arg;
 	char		*name = NULL;
-	int		 cose_alg = 0;
 	int		 ok = -1;
 
 	if (cbor_string_copy(key, &name) < 0) {
@@ -1401,10 +1400,11 @@ decode_attstmt_entry(const cbor_item_t *key, const cbor_item_t *val, void *arg)
 			fido_log_debug("%s: alg", __func__);
 			goto out;
 		}
-		if ((cose_alg = -(int)cbor_get_int(val) - 1) != COSE_ES256 &&
-		    cose_alg != COSE_RS256 && cose_alg != COSE_EDDSA) {
-			fido_log_debug("%s: unsupported cose_alg=%d", __func__,
-			    cose_alg);
+		attstmt->alg = -(int)cbor_get_int(val) - 1;
+		if (attstmt->alg != COSE_ES256 && attstmt->alg != COSE_RS256 &&
+		    attstmt->alg != COSE_EDDSA) {
+			fido_log_debug("%s: unsupported attstmt->alg=%d",
+			    __func__, attstmt->alg);
 			goto out;
 		}
 	} else if (!strcmp(name, "sig")) {

--- a/src/eddsa.c
+++ b/src/eddsa.c
@@ -162,6 +162,11 @@ eddsa_verify_sig(const fido_blob_t *dgst, EVP_PKEY *pkey,
 	EVP_MD_CTX	*mdctx = NULL;
 	int		 ok = -1;
 
+	if (EVP_PKEY_base_id(pkey) != EVP_PKEY_ED25519) {
+		fido_log_debug("%s: EVP_PKEY_base_id", __func__);
+		goto fail;
+	}
+
 	/* EVP_DigestVerify needs ints */
 	if (dgst->len > INT_MAX || sig->len > INT_MAX) {
 		fido_log_debug("%s: dgst->len=%zu, sig->len=%zu", __func__,

--- a/src/es256.c
+++ b/src/es256.c
@@ -469,8 +469,13 @@ int
 es256_verify_sig(const fido_blob_t *dgst, EVP_PKEY *pkey,
     const fido_blob_t *sig)
 {
-	EVP_PKEY_CTX	*pctx;
+	EVP_PKEY_CTX	*pctx = NULL;
 	int		 ok = -1;
+
+	if (EVP_PKEY_base_id(pkey) != EVP_PKEY_EC) {
+		fido_log_debug("%s: EVP_PKEY_base_id", __func__);
+		goto fail;
+	}
 
 	if ((pctx = EVP_PKEY_CTX_new(pkey, NULL)) == NULL ||
 	    EVP_PKEY_verify_init(pctx) != 1 ||

--- a/src/fido/param.h
+++ b/src/fido/param.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Yubico AB. All rights reserved.
+ * Copyright (c) 2018-2021 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -82,10 +82,12 @@
 #define FIDO_CAP_NMSG	0x08 /* if set, device doesn't support CTAP_CMD_MSG */
 
 /* Supported COSE algorithms. */
+#define	COSE_UNSPEC	0
 #define	COSE_ES256	-7
 #define	COSE_EDDSA	-8
 #define	COSE_ECDH_ES256	-25
 #define	COSE_RS256	-257
+#define	COSE_RS1	-65535
 
 /* Supported COSE types. */
 #define COSE_KTY_OKP	1

--- a/src/fido/types.h
+++ b/src/fido/types.h
@@ -110,6 +110,7 @@ typedef struct fido_attstmt {
 	fido_blob_t cbor; /* cbor-encoded attestation statement */
 	fido_blob_t x5c;  /* attestation certificate */
 	fido_blob_t sig;  /* attestation signature */
+	int         alg;  /* attestation algorithm (cose) */
 } fido_attstmt_t;
 
 typedef struct fido_rp {

--- a/src/rs1.c
+++ b/src/rs1.c
@@ -66,6 +66,11 @@ rs1_verify_sig(const fido_blob_t *dgst, EVP_PKEY *pkey,
 	EVP_MD		*md = NULL;
 	int		 ok = -1;
 
+	if (EVP_PKEY_base_id(pkey) != EVP_PKEY_RSA) {
+		fido_log_debug("%s: EVP_PKEY_base_id", __func__);
+		goto fail;
+	}
+
 	if ((md = rs1_get_EVP_MD()) == NULL) {
 		fido_log_debug("%s: rs1_get_EVP_MD", __func__);
 		goto fail;

--- a/src/rs256.c
+++ b/src/rs256.c
@@ -242,6 +242,11 @@ rs256_verify_sig(const fido_blob_t *dgst, EVP_PKEY *pkey,
 	EVP_MD		*md = NULL;
 	int		 ok = -1;
 
+	if (EVP_PKEY_base_id(pkey) != EVP_PKEY_RSA) {
+		fido_log_debug("%s: EVP_PKEY_base_id", __func__);
+		goto fail;
+	}
+
 	if ((md = rs256_get_EVP_MD()) == NULL) {
 		fido_log_debug("%s: rs256_get_EVP_MD", __func__);
 		goto fail;


### PR DESCRIPTION
Verify a credential's attestation according to the 'alg' (algorithm) in the attestation statement. This is needed to support TPM attestation, which uses RSA instead of ECDSA (the only signature algorithm supported by libfido2 for Basic Attestation so far).