### PR TITLE
examples: switch to fido_dev_set_timeout()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Yubico AB. All rights reserved.
+# Copyright (c) 2018-2021 Yubico AB. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -102,17 +102,12 @@ check_symbol_exists(getrandom sys/random.h HAVE_GETRANDOM)
 check_symbol_exists(memset_s string.h HAVE_MEMSET_S)
 check_symbol_exists(readpassphrase readpassphrase.h HAVE_READPASSPHRASE)
 check_symbol_exists(recallocarray stdlib.h HAVE_RECALLOCARRAY)
-check_symbol_exists(sigaction signal.h HAVE_SIGACTION)
 check_symbol_exists(strlcat string.h HAVE_STRLCAT)
 check_symbol_exists(strlcpy string.h HAVE_STRLCPY)
 check_symbol_exists(strsep string.h HAVE_STRSEP)
 check_symbol_exists(sysconf unistd.h HAVE_SYSCONF)
 check_symbol_exists(timespecsub sys/time.h HAVE_TIMESPECSUB)
 check_symbol_exists(timingsafe_bcmp string.h HAVE_TIMINGSAFE_BCMP)
-
-set(CMAKE_EXTRA_INCLUDE_FILES signal.h)
-check_type_size("sig_atomic_t" HAVE_SIG_ATOMIC_T)
-set(CMAKE_EXTRA_INCLUDE_FILES)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 try_compile(HAVE_POSIX_IOCTL
@@ -136,7 +131,6 @@ list(APPEND CHECK_VARIABLES
 	HAVE_POSIX_IOCTL
 	HAVE_READPASSPHRASE
 	HAVE_RECALLOCARRAY
-	HAVE_SIGACTION
 	HAVE_SIGNAL_H
 	HAVE_STRLCAT
 	HAVE_STRLCPY
@@ -157,10 +151,6 @@ endforeach()
 
 if(HAVE_EXPLICIT_BZERO AND NOT LIBFUZZER)
 	add_definitions(-DHAVE_EXPLICIT_BZERO)
-endif()
-
-if(HAVE_SIGACTION AND (NOT HAVE_SIG_ATOMIC_T STREQUAL ""))
-	add_definitions(-DSIGNAL_EXAMPLE)
 endif()
 
 if(UNIX)

--- a/examples/cred.c
+++ b/examples/cred.c
@@ -144,7 +144,7 @@ main(int argc, char **argv)
 	const char	*key_out = NULL;
 	const char	*id_out = NULL;
 	unsigned char	*body = NULL;
-	long long	 seconds = 0;
+	long long	 ms = 0;
 	size_t		 len;
 	int		 type = COSE_ES256;
 	int		 ext = 0;
@@ -160,16 +160,12 @@ main(int argc, char **argv)
 			pin = optarg;
 			break;
 		case 'T':
-#ifndef SIGNAL_EXAMPLE
-			(void)seconds;
-			errx(1, "-T not supported");
-#else
-			if (base10(optarg, &seconds) < 0)
+			if (base10(optarg, &ms) < 0)
 				errx(1, "base10: %s", optarg);
-			if (seconds <= 0 || seconds > 30)
+			if (ms <= 0 || ms > 30)
 				errx(1, "-T: %s must be in (0,30]", optarg);
+			ms *= 1000; /* seconds to milliseconds */
 			break;
-#endif
 		case 'b':
 			ext |= FIDO_EXT_LARGEBLOB_KEY;
 			blobkey_out = optarg;
@@ -268,20 +264,12 @@ main(int argc, char **argv)
 	if (uv && (r = fido_cred_set_uv(cred, FIDO_OPT_TRUE)) != FIDO_OK)
 		errx(1, "fido_cred_set_uv: %s (0x%x)", fido_strerr(r), r);
 
-#ifdef SIGNAL_EXAMPLE
-	prepare_signal_handler(SIGINT);
-	if (seconds) {
-		prepare_signal_handler(SIGALRM);
-		alarm((unsigned)seconds);
-	}
-#endif
+	/* timeout */
+	if (ms != 0 && (r = fido_dev_set_timeout(dev, (int)ms)) != FIDO_OK)
+		errx(1, "fido_dev_set_timeout: %s (0x%x)", fido_strerr(r), r);
 
-	r = fido_dev_make_cred(dev, cred, pin);
-	if (r != FIDO_OK) {
-#ifdef SIGNAL_EXAMPLE
-		if (got_signal)
-			fido_dev_cancel(dev);
-#endif
+	if ((r = fido_dev_make_cred(dev, cred, pin)) != FIDO_OK) {
+		fido_dev_cancel(dev);
 		errx(1, "fido_makecred: %s (0x%x)", fido_strerr(r), r);
 	}
 

--- a/examples/extern.h
+++ b/examples/extern.h
@@ -11,10 +11,6 @@
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
 
-#ifdef HAVE_SIGNAL_H
-#include <signal.h>
-#endif
-
 /* util.c */
 EC_KEY *read_ec_pubkey(const char *);
 RSA *read_rsa_pubkey(const  char *);
@@ -25,9 +21,5 @@ int write_blob(const char *, const unsigned char *, size_t);
 int write_ec_pubkey(const char *, const void *, size_t);
 int write_rsa_pubkey(const char *, const void *, size_t);
 int write_eddsa_pubkey(const char *, const void *, size_t);
-#ifdef SIGNAL_EXAMPLE
-void prepare_signal_handler(int);
-extern volatile sig_atomic_t got_signal;
-#endif
 
 #endif /* _EXTERN_H_ */

--- a/examples/reset.c
+++ b/examples/reset.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Yubico AB. All rights reserved.
+ * Copyright (c) 2018-2021 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -34,16 +34,9 @@ main(int argc, char **argv)
 	if ((r = fido_dev_open(dev, argv[1])) != FIDO_OK)
 		errx(1, "fido_dev_open: %s (0x%x)", fido_strerr(r), r);
 
-#ifdef SIGNAL_EXAMPLE
-	prepare_signal_handler(SIGINT);
-#endif
-
 	if ((r = fido_dev_reset(dev)) != FIDO_OK) {
-#ifdef SIGNAL_EXAMPLE
-		if (got_signal)
-			fido_dev_cancel(dev);
-#endif
-		errx(1, "fido_reset: %s (0x%x)", fido_strerr(r), r);
+		fido_dev_cancel(dev);
+		errx(1, "fido_dev_reset: %s (0x%x)", fido_strerr(r), r);
 	}
 
 	if ((r = fido_dev_close(dev)) != FIDO_OK)

--- a/examples/util.c
+++ b/examples/util.c
@@ -21,9 +21,6 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef HAVE_SIGNAL_H
-#include <signal.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -32,31 +29,6 @@
 #endif
 #include "../openbsd-compat/openbsd-compat.h"
 #include "extern.h"
-
-#ifdef SIGNAL_EXAMPLE
-volatile sig_atomic_t got_signal = 0;
-
-static void
-signal_handler(int signo)
-{
-	(void)signo;
-	got_signal = 1;
-}
-
-void
-prepare_signal_handler(int signo)
-{
-	struct sigaction sa;
-
-	memset(&sa, 0, sizeof(sa));
-
-	sigemptyset(&sa.sa_mask);
-	sa.sa_handler = signal_handler;
-
-	if (sigaction(signo, &sa, NULL) < 0)
-		err(1, "sigaction");
-}
-#endif
 
 int
 base10(const char *str, long long *ll)


### PR DESCRIPTION
drop the existing signal-based timeout implementation in favour of the recently introduced fido_dev_set_timeout().