### PR TITLE
nfc: work with nfc:// paths

### DIFF
--- a/src/dev.c
+++ b/src/dev.c
@@ -341,14 +341,7 @@ int
 fido_dev_open(fido_dev_t *dev, const char *path)
 {
 #ifdef NFC_LINUX
-	/*
-	 * this is a hack to get existing applications up and running with nfc;
-	 * it will *NOT* be part of a libfido2 release. to support nfc in your
-	 * application, please change it to use fido_dev_open_with_info().
-	 */
-	if (strncmp(path, "/sys", strlen("/sys")) == 0 && strlen(path) > 4 &&
-	    path[strlen(path) - 4] == 'n' && path[strlen(path) - 3] == 'f' &&
-	    path[strlen(path) - 2] == 'c') {
+	if (strncmp(path, FIDO_NFC_PREFIX, strlen(FIDO_NFC_PREFIX)) == 0) {
 		dev->io_own = true;
 		dev->io = (fido_dev_io_t) {
 			fido_nfc_open,

--- a/src/extern.h
+++ b/src/extern.h
@@ -247,6 +247,7 @@ uint32_t uniform_random(uint32_t);
 #define FIDO_DUMMY_USER_NAME	"dummy"
 #define FIDO_DUMMY_USER_ID	1
 #define FIDO_WINHELLO_PATH	"windows://hello"
+#define FIDO_NFC_PREFIX		"nfc:"
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
so that fido2-token -L now outputs:

```
ted:~/projects/libfido2$ build/tools/fido2-token -L                                                                      
nfc://sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3:1.0/nfc/nfc0: vendor=0x072f, product=0x2200 (ACS ACR122U PICC Interface)
/dev/hidraw4: vendor=0x1050, product=0x0406 (Yubico YubiKey FIDO+CCID)
ted:~/projects/libfido2$ build/tools/fido2-token -I nfc://sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3:1.0/nfc/nfc0 
proto: 0x00
major: 0x00
minor: 0x00
build: 0x00
caps: 0x04 (nowink, cbor, msg)
version strings: U2F_V2, FIDO_2_0, FIDO_2_1_PRE
extension strings: credProtect, hmac-secret
transport strings: nfc, usb
algorithms: es256 (public-key), eddsa (public-key)
aaguid: 149a20218ef6413396b881f8d5b7f1f5
options: rk, up, noplat, clientPin, credentialMgmtPreview
maxmsgsiz: 1200
maxcredcntlst: 8
maxcredlen: 128
fwversion: 0x0
pin protocols: 1
pin retries: 7
uv retries: undefined
```