### PR TITLE
iso7816: Avoid storing pointers in a packed structure

### DIFF
--- a/src/iso7816.c
+++ b/src/iso7816.c
@@ -59,6 +59,6 @@ iso7816_ptr(const iso7816_apdu_t *apdu)
 size_t
 iso7816_len(const iso7816_apdu_t *apdu)
 {
-	return apdu->alloc_len - sizeof(apdu->alloc_len) -
-	    sizeof(apdu->payload_len) - sizeof(apdu->payload_ptr);
+	return apdu->alloc_len - offsetof(iso7816_apdu_t, header) -
+	    (sizeof(iso7816_apdu_t) - offsetof(iso7816_apdu_t, payload));
 }

--- a/src/iso7816.h
+++ b/src/iso7816.h
@@ -27,14 +27,13 @@ struct iso7816_header {
 	uint8_t lc3;
 })
 
-PACKED_TYPE(iso7816_apdu_t,
-struct iso7816_apdu {
+typedef struct iso7816_apdu {
 	size_t            alloc_len;
 	uint16_t          payload_len;
 	uint8_t          *payload_ptr;
 	iso7816_header_t  header;
 	uint8_t           payload[];
-})
+} iso7816_apdu_t;
 
 const unsigned char *iso7816_ptr(const iso7816_apdu_t *);
 int iso7816_add(iso7816_apdu_t *, const void *, size_t);


### PR DESCRIPTION
On CHERI, and thus Arm's experimental Morello prototype architecture,
pointers are represented as capabilities, which are unforgeable bounded
pointers, providing always-on fine-grained spatial memory safety. The
unforgeability is enforced through the use of tagged memory, with one
validity tag bit per capability-sized-and-aligned word in memory. This
means that storing a pointer to an unaligned location, which is not
guaranteed to work per the C standard, either traps or results in the
capability losing its tag (and thus never being dereferenceable again),
depending on how exactly the store is done (specifically, whether a
capability store or memcpy is used).

However, iso7816 itself does not need to be packed, and doing so likely
causes inefficiencies on existing architectures. The iso7816_header_t
member is packed, and the flexible payload array is a uint8_t (which by
definition has no padding bits and is exactly 8 bits in size and, since
CHAR_BITS must be at least 8, its existence implies that it has the same
representation as unsigned char, and that it has size and alignment 1)
so there will never be any padding inserted between header and payload.