### PR TITLE
windows: bump LibreSSL to 3.4.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,7 @@ if(MSVC)
 	endif()
 	set(CBOR_LIBRARIES cbor)
 	set(ZLIB_LIBRARIES zlib)
-	set(CRYPTO_LIBRARIES crypto-46)
+	set(CRYPTO_LIBRARIES crypto-47)
 	set(MSVC_DISABLED_WARNINGS_LIST
 		"C4152" # nonstandard extension used: function/data pointer
 			# conversion in expression;

--- a/src/eddsa.c
+++ b/src/eddsa.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Yubico AB. All rights reserved.
+ * Copyright (c) 2019-2021 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -37,7 +37,9 @@ EVP_PKEY_get_raw_public_key(const EVP_PKEY *pkey, unsigned char *pub,
 
 	return (0);
 }
+#endif /* LIBRESSL_VERSION_NUMBER */
 
+#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x3040000f
 int
 EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret, size_t siglen,
     const unsigned char *tbs, size_t tbslen)
@@ -52,7 +54,7 @@ EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret, size_t siglen,
 
 	return (0);
 }
-#endif /* LIBRESSL_VERSION_NUMBER */
+#endif /* LIBRESSL_VERSION_NUMBER < 0x3040000f */
 
 static int
 decode_coord(const cbor_item_t *item, void *xy, size_t xy_len)

--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -229,7 +229,7 @@ try {
 	    ExitOnError
 	# Copy DLLs.
 	if ("${SHARED}" -eq "ON") {
-		"cbor.dll", "crypto-46.dll", "zlib1.dll" | `
+		"cbor.dll", "crypto-47.dll", "zlib1.dll" | `
 		    %{ Copy-Item "${PREFIX}\bin\$_" `
 		    -Destination "examples\${Config}" }
 	}

--- a/windows/const.ps1
+++ b/windows/const.ps1
@@ -6,7 +6,7 @@
 New-Variable -Name 'LIBRESSL_URL' `
     -Value 'https://fastly.cdn.openbsd.org/pub/OpenBSD/LibreSSL' `
     -Option Constant
-New-Variable -Name 'LIBRESSL' -Value 'libressl-3.3.4' -Option Constant
+New-Variable -Name 'LIBRESSL' -Value 'libressl-3.4.2' -Option Constant
 
 # libcbor coordinates.
 New-Variable -Name 'LIBCBOR' -Value 'libcbor-0.9.0' -Option Constant

--- a/windows/release.ps1
+++ b/windows/release.ps1
@@ -7,7 +7,7 @@ $Architectures = @('x64', 'Win32', 'ARM64', 'ARM')
 $InstallPrefixes =  @('Win64', 'Win32', 'ARM64', 'ARM')
 $Types = @('dynamic', 'static')
 $Config = 'Release'
-$LibCrypto = '46'
+$LibCrypto = '47'
 $SDK = '143'
 
 . "$PSScriptRoot\const.ps1"
@@ -49,7 +49,7 @@ Function Package-Static(${SRC}, ${DEST}) {
 }
 
 Function Package-PDBs(${SRC}, ${DEST}) {
-	Copy-Item "${SRC}\${LIBRESSL}\crypto\crypto.dir\${Config}\vc${SDK}.pdb" `
+	Copy-Item "${SRC}\${LIBRESSL}\crypto\crypto_obj.dir\${Config}\crypto_obj.pdb" `
 	    "${DEST}\crypto-${LibCrypto}.pdb"
 	Copy-Item "${SRC}\${LIBCBOR}\src\cbor.dir\${Config}\vc${SDK}.pdb" `
 	    "${DEST}\cbor.pdb"


### PR DESCRIPTION
https://marc.info/?l=openbsd-announce&m=163789626027148

Please note that:

- LibreSSL 3.4 defines `EVP_DigestVerify()`, so we need to adjust the compatibility shim in eddsa.c;
- The path to crypto-47.pdb has changed (due to changes in LibreSSL's CMakeLists.txt).