### PR TITLE
fuzz: reintroduce MSAN instrumentation

### DIFF
--- a/fuzz/fuzz_assert.c
+++ b/fuzz/fuzz_assert.c
@@ -459,7 +459,7 @@ out:
 }
 
 void
-mutate(struct param *p, unsigned int seed, unsigned int flags)
+mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 {
 	if (flags & MUTATE_SEED)
 		p->seed = (int)seed;

--- a/fuzz/fuzz_bio.c
+++ b/fuzz/fuzz_bio.c
@@ -420,7 +420,7 @@ test(const struct param *p)
 }
 
 void
-mutate(struct param *p, unsigned int seed, unsigned int flags)
+mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 {
 	if (flags & MUTATE_SEED)
 		p->seed = (int)seed;

--- a/fuzz/fuzz_cred.c
+++ b/fuzz/fuzz_cred.c
@@ -440,7 +440,7 @@ test(const struct param *p)
 }
 
 void
-mutate(struct param *p, unsigned int seed, unsigned int flags)
+mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 {
 	if (flags & MUTATE_SEED)
 		p->seed = (int)seed;

--- a/fuzz/fuzz_credman.c
+++ b/fuzz/fuzz_credman.c
@@ -386,7 +386,7 @@ test(const struct param *p)
 }
 
 void
-mutate(struct param *p, unsigned int seed, unsigned int flags)
+mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 {
 	if (flags & MUTATE_SEED)
 		p->seed = (int)seed;

--- a/fuzz/fuzz_hid.c
+++ b/fuzz/fuzz_hid.c
@@ -214,7 +214,7 @@ test(const struct param *p)
 }
 
 void
-mutate(struct param *p, unsigned int seed, unsigned int flags)
+mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 {
 	if (flags & MUTATE_SEED)
 		p->seed = (int)seed;

--- a/fuzz/fuzz_largeblob.c
+++ b/fuzz/fuzz_largeblob.c
@@ -254,7 +254,7 @@ test(const struct param *p)
 }
 
 void
-mutate(struct param *p, unsigned int seed, unsigned int flags)
+mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 {
 	if (flags & MUTATE_SEED)
 		p->seed = (int)seed;

--- a/fuzz/fuzz_mgmt.c
+++ b/fuzz/fuzz_mgmt.c
@@ -488,7 +488,7 @@ test(const struct param *p)
 }
 
 void
-mutate(struct param *p, unsigned int seed, unsigned int flags)
+mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 {
 	if (flags & MUTATE_SEED)
 		p->seed = (int)seed;

--- a/fuzz/fuzz_netlink.c
+++ b/fuzz/fuzz_netlink.c
@@ -150,7 +150,7 @@ test(const struct param *p)
 }
 
 void
-mutate(struct param *p, unsigned int seed, unsigned int flags)
+mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 {
 	if (flags & MUTATE_SEED)
 		p->seed = (int)seed;

--- a/fuzz/libfuzzer.c
+++ b/fuzz/libfuzzer.c
@@ -137,7 +137,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
 size_t
 LLVMFuzzerCustomMutator(uint8_t *data, size_t size, size_t maxsize,
-    unsigned int seed)
+    unsigned int seed) NO_MSAN
 {
 	struct param *p;
 	uint8_t blob[4096];

--- a/fuzz/mutator_aux.c
+++ b/fuzz/mutator_aux.c
@@ -103,7 +103,7 @@ unpack_blob(cbor_item_t *item, struct blob *v)
 }
 
 cbor_item_t *
-pack_int(int v)
+pack_int(int v) NO_MSAN
 {
 	if (v < 0)
 		return cbor_build_negint64((uint64_t)(-(int64_t)v - 1));
@@ -112,7 +112,7 @@ pack_int(int v)
 }
 
 cbor_item_t *
-pack_string(const char *v)
+pack_string(const char *v) NO_MSAN
 {
 	if (strlen(v) >= MAXSTR)
 		return NULL;
@@ -121,13 +121,13 @@ pack_string(const char *v)
 }
 
 cbor_item_t *
-pack_byte(uint8_t v)
+pack_byte(uint8_t v) NO_MSAN
 {
 	return cbor_build_uint8(v);
 }
 
 cbor_item_t *
-pack_blob(const struct blob *v)
+pack_blob(const struct blob *v) NO_MSAN
 {
 	return cbor_build_bytestring(v->body, v->len);
 }

--- a/fuzz/mutator_aux.h
+++ b/fuzz/mutator_aux.h
@@ -21,11 +21,26 @@
 #include "../src/fido/rs256.h"
 #include "../src/netlink.h"
 
+/*
+ * As of LLVM 10.0.0, MSAN support in libFuzzer was still experimental.
+ * We therefore have to be careful when using our custom mutator, or
+ * MSAN will flag uninitialised reads on memory populated by libFuzzer.
+ * Since there is no way to suppress MSAN without regenerating object
+ * code (in which case you might as well rebuild libFuzzer with MSAN),
+ * we adjust our mutator to make it less accurate while allowing
+ * fuzzing to proceed.
+ */
+
 #if defined(__has_feature)
 # if  __has_feature(memory_sanitizer)
 #  include <sanitizer/msan_interface.h>
+#  define NO_MSAN	__attribute__((no_sanitize("memory")))
 #  define WITH_MSAN	1
 # endif
+#endif
+
+#if !defined(WITH_MSAN)
+# define NO_MSAN
 #endif
 
 #define MUTATE_SEED	0x01


### PR DESCRIPTION
It turns out it is still needed. We just didn't see the problem due to a combination of factors:

- libfido2's libFuzzer harnesses have different mutation modes: seed, wiredata, and param. By default (i.e. unless `--fido-mutate` is specified), all three are used;
- oss-fuzz disabled our MSAN runners on August 26th (https://github.com/google/oss-fuzz/commit/390c200). This likely happened because we link against libudev from apt, which is not instrumented, although we don't use libudev when fuzzing. oss-fuzz does not specify `--fido-mutate`;
- the commit removing the MSAN instrumentation from `fuzz/` (https://github.com/Yubico/libfido2/commit/a72273) was authored on September 15th;
- our fuzzing infrastructure alternates between the wiredata and seed mutation modes;
- the problem is only triggered  if the param mutation mode is enabled.

In a sentence: we thought the instrumentation was no longer needed because our own fuzzing infrastructure was inadvertently dodging it, and oss-fuzz's MSAN runners were not running.

This commits reverts https://github.com/Yubico/libfido2/commit/a72273. Problem spotted by @alexgeana.