### PR TITLE
bio: fix CTAP canonical CBOR encoding

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -424,7 +424,7 @@ bio_enroll_begin_wait(fido_dev_t *dev, fido_bio_template_t *t,
 
 	memset(&argv, 0, sizeof(argv));
 
-	if ((argv[2] = cbor_build_uint32(timo_ms)) == NULL) {
+	if ((argv[2] = cbor_build_uint(timo_ms)) == NULL) {
 		fido_log_debug("%s: cbor encode", __func__);
 		goto fail;
 	}
@@ -520,7 +520,7 @@ bio_enroll_continue_wait(fido_dev_t *dev, const fido_bio_template_t *t,
 	memset(&argv, 0, sizeof(argv));
 
 	if ((argv[0] = fido_blob_encode(&t->id)) == NULL ||
-	    (argv[2] = cbor_build_uint32(timo_ms)) == NULL) {
+	    (argv[2] = cbor_build_uint(timo_ms)) == NULL) {
 		fido_log_debug("%s: cbor encode", __func__);
 		goto fail;
 	}


### PR DESCRIPTION
CTAP canonical CBOR encoding establishes that we must use the smallest representation possible for a given integer; as such, even though timo_ms is a uint32_t type, we must use cbor_build_uint() to encode it instead of cbor_build_uint32(), as the value may ultimately fit in a smaller integer type. Fixes #480.