### PR TITLE
dev,info: pass timeout by reference

### DIFF
--- a/src/extern.h
+++ b/src/extern.h
@@ -172,7 +172,7 @@ int u2f_get_touch_status(fido_dev_t *, int *, int);
 /* unexposed fido ops */
 uint8_t fido_dev_get_pin_protocol(const fido_dev_t *);
 int fido_dev_authkey(fido_dev_t *, es256_pk_t *);
-int fido_dev_get_cbor_info_wait(fido_dev_t *, fido_cbor_info_t *, int);
+int fido_dev_get_cbor_info_wait(fido_dev_t *, fido_cbor_info_t *, int *);
 int fido_dev_get_uv_token(fido_dev_t *, uint8_t, const char *,
     const fido_blob_t *, const es256_pk_t *, const char *, fido_blob_t *);
 uint64_t fido_dev_maxmsgsize(const fido_dev_t *);

--- a/src/extern.h
+++ b/src/extern.h
@@ -249,6 +249,12 @@ uint32_t uniform_random(uint32_t);
 #define FIDO_WINHELLO_PATH	"windows://hello"
 #define FIDO_NFC_PREFIX		"nfc:"
 
+/* XXX */
+#ifdef FIDO_RX_MS_REF
+#define fido_rx_cbor_status(dev, ms) fido_rx_cbor_status(dev, *(ms))
+#define fido_rx(dev, cmd, buf, siz, ms) fido_rx(dev, cmd, buf, siz, *(ms))
+#endif
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */

--- a/src/info.c
+++ b/src/info.c
@@ -4,6 +4,7 @@
  * license that can be found in the LICENSE file.
  */
 
+#define FIDO_RX_MS_REF
 #include "fido.h"
 
 static int
@@ -294,13 +295,13 @@ fido_dev_get_cbor_info_tx(fido_dev_t *dev)
 }
 
 static int
-fido_dev_get_cbor_info_rx(fido_dev_t *dev, fido_cbor_info_t *ci, int ms)
+fido_dev_get_cbor_info_rx(fido_dev_t *dev, fido_cbor_info_t *ci, int *ms)
 {
 	unsigned char	reply[FIDO_MAXMSG];
 	int		reply_len;
 
 	fido_log_debug("%s: dev=%p, ci=%p, ms=%d", __func__, (void *)dev,
-	    (void *)ci, ms);
+	    (void *)ci, *ms);
 
 	fido_cbor_info_reset(ci);
 
@@ -315,7 +316,7 @@ fido_dev_get_cbor_info_rx(fido_dev_t *dev, fido_cbor_info_t *ci, int ms)
 }
 
 int
-fido_dev_get_cbor_info_wait(fido_dev_t *dev, fido_cbor_info_t *ci, int ms)
+fido_dev_get_cbor_info_wait(fido_dev_t *dev, fido_cbor_info_t *ci, int *ms)
 {
 	int r;
 
@@ -333,7 +334,9 @@ fido_dev_get_cbor_info_wait(fido_dev_t *dev, fido_cbor_info_t *ci, int ms)
 int
 fido_dev_get_cbor_info(fido_dev_t *dev, fido_cbor_info_t *ci)
 {
-	return (fido_dev_get_cbor_info_wait(dev, ci, -1));
+	int ms = dev->timeout_ms;
+
+	return (fido_dev_get_cbor_info_wait(dev, ci, &ms));
 }
 
 /*


### PR DESCRIPTION
Take a copy of the device's timeout attribute and pass a reference to it instead of hard-coded `-1` ms.

This introduces a set of temporary stubs to pass a reference of the timeout to `fido_rx()` and `fido_rx_cbor_status()` until we are ready to change the signature of these functions.