### PR TITLE
Parse the 'certInfo' and 'pubArea' keys of a TPM attestation statement

### DIFF
--- a/src/cbor.c
+++ b/src/cbor.c
@@ -1419,6 +1419,16 @@ decode_attstmt_entry(const cbor_item_t *key, const cbor_item_t *val, void *arg)
 			fido_log_debug("%s: x5c", __func__);
 			goto out;
 		}
+	} else if (!strcmp(name, "certInfo")) {
+		if (fido_blob_decode(val, &attstmt->certinfo) < 0) {
+			fido_log_debug("%s: certinfo", __func__);
+			goto out;
+		}
+	} else if (!strcmp(name, "pubArea")) {
+		if (fido_blob_decode(val, &attstmt->pubarea) < 0) {
+			fido_log_debug("%s: pubarea", __func__);
+			goto out;
+		}
 	}
 
 	ok = 0;

--- a/src/cred.c
+++ b/src/cred.c
@@ -502,6 +502,8 @@ fido_cred_clean_authdata(fido_cred_t *cred)
 static void
 fido_cred_clean_attstmt(fido_attstmt_t *attstmt)
 {
+	fido_blob_reset(&attstmt->certinfo);
+	fido_blob_reset(&attstmt->pubarea);
 	fido_blob_reset(&attstmt->cbor);
 	fido_blob_reset(&attstmt->x5c);
 	fido_blob_reset(&attstmt->sig);

--- a/src/fido/types.h
+++ b/src/fido/types.h
@@ -107,10 +107,12 @@ typedef struct fido_attcred {
 } fido_attcred_t;
 
 typedef struct fido_attstmt {
-	fido_blob_t cbor; /* cbor-encoded attestation statement */
-	fido_blob_t x5c;  /* attestation certificate */
-	fido_blob_t sig;  /* attestation signature */
-	int         alg;  /* attestation algorithm (cose) */
+	fido_blob_t certinfo; /* tpm attestation TPMS_ATTEST structure */
+	fido_blob_t pubarea;  /* tpm attestation TPMT_PUBLIC structure */
+	fido_blob_t cbor;     /* cbor-encoded attestation statement */
+	fido_blob_t x5c;      /* attestation certificate */
+	fido_blob_t sig;      /* attestation signature */
+	int         alg;      /* attestation algorithm (cose) */
 } fido_attstmt_t;
 
 typedef struct fido_rp {


### PR DESCRIPTION
These are needed to verify the attestation signature.