### PR TITLE
winhello: parse attestation object

### DIFF
--- a/src/winhello.c
+++ b/src/winhello.c
@@ -816,6 +816,8 @@ fido_winhello_get_assert(fido_dev_t *dev, fido_assert_t *assert,
 
 	(void)dev;
 
+	fido_assert_reset_rx(assert);
+
 	if ((ctx = calloc(1, sizeof(*ctx))) == NULL) {
 		fido_log_debug("%s: calloc", __func__);
 		goto fail;
@@ -886,6 +888,8 @@ fido_winhello_make_cred(fido_dev_t *dev, fido_cred_t *cred, const char *pin)
 	int			 r = FIDO_ERR_INTERNAL;
 
 	(void)dev;
+
+	fido_cred_reset_rx(cred);
 
 	if ((ctx = calloc(1, sizeof(*ctx))) == NULL) {
 		fido_log_debug("%s: calloc", __func__);


### PR DESCRIPTION
Parse the attestation object provided by Microsoft's webauthn.h instead of poking at various pointers in `WEBAUTHN_CREDENTIAL_ATTESTATION`, shrinking the number of lines of code while allowing the 'certInfo' and 'pubArea' parts of the attestation statement to be parsed.