### PR TITLE
pinUvAuthProtocol parameter in HMAC-Secret assertion

### DIFF
--- a/src/cbor.c
+++ b/src/cbor.c
@@ -817,13 +817,20 @@ cbor_encode_hmac_secret_param(const fido_dev_t *dev, cbor_item_t *item,
 	/* XXX not pin, but salt */
 	if ((argv[0] = es256_pk_encode(pk, 1)) == NULL ||
 	    (argv[1] = fido_blob_encode(enc)) == NULL ||
-	    (argv[2] = cbor_encode_pin_auth(dev, ecdh, enc)) == NULL ||
-	    (argv[3] = cbor_encode_pin_opt(dev)) == NULL) {
+	    (argv[2] = cbor_encode_pin_auth(dev, ecdh, enc)) == NULL ) {
 		fido_log_debug("%s: cbor encode", __func__);
 		r = FIDO_ERR_INTERNAL;
 		goto fail;
 	}
 
+	if (fido_dev_supports_pin_protocol_in_hmac_assert(dev)) {
+            if ((argv[3] = cbor_encode_pin_opt(dev)) == NULL) {
+                fido_log_debug("%s: cbor encode", __func__);
+                r = FIDO_ERR_INTERNAL;
+                goto fail;
+            }
+    	}
+	
 	if ((param = cbor_flatten_vector(argv, nitems(argv))) == NULL) {
 		fido_log_debug("%s: cbor_flatten_vector", __func__);
 		r = FIDO_ERR_INTERNAL;

--- a/src/dev.c
+++ b/src/dev.c
@@ -98,11 +98,25 @@ fido_dev_set_protocol_flags(fido_dev_t *dev, const fido_cbor_info_t *info)
 }
 
 static void
+fido_dev_set_versions_flags(fido_dev_t *dev, const fido_cbor_info_t *info)
+{
+    const char ** versions = fido_cbor_info_versions_ptr(info);
+    size_t len = fido_cbor_info_versions_len(info);
+    for(size_t i = 0;i < len; i++)
+    {
+        if (strcmp(versions[i], "FIDO_2_1") == 0){
+            dev->flags |= FIDO_2_1;
+        }
+    }
+}
+
+static void
 fido_dev_set_flags(fido_dev_t *dev, const fido_cbor_info_t *info)
 {
 	fido_dev_set_extension_flags(dev, info);
 	fido_dev_set_option_flags(dev, info);
 	fido_dev_set_protocol_flags(dev, info);
+	fido_dev_set_versions_flags(dev, info);
 }
 
 static int
@@ -708,6 +722,12 @@ void
 fido_dev_force_fido2(fido_dev_t *dev)
 {
 	dev->attr.flags |= FIDO_CAP_CBOR;
+}
+
+bool
+fido_dev_supports_pin_protocol_in_hmac_assert(const fido_dev_t* dev)
+{
+    return (dev->flags & FIDO_2_1);
 }
 
 uint8_t

--- a/src/extern.h
+++ b/src/extern.h
@@ -171,6 +171,7 @@ int u2f_get_touch_status(fido_dev_t *, int *, int);
 
 /* unexposed fido ops */
 uint8_t fido_dev_get_pin_protocol(const fido_dev_t *);
+bool fido_dev_supports_pin_protocol_in_hmac_assert(const fido_dev_t *);
 int fido_dev_authkey(fido_dev_t *, es256_pk_t *);
 int fido_dev_get_cbor_info_wait(fido_dev_t *, fido_cbor_info_t *, int);
 int fido_dev_get_uv_token(fido_dev_t *, uint8_t, const char *,
@@ -240,6 +241,7 @@ uint32_t uniform_random(uint32_t);
 #define FIDO_DEV_UV_UNSET	0x080
 #define FIDO_DEV_TOKEN_PERMS	0x100
 #define FIDO_DEV_WINHELLO	0x200
+#define FIDO_2_1 0x400
 
 /* miscellanea */
 #define FIDO_DUMMY_CLIENTDATA	""


### PR DESCRIPTION
In 1.7.0 cbor_encode_hmac_secret_param add a new fourth parameter ( pinUvAuthProtocol ) to HMAC Secret Extension as part of GetAssertion.
This parameter was added (even thought optional) to hmac-secret authenticatorGetAssertion request in FIDO 2.1, and not in FIDO 2.0 (regardless the existence of pin protocol).
So, some kind of version checking should apply before adding the new parameter.
This parameter make feitian fido2 authenticator to return FIDO_ERR_UNSUPPORTED_EXTENSION when try the get assertion with FIDO_EXT_HMAC_SECRET.