### PR TITLE
time: let read primitive determine timeout

### DIFF
--- a/man/fido_dev_set_io_functions.3
+++ b/man/fido_dev_set_io_functions.3
@@ -137,9 +137,7 @@ milliseconds while communicating with
 If a timeout occurs, the corresponding
 .Em fido_dev_*
 function will fail with
-.Dv FIDO_ERR_RX
-or
-.Dv FIDO_ERR_TX .
+.Dv FIDO_ERR_RX .
 If
 .Fa ms
 is -1,

--- a/src/time.c
+++ b/src/time.c
@@ -65,10 +65,8 @@ fido_time_delta(const struct timespec *ts_start, int *ms_remain)
 		return -1;
 	}
 
-	if (ms > *ms_remain) {
-		fido_log_debug("%s: timeout", __func__);
-		return -1;
-	}
+	if (ms > *ms_remain)
+		ms = *ms_remain;
 
 	*ms_remain -= ms;
 


### PR DESCRIPTION
`fido_time_delta()` now only subtracts the elapsed time from the remaining
timeout, clamping it to zero. Effectively, this leaves the read
primitive in charge of determining whether a timeout has occurred.
Notably, if a frame is received in exactly `ms` milliseconds, then
libfido2 will no longer return `FIDO_ERR_RX`.

Moreover, since the write primitive does not have a timeout argument,
a successful write will not result in a timeout error. However, the
elapsed time will be accounted for.

Regression tests and documentation adjusted accordingly.