### PR TITLE
dev: add fido_dev_set_timeout

### DIFF
--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -234,6 +234,7 @@ list(APPEND MAN_ALIAS
 	fido_dev_set_pin fido_dev_get_uv_retry_count
 	fido_dev_set_pin fido_dev_reset
 	fido_dev_set_io_functions fido_dev_set_sigmask
+	fido_dev_set_io_functions fido_dev_set_timeout
 	fido_dev_largeblob_get fido_dev_largeblob_set
 	fido_dev_largeblob_get fido_dev_largeblob_remove
 	fido_dev_largeblob_get fido_dev_largeblob_get_array

--- a/man/fido_dev_set_io_functions.3
+++ b/man/fido_dev_set_io_functions.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2018 Yubico AB. All rights reserved.
+.\" Copyright (c) 2018-2021 Yubico AB. All rights reserved.
 .\" Use of this source code is governed by a BSD-style
 .\" license that can be found in the LICENSE file.
 .\"
@@ -7,7 +7,8 @@
 .Os
 .Sh NAME
 .Nm fido_dev_set_io_functions ,
-.Nm fido_dev_set_sigmask
+.Nm fido_dev_set_sigmask ,
+.Nm fido_dev_set_timeout
 .Nd FIDO 2 device I/O interface
 .Sh SYNOPSIS
 .In fido.h
@@ -34,6 +35,8 @@ typedef sigset_t fido_sigset_t;
 .Fn fido_dev_set_io_functions "fido_dev_t *dev" "const fido_dev_io_t *io"
 .Ft int
 .Fn fido_dev_set_sigmask "fido_dev_t *dev" "const fido_sigset_t *sigmask"
+.Ft int
+.Fn fido_dev_set_timeout "fido_dev_t *dev" "int ms"
 .Sh DESCRIPTION
 The
 .Fn fido_dev_set_io_functions
@@ -122,11 +125,35 @@ No references to
 .Fa sigmask
 are held by
 .Fn fido_dev_set_sigmask .
+.Pp
+The
+.Fn fido_dev_set_timeout
+function informs
+.Em libfido2
+not to block for more than
+.Fa ms
+milliseconds while communicating with
+.Fa dev .
+If a timeout occurs, the corresponding
+.Em fido_dev_*
+function will fail with
+.Dv FIDO_ERR_RX .
+If
+.Fa ms
+is -1,
+then
+.Em libfido2
+may block indefinitely.
+This is the default behaviour.
+When using the Windows Hello backend,
+.Fa ms
+is used as a guidance and may be overwritten by the platform.
 .Sh RETURN VALUES
 On success,
-.Fn fido_dev_set_io_functions
+.Fn fido_dev_set_io_functions ,
+.Fn fido_dev_set_sigmask ,
 and
-.Fn fido_dev_set_sigmask
+.Fn fido_dev_set_timeout
 return
 .Dv FIDO_OK .
 On error, a different error code defined in

--- a/src/dev.c
+++ b/src/dev.c
@@ -736,3 +736,14 @@ fido_dev_maxmsgsize(const fido_dev_t *dev)
 {
 	return (dev->maxmsgsize);
 }
+
+int
+fido_dev_set_timeout(fido_dev_t *dev, int ms)
+{
+	if (ms < -1)
+		return (FIDO_ERR_INVALID_ARGUMENT);
+
+	dev->timeout_ms = ms;
+
+	return (FIDO_OK);
+}

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -216,6 +216,7 @@
 		fido_dev_set_pin_minlen;
 		fido_dev_set_pin_minlen_rpid;
 		fido_dev_set_sigmask;
+		fido_dev_set_timeout;
 		fido_dev_set_transport_functions;
 		fido_dev_supports_cred_prot;
 		fido_dev_supports_credman;

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -214,6 +214,7 @@ _fido_dev_set_pin
 _fido_dev_set_pin_minlen
 _fido_dev_set_pin_minlen_rpid
 _fido_dev_set_sigmask
+_fido_dev_set_timeout
 _fido_dev_set_transport_functions
 _fido_dev_supports_cred_prot
 _fido_dev_supports_credman

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -215,6 +215,7 @@ fido_dev_set_pin
 fido_dev_set_pin_minlen
 fido_dev_set_pin_minlen_rpid
 fido_dev_set_sigmask
+fido_dev_set_timeout
 fido_dev_set_transport_functions
 fido_dev_supports_cred_prot
 fido_dev_supports_credman

--- a/src/fido.h
+++ b/src/fido.h
@@ -160,6 +160,7 @@ int fido_dev_reset(fido_dev_t *);
 int fido_dev_set_io_functions(fido_dev_t *, const fido_dev_io_t *);
 int fido_dev_set_pin(fido_dev_t *, const char *, const char *);
 int fido_dev_set_transport_functions(fido_dev_t *, const fido_dev_transport_t *);
+int fido_dev_set_timeout(fido_dev_t *, int);
 
 size_t fido_assert_authdata_len(const fido_assert_t *, size_t);
 size_t fido_assert_clientdata_hash_len(const fido_assert_t *);


### PR DESCRIPTION
Sets an upper limit for how long libfido2 may block while communicating
with a device.