### PR TITLE
Add missing support for custom transport functions

### DIFF
--- a/man/fido_dev_info_manifest.3
+++ b/man/fido_dev_info_manifest.3
@@ -14,7 +14,8 @@
 .Nm fido_dev_info_product ,
 .Nm fido_dev_info_vendor ,
 .Nm fido_dev_info_manufacturer_string ,
-.Nm fido_dev_info_product_string
+.Nm fido_dev_info_product_string ,
+.Nm fido_dev_info_set
 .Nd FIDO 2 device discovery functions
 .Sh SYNOPSIS
 .In fido.h
@@ -36,6 +37,8 @@
 .Fn fido_dev_info_manufacturer_string "const fido_dev_info_t *di"
 .Ft const char *
 .Fn fido_dev_info_product_string "const fido_dev_info_t *di"
+.Ft int
+.Fn fido_dev_info_set "fido_dev_info_t *devlist" "size_t i" "const char *path" "const char *manufacturer" "const char *product" "const fido_dev_io_t *io" "const fido_dev_transport_t *transport"
 .Sh DESCRIPTION
 The
 .Fn fido_dev_info_manifest
@@ -133,6 +136,30 @@ can be found in the
 .Pa examples/manifest.c
 file shipped with
 .Em libfido2 .
+.Pp
+The
+.Fn fido_dev_info_set
+function initializes an entry in a device list allocated by
+.Fn fido_dev_info_new
+with the specified path, manufacturer, and product strings, and with
+the specified I/O handlers and, optionally, transport functions, as
+described in
+.Xr fido_dev_set_io_functions 3 .
+The
+.Fa io
+argument must be specified; the
+.Fa transport
+argument may be
+.Dv NULL .
+The path, I/O handlers, and transport functions will be used
+automatically by
+.Xr fido_dev_new_with_info 3
+and
+.Xr fido_dev_open_with_info 3 .
+An application can use this, for example, to substitute mock FIDO
+devices in testing for the real ones that
+.Fn fido_dev_info_manifest
+would discover.
 .Sh RETURN VALUES
 The
 .Fn fido_dev_info_manifest
@@ -141,6 +168,14 @@ function always returns
 If a discovery error occurs, the
 .Fa olen
 pointer is set to 0.
+.Pp
+On success, the
+.Fn fido_dev_info_set
+function returns
+.Dv FIDO_OK .
+On error, a different error code defined in
+.In fido/err.h
+is returned.
 .Pp
 The pointers returned by
 .Fn fido_dev_info_ptr ,

--- a/man/fido_dev_open.3
+++ b/man/fido_dev_open.3
@@ -7,9 +7,11 @@
 .Os
 .Sh NAME
 .Nm fido_dev_open ,
+.Nm fido_dev_open_with_info ,
 .Nm fido_dev_close ,
 .Nm fido_dev_cancel ,
 .Nm fido_dev_new ,
+.Nm fido_dev_new_with_info ,
 .Nm fido_dev_free ,
 .Nm fido_dev_force_fido2 ,
 .Nm fido_dev_force_u2f ,
@@ -32,11 +34,15 @@
 .Ft int
 .Fn fido_dev_open "fido_dev_t *dev" "const char *path"
 .Ft int
+.Fn fido_dev_open_with_info "fido_dev_t *dev"
+.Ft int
 .Fn fido_dev_close "fido_dev_t *dev"
 .Ft int
 .Fn fido_dev_cancel "fido_dev_t *dev"
 .Ft fido_dev_t *
 .Fn fido_dev_new "void"
+.Ft fido_dev_t *
+.Fn fido_dev_new_with_info "const fido_dev_info_t *"
 .Ft void
 .Fn fido_dev_free "fido_dev_t **dev_p"
 .Ft void
@@ -90,6 +96,14 @@ will fallback to U2F unless the
 .Dv FIDO_DISABLE_U2F_FALLBACK
 flag was set in
 .Xr fido_init 3 .
+The
+.Fn fido_dev_open_with_info
+function can be used only with
+.Fn fido_dev_new_with_info ,
+and opens the device by the
+.Vt fido_dev_info_t
+passed to it, using any specified path, I/O functions, transport
+functions, etc.
 .Pp
 The
 .Fn fido_dev_close
@@ -111,6 +125,16 @@ The
 function returns a pointer to a newly allocated, empty
 .Vt fido_dev_t .
 If memory cannot be allocated, NULL is returned.
+The
+.Fn fido_dev_new_with_info
+function returns a pointer to a newly allocated
+.Vt fido_dev_t
+with
+.Vt fido_dev_info_t
+parameters, for use with
+.Xr fido_dev_info_manifest 3
+and
+.Fn fido_dev_open_with_info .
 .Pp
 The
 .Fn fido_dev_free

--- a/man/fido_dev_set_io_functions.3
+++ b/man/fido_dev_set_io_functions.3
@@ -8,7 +8,9 @@
 .Sh NAME
 .Nm fido_dev_set_io_functions ,
 .Nm fido_dev_set_sigmask ,
-.Nm fido_dev_set_timeout
+.Nm fido_dev_set_timeout ,
+.Nm fido_dev_set_transport_functions ,
+.Nm fido_dev_io_handle
 .Nd FIDO 2 device I/O interface
 .Sh SYNOPSIS
 .In fido.h
@@ -30,13 +32,28 @@ typedef int fido_sigset_t;
 #else
 typedef sigset_t fido_sigset_t;
 #endif
+
+typedef int   fido_dev_rx_t(struct fido_dev *,
+                  uint8_t, unsigned char *, size_t, int);
+typedef int   fido_dev_tx_t(struct fido_dev *,
+                  uint8_t, const unsigned char *, size_t);
+
+typedef struct fido_dev_transport {
+	fido_dev_rx_t *rx;
+	fido_dev_tx_t *tx;
+} fido_dev_transport_t;
 .Ed
+.Pp
 .Ft int
 .Fn fido_dev_set_io_functions "fido_dev_t *dev" "const fido_dev_io_t *io"
 .Ft int
 .Fn fido_dev_set_sigmask "fido_dev_t *dev" "const fido_sigset_t *sigmask"
 .Ft int
 .Fn fido_dev_set_timeout "fido_dev_t *dev" "int ms"
+.Ft int
+.Fn fido_dev_set_transport_functions "fido_dev_t *dev" "const fido_dev_transport_t *t"
+.Ft void *
+.Fn fido_dev_io_handle "fido_dev_t *dev"
 .Sh DESCRIPTION
 The
 .Fn fido_dev_set_io_functions
@@ -148,9 +165,59 @@ This is the default behaviour.
 When using the Windows Hello backend,
 .Fa ms
 is used as a guidance and may be overwritten by the platform.
+.Pp
+The
+.Fn fido_dev_set_transport_functions
+function sets the transport functions used by
+.Em libfido2
+to talk to
+.Fa dev .
+While the I/O handlers are responsible for sending and receiving
+transmission units of initialization and continuation packets already
+formatted by
+.Em libfido2 ,
+the transport handlers are responsible for sending and receiving
+the CTAPHID commands and data directly, as defined in the FIDO Client
+to Authenticator Protocol (CTAP) standard.
+They are defined as follows:
+.Bl -tag -width Ds
+.It Vt fido_dev_tx_t
+Receives a device, a CTAPHID command to transmit, a data buffer to
+transmit, and the length of the data buffer.
+On success, 0 is returned.
+On error, -1 is returned.
+.It Vt fido_dev_rx_t
+Receives a device, a CTAPHID command whose response the caller expects
+to receive, a data buffer to receive into, the size of the data buffer
+determining the maximum length of a response, and the maximum number of
+milliseconds to wait for a response.
+On success, the number of bytes read into the data buffer is returned.
+On error, -1 is returned.
+.El
+.Pp
+When transport functions are specified,
+.Em libfido2
+will use them instead of the
+.Dv read
+and
+.Dv write
+functions of the I/O handlers.
+However, the I/O handlers must still be specified to open and close the
+device.
+.Pp
+The
+.Fn fido_dev_io_handle
+function returns the opaque pointer returned by the
+.Dv open
+function of the I/O handlers.
+This is useful mainly for the transport functions, which unlike the I/O
+handlers are passed the
+.Vt fido_dev_t
+pointer instead of the opaque I/O handle.
 .Sh RETURN VALUES
 On success,
 .Fn fido_dev_set_io_functions ,
+.Fn fido_dev_set_transport_functions ,
 .Fn fido_dev_set_sigmask ,
 and
 .Fn fido_dev_set_timeout
@@ -159,3 +226,13 @@ return
 On error, a different error code defined in
 .In fido/err.h
 is returned.
+.Sh SEE ALSO
+.Xr fido_dev_info_manifest 3 ,
+.Xr fido_dev_open 3
+.Rs
+.%D 2021-06-15
+.%O Proposed Standard, Version 2.1
+.%Q FIDO Alliance
+.%R Client to Authenticator Protocol (CTAP)
+.%U https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html
+.Re

--- a/src/dev.c
+++ b/src/dev.c
@@ -548,6 +548,13 @@ fido_dev_set_transport_functions(fido_dev_t *dev, const fido_dev_transport_t *t)
 	return (FIDO_OK);
 }
 
+void *
+fido_dev_io_handle(const fido_dev_t *dev)
+{
+
+	return (dev->io_handle);
+}
+
 void
 fido_init(int flags)
 {

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -202,6 +202,7 @@
 		fido_dev_info_product_string;
 		fido_dev_info_ptr;
 		fido_dev_info_vendor;
+		fido_dev_io_handle;
 		fido_dev_is_fido2;
 		fido_dev_is_winhello;
 		fido_dev_major;

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -208,7 +208,9 @@
 		fido_dev_make_cred;
 		fido_dev_minor;
 		fido_dev_new;
+		fido_dev_new_with_info;
 		fido_dev_open;
+		fido_dev_open_with_info;
 		fido_dev_protocol;
 		fido_dev_reset;
 		fido_dev_set_io_functions;

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -201,6 +201,7 @@
 		fido_dev_info_product;
 		fido_dev_info_product_string;
 		fido_dev_info_ptr;
+		fido_dev_info_set;
 		fido_dev_info_vendor;
 		fido_dev_io_handle;
 		fido_dev_is_fido2;

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -206,7 +206,9 @@ _fido_dev_major
 _fido_dev_make_cred
 _fido_dev_minor
 _fido_dev_new
+_fido_dev_new_with_info
 _fido_dev_open
+_fido_dev_open_with_info
 _fido_dev_protocol
 _fido_dev_reset
 _fido_dev_set_io_functions

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -200,6 +200,7 @@ _fido_dev_info_product
 _fido_dev_info_product_string
 _fido_dev_info_ptr
 _fido_dev_info_vendor
+_fido_dev_io_handle
 _fido_dev_is_fido2
 _fido_dev_is_winhello
 _fido_dev_major

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -199,6 +199,7 @@ _fido_dev_info_path
 _fido_dev_info_product
 _fido_dev_info_product_string
 _fido_dev_info_ptr
+_fido_dev_info_set
 _fido_dev_info_vendor
 _fido_dev_io_handle
 _fido_dev_is_fido2

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -207,7 +207,9 @@ fido_dev_major
 fido_dev_make_cred
 fido_dev_minor
 fido_dev_new
+fido_dev_new_with_info
 fido_dev_open
+fido_dev_open_with_info
 fido_dev_protocol
 fido_dev_reset
 fido_dev_set_io_functions

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -200,6 +200,7 @@ fido_dev_info_path
 fido_dev_info_product
 fido_dev_info_product_string
 fido_dev_info_ptr
+fido_dev_info_set
 fido_dev_info_vendor
 fido_dev_io_handle
 fido_dev_is_fido2

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -201,6 +201,7 @@ fido_dev_info_product
 fido_dev_info_product_string
 fido_dev_info_ptr
 fido_dev_info_vendor
+fido_dev_io_handle
 fido_dev_is_fido2
 fido_dev_is_winhello
 fido_dev_major

--- a/src/fido.h
+++ b/src/fido.h
@@ -40,6 +40,7 @@ fido_dev_t *fido_dev_new(void);
 fido_dev_t *fido_dev_new_with_info(const fido_dev_info_t *);
 fido_dev_info_t *fido_dev_info_new(size_t);
 fido_cbor_info_t *fido_cbor_info_new(void);
+void *fido_dev_io_handle(const fido_dev_t *);
 
 void fido_assert_free(fido_assert_t **);
 void fido_cbor_info_free(fido_cbor_info_t **);

--- a/src/fido.h
+++ b/src/fido.h
@@ -85,6 +85,8 @@ const char *fido_dev_info_manufacturer_string(const fido_dev_info_t *);
 const char *fido_dev_info_path(const fido_dev_info_t *);
 const char *fido_dev_info_product_string(const fido_dev_info_t *);
 const fido_dev_info_t *fido_dev_info_ptr(const fido_dev_info_t *, size_t);
+int fido_dev_info_set(fido_dev_info_t *, size_t, const char *, const char *,
+    const char *, const fido_dev_io_t *, const fido_dev_transport_t *);
 const uint8_t *fido_cbor_info_protocols_ptr(const fido_cbor_info_t *);
 const unsigned char *fido_cbor_info_aaguid_ptr(const fido_cbor_info_t *);
 const unsigned char *fido_cred_aaguid_ptr(const fido_cred_t *);

--- a/src/hid.c
+++ b/src/hid.c
@@ -148,6 +148,43 @@ fido_dev_info_ptr(const fido_dev_info_t *devlist, size_t i)
 	return (&devlist[i]);
 }
 
+int
+fido_dev_info_set(fido_dev_info_t *devlist, size_t i,
+    const char *path, const char *manufacturer, const char *product,
+    const fido_dev_io_t *io, const fido_dev_transport_t *transport)
+{
+	char *path_copy = NULL, *manu_copy = NULL, *prod_copy = NULL;
+	int r;
+
+	if (path == NULL || manufacturer == NULL || product == NULL ||
+	    io == NULL) {
+		r = FIDO_ERR_INVALID_ARGUMENT;
+		goto out;
+	}
+
+	if ((path_copy = strdup(path)) == NULL ||
+	    (manu_copy = strdup(manufacturer)) == NULL ||
+	    (prod_copy = strdup(product)) == NULL) {
+		r = FIDO_ERR_INTERNAL;
+		goto out;
+	}
+
+	devlist[i].path = path_copy;
+	devlist[i].manufacturer = manu_copy;
+	devlist[i].product = prod_copy;
+	devlist[i].io = *io;
+	if (transport)
+		devlist[i].transport = *transport;
+	r = FIDO_OK;
+out:
+	if (r != FIDO_OK) {
+		free(prod_copy);
+		free(manu_copy);
+		free(path_copy);
+	}
+	return (r);
+}
+
 const char *
 fido_dev_info_path(const fido_dev_info_t *di)
 {


### PR DESCRIPTION
fix https://github.com/Yubico/libfido2/issues/465

For the moment, I didn't provide any way to use _only_ custom transport functions -- it is still necessary to combine custom I/O functions (open and close, but not read or write) with custom transport functions (tx and rx).  This serves for my purposes, but it might be nice if the transport layer operated independently of the I/O layer.  Also, for the moment, the only way to set the device handle is via the I/O open function, which is only passed a path as an argument -- again, adequate for my purposes, but other applications might want simpler control from the caller over the device handle.  (Of course, you could snprintf("%p") and then sscanf it back!)