### PR TITLE
cmake: Add -Werror when checking host compiler for -fstack-protector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if(NOT MSVC)
 endif()
 
 check_c_compiler_flag("-Wshorten-64-to-32" HAVE_SHORTEN_64_TO_32)
-check_c_compiler_flag("-fstack-protector-all" HAVE_STACK_PROTECTOR_ALL)
+check_c_compiler_flag("-Werror -fstack-protector-all" HAVE_STACK_PROTECTOR_ALL)
 
 check_include_files(cbor.h HAVE_CBOR_H)
 check_include_files(endian.h HAVE_ENDIAN_H)


### PR DESCRIPTION
Since calling GCC with -fstack-protector will just generate a warning
when it doesn't support the flag on a given host architecture, we need
to add -Werror so the warning turns into an error and cause the cmake
check HAVE_STACK_PROTECTOR_ALL to fail when the flag is not supported.

fixes gh#443