### PR TITLE
Support devices without vendor/product strings

### DIFF
--- a/man/fido_dev_info_manifest.3
+++ b/man/fido_dev_info_manifest.3
@@ -112,11 +112,21 @@ The
 .Fn fido_dev_info_manufacturer_string
 function returns the manufacturer string of
 .Fa di .
+If
+.Fa di
+does not have an associated manufacturer string,
+.Fn fido_dev_info_manufacturer_string
+returns an empty string.
 .Pp
 The
 .Fn fido_dev_info_product_string
 function returns the product string of
 .Fa di .
+If
+.Fa di
+does not have an associated product string,
+.Fn fido_dev_info_product_string
+returns an empty string.
 .Pp
 An example of how to use the functions described in this document
 can be found in the

--- a/src/hid_linux.c
+++ b/src/hid_linux.c
@@ -160,9 +160,9 @@ copy_info(fido_dev_info_t *di, struct udev *udev,
 
 	di->path = strdup(path);
 	if ((di->manufacturer = get_usb_attr(dev, "manufacturer")) == NULL)
-		di->manufacturer = strdup("unknown");
+		di->manufacturer = strdup("");
 	if ((di->product = get_usb_attr(dev, "product")) == NULL)
-		di->product = strdup("unknown");
+		di->product = strdup("");
 	if (di->path == NULL || di->manufacturer == NULL || di->product == NULL)
 		goto fail;
 

--- a/src/hid_osx.c
+++ b/src/hid_osx.c
@@ -131,23 +131,18 @@ get_str(IOHIDDeviceRef dev, char **manufacturer, char **product)
 	*manufacturer = NULL;
 	*product = NULL;
 
-	if (get_utf8(dev, CFSTR(kIOHIDManufacturerKey), buf, sizeof(buf)) < 0) {
-		fido_log_debug("%s: get_utf8 manufacturer", __func__);
-		goto fail;
-	}
+	if (get_utf8(dev, CFSTR(kIOHIDManufacturerKey), buf, sizeof(buf)) < 0)
+		*manufacturer = strdup("");
+	else
+		*manufacturer = strdup(buf);
 
-	if ((*manufacturer = strdup(buf)) == NULL) {
-		fido_log_debug("%s: strdup manufacturer", __func__);
-		goto fail;
-	}
+	if (get_utf8(dev, CFSTR(kIOHIDProductKey), buf, sizeof(buf)) < 0)
+		*product = strdup("");
+	else
+		*product = strdup(buf);
 
-	if (get_utf8(dev, CFSTR(kIOHIDProductKey), buf, sizeof(buf)) < 0) {
-		fido_log_debug("%s: get_utf8 product", __func__);
-		goto fail;
-	}
-
-	if ((*product = strdup(buf)) == NULL) {
-		fido_log_debug("%s: strdup product", __func__);
+	if (*manufacturer == NULL || *product == NULL) {
+		fido_log_debug("%s: strdup", __func__);
 		goto fail;
 	}
 

--- a/src/hid_win.c
+++ b/src/hid_win.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Yubico AB. All rights reserved.
+ * Copyright (c) 2019-2021 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -103,7 +103,7 @@ fail:
 }
 
 static int
-get_int(HANDLE dev, int16_t *vendor_id, int16_t *product_id)
+get_id(HANDLE dev, int16_t *vendor_id, int16_t *product_id)
 {
 	HIDD_ATTRIBUTES attr;
 
@@ -121,14 +121,13 @@ get_int(HANDLE dev, int16_t *vendor_id, int16_t *product_id)
 }
 
 static int
-get_str(HANDLE dev, char **manufacturer, char **product)
+get_manufacturer(HANDLE dev, char **manufacturer)
 {
 	wchar_t	buf[512];
 	int	utf8_len;
 	int	ok = -1;
 
 	*manufacturer = NULL;
-	*product = NULL;
 
 	if (HidD_GetManufacturerString(dev, &buf, sizeof(buf)) == false) {
 		fido_log_debug("%s: HidD_GetManufacturerString", __func__);
@@ -151,6 +150,25 @@ get_str(HANDLE dev, char **manufacturer, char **product)
 		fido_log_debug("%s: WideCharToMultiByte", __func__);
 		goto fail;
 	}
+
+	ok = 0;
+fail:
+	if (ok < 0) {
+		free(*manufacturer);
+		*manufacturer = NULL;
+	}
+
+	return (ok);
+}
+
+static int
+get_product(HANDLE dev, char **product)
+{
+	wchar_t	buf[512];
+	int	utf8_len;
+	int	ok = -1;
+
+	*product = NULL;
 
 	if (HidD_GetProductString(dev, &buf, sizeof(buf)) == false) {
 		fido_log_debug("%s: HidD_GetProductString", __func__);
@@ -177,9 +195,7 @@ get_str(HANDLE dev, char **manufacturer, char **product)
 	ok = 0;
 fail:
 	if (ok < 0) {
-		free(*manufacturer);
 		free(*product);
-		*manufacturer = NULL;
 		*product = NULL;
 	}
 
@@ -313,9 +329,23 @@ copy_info(fido_dev_info_t *di, HDEVINFO devinfo, DWORD idx,
 		goto fail;
 	}
 
-	if (get_int(dev, &di->vendor_id, &di->product_id) < 0 ||
-	    get_str(dev, &di->manufacturer, &di->product) < 0) {
-		fido_log_debug("%s: get_int/get_str", __func__);
+	if (get_id(dev, &di->vendor_id, &di->product_id) < 0) {
+		fido_log_debug("%s: get_id", __func__);
+		goto fail;
+	}
+
+	if (get_manufacturer(dev, &di->manufacturer) < 0) {
+		fido_log_debug("%s: get_manufacturer", __func__);
+		di->manufacturer = strdup("");
+	}
+
+	if (get_product(dev, &di->product) < 0) {
+		fido_log_debug("%s: get_product", __func__);
+		di->product = strdup("");
+	}
+
+	if (di->manufacturer == NULL || di->product == NULL) {
+		fido_log_debug("%s: manufacturer/product", __func__);
 		goto fail;
 	}
 

--- a/src/nfc_linux.c
+++ b/src/nfc_linux.c
@@ -357,9 +357,13 @@ copy_info(fido_dev_info_t *di, struct udev *udev,
 	if ((name = udev_list_entry_get_name(udev_entry)) == NULL ||
 	    (dev = udev_device_new_from_syspath(udev, name)) == NULL)
 		goto fail;
-	if (asprintf(&di->path, "%s/%s", FIDO_NFC_PREFIX, name) == -1 ||
-	    (di->manufacturer = get_usb_attr(dev, "manufacturer")) == NULL ||
-	    (di->product = get_usb_attr(dev, "product")) == NULL)
+	if (asprintf(&di->path, "%s/%s", FIDO_NFC_PREFIX, name) == -1)
+		goto fail;
+	if ((di->manufacturer = get_usb_attr(dev, "manufacturer")) == NULL)
+		di->manufacturer = strdup("");
+	if ((di->product = get_usb_attr(dev, "product")) == NULL)
+		di->product = strdup("");
+	if (di->manufacturer == NULL || di->product == NULL)
 		goto fail;
 	/* XXX assumes USB for vendor/product info */
 	if ((str = get_usb_attr(dev, "idVendor")) != NULL &&


### PR DESCRIPTION
Some devices don't have associated vendor/product strings, e.g. Kensington's VeriMark Guard Fingerprint Key, as seen in #381. Instead of rejecting these devices, accept them with empty identifier strings, and do so consistently across Linux/macOS/Windows.