### PR TITLE
hid_osx: handle kIOMasterPortDefault deprecation

### DIFF
--- a/src/hid_osx.c
+++ b/src/hid_osx.c
@@ -11,10 +11,15 @@
 #include <signal.h>
 #include <unistd.h>
 
+#include <Availability.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/IOKitLib.h>
 #include <IOKit/hid/IOHIDKeys.h>
 #include <IOKit/hid/IOHIDManager.h>
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 120000
+#define kIOMainPortDefault kIOMasterPortDefault
+#endif
 
 #include "fido.h"
 
@@ -393,7 +398,7 @@ fido_hid_open(const char *path)
 		goto fail;
 	}
 
-	if ((entry = IORegistryEntryFromPath(kIOMasterPortDefault,
+	if ((entry = IORegistryEntryFromPath(kIOMainPortDefault,
 	    path)) == MACH_PORT_NULL) {
 		fido_log_debug("%s: IORegistryEntryFromPath", __func__);
 		goto fail;


### PR DESCRIPTION
kIOMasterPortDefault has been deprecated in macOS 12; report & fix from @sb230132 in #450; thanks!