### PR TITLE
assert: pass timeout by reference

### DIFF
--- a/src/assert.c
+++ b/src/assert.c
@@ -309,7 +309,7 @@ fido_dev_get_assert(fido_dev_t *dev, fido_assert_t *assert, const char *pin)
 	if (pin != NULL || (assert->uv == FIDO_OPT_TRUE &&
 	    fido_dev_supports_permissions(dev)) ||
 	    (assert->ext.mask & FIDO_EXT_HMAC_SECRET)) {
-		if ((r = fido_do_ecdh(dev, &pk, &ecdh)) != FIDO_OK) {
+		if ((r = fido_do_ecdh(dev, &pk, &ecdh, &ms)) != FIDO_OK) {
 			fido_log_debug("%s: fido_do_ecdh", __func__);
 			goto fail;
 		}

--- a/src/assert.c
+++ b/src/assert.c
@@ -6,6 +6,7 @@
 
 #include <openssl/sha.h>
 
+#define FIDO_RX_MS_REF
 #include "fido.h"
 #include "fido/es256.h"
 #include "fido/rs256.h"
@@ -158,7 +159,7 @@ fail:
 }
 
 static int
-fido_dev_get_assert_rx(fido_dev_t *dev, fido_assert_t *assert, int ms)
+fido_dev_get_assert_rx(fido_dev_t *dev, fido_assert_t *assert, int *ms)
 {
 	unsigned char	reply[FIDO_MAXMSG];
 	int		reply_len;
@@ -212,7 +213,7 @@ fido_get_next_assert_tx(fido_dev_t *dev)
 }
 
 static int
-fido_get_next_assert_rx(fido_dev_t *dev, fido_assert_t *assert, int ms)
+fido_get_next_assert_rx(fido_dev_t *dev, fido_assert_t *assert, int *ms)
 {
 	unsigned char	reply[FIDO_MAXMSG];
 	int		reply_len;
@@ -242,7 +243,7 @@ fido_get_next_assert_rx(fido_dev_t *dev, fido_assert_t *assert, int ms)
 
 static int
 fido_dev_get_assert_wait(fido_dev_t *dev, fido_assert_t *assert,
-    const es256_pk_t *pk, const fido_blob_t *ecdh, const char *pin, int ms)
+    const es256_pk_t *pk, const fido_blob_t *ecdh, const char *pin, int *ms)
 {
 	int r;
 
@@ -314,7 +315,7 @@ fido_dev_get_assert(fido_dev_t *dev, fido_assert_t *assert, const char *pin)
 		}
 	}
 
-	r = fido_dev_get_assert_wait(dev, assert, pk, ecdh, pin, -1);
+	r = fido_dev_get_assert_wait(dev, assert, pk, ecdh, pin, &ms);
 	if (r == FIDO_OK && (assert->ext.mask & FIDO_EXT_HMAC_SECRET))
 		if (decrypt_hmac_secrets(dev, assert, ecdh) < 0) {
 			fido_log_debug("%s: decrypt_hmac_secrets", __func__);

--- a/src/extern.h
+++ b/src/extern.h
@@ -253,6 +253,8 @@ uint32_t uniform_random(uint32_t);
 #ifdef FIDO_RX_MS_REF
 #define fido_rx_cbor_status(dev, ms) fido_rx_cbor_status(dev, *(ms))
 #define fido_rx(dev, cmd, buf, siz, ms) fido_rx(dev, cmd, buf, siz, *(ms))
+#define fido_do_ecdh(dev, pk, ecdh, ms) \
+    ((void)(ms), fido_do_ecdh(dev, pk, ecdh))
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
While here, also prepare for `fido_do_ecdh()` accepting a timeout argument. `fido_do_ecdh()` calls into `fido_dev_authkey()`, which should ultimately also accept a timeout argument.