### PR TITLE
stylistic consistency fixes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ image:https://oss-fuzz-build-logs.storage.googleapis.com/badges/libfido2.svg["Fu
 communicate with a FIDO device over USB, and to verify attestation and
 assertion signatures.
 
-*libfido2* supports the FIDO U2F (CTAP 1) and FIDO 2.0 (CTAP 2) protocols.
+*libfido2* supports the FIDO U2F (CTAP 1) and FIDO2 (CTAP 2) protocols.
 
 For usage, see the `examples/` directory.
 

--- a/examples/README.adoc
+++ b/examples/README.adoc
@@ -25,7 +25,7 @@ The following definitions are used in the description below:
 
 - <blobkey>
 
-	A credential's associated FIDO 2.1 "largeBlob" symmetric key.
+	A credential's associated CTAP 2.1 "largeBlob" symmetric key.
 
 === Description
 

--- a/man/eddsa_pk_new.3
+++ b/man/eddsa_pk_new.3
@@ -11,7 +11,7 @@
 .Nm eddsa_pk_from_EVP_PKEY ,
 .Nm eddsa_pk_from_ptr ,
 .Nm eddsa_pk_to_EVP_PKEY
-.Nd FIDO 2 COSE EDDSA API
+.Nd FIDO2 COSE EDDSA API
 .Sh SYNOPSIS
 .In openssl/evp.h
 .In fido/eddsa.h

--- a/man/es256_pk_new.3
+++ b/man/es256_pk_new.3
@@ -12,7 +12,7 @@
 .Nm es256_pk_from_EVP_KEY ,
 .Nm es256_pk_from_ptr ,
 .Nm es256_pk_to_EVP_PKEY
-.Nd FIDO 2 COSE ES256 API
+.Nd FIDO2 COSE ES256 API
 .Sh SYNOPSIS
 .In openssl/ec.h
 .In fido/es256.h

--- a/man/fido2-assert.1
+++ b/man/fido2-assert.1
@@ -7,7 +7,7 @@
 .Os
 .Sh NAME
 .Nm fido2-assert
-.Nd get/verify a FIDO 2 assertion
+.Nd get/verify a FIDO2 assertion
 .Sh SYNOPSIS
 .Nm
 .Fl G
@@ -24,7 +24,7 @@
 .Op Ar type
 .Sh DESCRIPTION
 .Nm
-gets or verifies a FIDO 2 assertion.
+gets or verifies a FIDO2 assertion.
 .Pp
 The input of
 .Nm
@@ -117,7 +117,7 @@ will not expect a credential id in its input, and may output
 multiple assertions.
 Resident credentials are called
 .Dq discoverable credentials
-in FIDO 2.1.
+in CTAP 2.1.
 .It Fl t Ar option
 Toggles a key/value
 .Ar option ,

--- a/man/fido2-cred.1
+++ b/man/fido2-cred.1
@@ -7,7 +7,7 @@
 .Os
 .Sh NAME
 .Nm fido2-cred
-.Nd make/verify a FIDO 2 credential
+.Nd make/verify a FIDO2 credential
 .Sh SYNOPSIS
 .Nm
 .Fl M
@@ -26,7 +26,7 @@
 .Op Ar type
 .Sh DESCRIPTION
 .Nm
-makes or verifies a FIDO 2 credential.
+makes or verifies a FIDO2 credential.
 .Pp
 A credential
 .Ar type
@@ -143,7 +143,7 @@ will fail.
 Create a resident credential.
 Resident credentials are called
 .Dq discoverable credentials
-in FIDO 2.1.
+in CTAP 2.1.
 .It Fl u
 Create a U2F credential.
 By default,

--- a/man/fido2-token.1
+++ b/man/fido2-token.1
@@ -7,7 +7,7 @@
 .Os
 .Sh NAME
 .Nm fido2-token
-.Nd find and manage a FIDO 2 authenticator
+.Nd find and manage a FIDO2 authenticator
 .Sh SYNOPSIS
 .Nm
 .Fl C
@@ -121,7 +121,7 @@
 .Fl V
 .Sh DESCRIPTION
 .Nm
-manages a FIDO 2 authenticator.
+manages a FIDO2 authenticator.
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
@@ -176,12 +176,12 @@ where
 is the enrollment's template base64-encoded id.
 The user will be prompted for the PIN.
 .It Fl D Fl u Ar device
-Disables the FIDO 2.1
+Disables the CTAP 2.1
 .Dq user verification always
 feature on
 .Ar device .
 .It Fl G Fl b Fl k Ar key_path Ar blob_path Ar device
-Gets a FIDO 2.1
+Gets a CTAP 2.1
 .Dq largeBlob
 encrypted with
 .Ar key_path
@@ -194,7 +194,7 @@ The blob is written to
 .Ar blob_path .
 A PIN or equivalent user-verification gesture is required.
 .It Fl G Fl b Fl n Ar rp_id Oo Fl i Ar cred_id Oc Ar blob_path Ar device
-Gets a FIDO 2.1
+Gets a CTAP 2.1
 .Dq largeBlob
 associated with
 .Ar rp_id
@@ -234,7 +234,7 @@ The user will be prompted for the PIN.
 .It Fl L
 Produces a list of authenticators found by the operating system.
 .It Fl L Fl b Ar device
-Produces a list of FIDO 2.1
+Produces a list of CTAP 2.1
 .Dq largeBlobs
 on
 .Ar device .
@@ -264,12 +264,12 @@ Sets the PIN of
 .Ar device .
 The user will be prompted for the PIN.
 .It Fl S Fl a Ar device
-Enables FIDO 2.1 Enterprise Attestation on
+Enables CTAP 2.1 Enterprise Attestation on
 .Ar device .
 .It Fl S Fl b Fl k Ar key_path Ar blob_path Ar device
 Sets
 .Ar blob_path
-as a FIDO 2.1
+as a CTAP 2.1
 .Dq largeBlob
 encrypted with
 .Ar key_path
@@ -284,7 +284,7 @@ A PIN or equivalent user-verification gesture is required.
 .It Fl S Fl b Fl n Ar rp_id Oo Fl i Ar cred_id Oc Ar blob_path Ar device
 Sets
 .Ar blob_path
-as a FIDO 2.1
+as a CTAP 2.1
 .Dq largeBlob
 associated with
 .Ar rp_id
@@ -353,7 +353,7 @@ the minimum PIN length of
 Multiple IDs may be specified, separated by commas.
 The user will be prompted for the PIN.
 .It Fl S Fl u Ar device
-Enables the FIDO 2.1
+Enables the CTAP 2.1
 .Dq user verification always
 feature on
 .Ar device .
@@ -392,9 +392,9 @@ An authenticator's path may contain spaces.
 .Pp
 Resident credentials are called
 .Dq discoverable credentials
-in FIDO 2.1.
+in CTAP 2.1.
 .Pp
-Whether the FIDO 2.1
+Whether the CTAP 2.1
 .Dq user verification always
 feature is activated or deactivated after an authenticator reset
 is vendor-specific.

--- a/man/fido_assert_allow_cred.3
+++ b/man/fido_assert_allow_cred.3
@@ -31,7 +31,7 @@ If
 .Fn fido_assert_allow_cred
 fails, the existing list of allowed credentials is preserved.
 .Pp
-For the format of a FIDO 2 credential ID, please refer to the
+For the format of a FIDO2 credential ID, please refer to the
 Web Authentication (webauthn) standard.
 .Sh RETURN VALUES
 The error codes returned by

--- a/man/fido_assert_new.3
+++ b/man/fido_assert_new.3
@@ -31,7 +31,7 @@
 .Nm fido_assert_id_len ,
 .Nm fido_assert_sigcount ,
 .Nm fido_assert_flags
-.Nd FIDO 2 assertion API
+.Nd FIDO2 assertion API
 .Sh SYNOPSIS
 .In fido.h
 .Ft fido_assert_t *
@@ -85,7 +85,7 @@
 .Ft uint8_t
 .Fn fido_assert_flags "const fido_assert_t *assert" "size_t idx"
 .Sh DESCRIPTION
-FIDO 2 assertions are abstracted in
+FIDO2 assertions are abstracted in
 .Em libfido2
 by the
 .Vt fido_assert_t
@@ -202,7 +202,7 @@ has an
 (index) value of 0.
 .Pp
 The authenticator data and signature parts of an assertion
-statement are typically passed to a FIDO 2 server for verification.
+statement are typically passed to a FIDO2 server for verification.
 .Pp
 The
 .Fn fido_assert_clientdata_hash_ptr

--- a/man/fido_assert_set_authdata.3
+++ b/man/fido_assert_set_authdata.3
@@ -18,7 +18,7 @@
 .Nm fido_assert_set_uv ,
 .Nm fido_assert_set_rp ,
 .Nm fido_assert_set_sig
-.Nd set parameters of a FIDO 2 assertion
+.Nd set parameters of a FIDO2 assertion
 .Sh SYNOPSIS
 .In fido.h
 .Bd -literal
@@ -55,14 +55,14 @@ typedef enum {
 .Sh DESCRIPTION
 The
 .Nm
-set of functions define the various parameters of a FIDO 2
+set of functions define the various parameters of a FIDO2
 assertion, allowing a
 .Fa fido_assert_t
 type to be prepared for a subsequent call to
 .Xr fido_dev_get_assert 3
 or
 .Xr fido_assert_verify 3 .
-For the complete specification of a FIDO 2 assertion and the format
+For the complete specification of a FIDO2 assertion and the format
 of its constituent parts, please refer to the Web Authentication
 (webauthn) standard.
 .Pp
@@ -184,16 +184,16 @@ by default, allowing the authenticator to use its default settings.
 Use of the
 .Nm
 set of functions may happen in two distinct situations:
-when asking a FIDO device to produce a series of assertion
+when asking a FIDO2 device to produce a series of assertion
 statements, prior to
 .Xr fido_dev_get_assert 3
-(i.e, in the context of a FIDO client), or when verifying assertion
+(i.e, in the context of a FIDO2 client), or when verifying assertion
 statements using
 .Xr fido_assert_verify 3
-(i.e, in the context of a FIDO server).
+(i.e, in the context of a FIDO2 server).
 .Pp
-For a complete description of the generation of a FIDO 2 assertion
-and its verification, please refer to the FIDO 2 specification.
+For a complete description of the generation of a FIDO2 assertion
+and its verification, please refer to the FIDO2 specification.
 An example of how to use the
 .Nm
 set of functions can be found in the
@@ -202,7 +202,7 @@ file shipped with
 .Em libfido2 .
 .Pp
 .Fn fido_assert_set_hmac_secret
-is not normally useful in a FIDO client or server \(em it is provided
+is not normally useful in a FIDO2 client or server \(em it is provided
 to enable testing other functionality that relies on retrieving the
 HMAC secret from an assertion obtained from an authenticator.
 .Sh RETURN VALUES

--- a/man/fido_assert_verify.3
+++ b/man/fido_assert_verify.3
@@ -7,7 +7,7 @@
 .Os
 .Sh NAME
 .Nm fido_assert_verify
-.Nd verifies the signature of a FIDO 2 assertion statement
+.Nd verifies the signature of a FIDO2 assertion statement
 .Sh SYNOPSIS
 .In fido.h
 .Ft int
@@ -23,7 +23,7 @@ matches the parameters of the assertion.
 Before using
 .Fn fido_assert_verify
 in a sensitive context, the reader is strongly encouraged to make
-herself familiar with the FIDO 2 assertion statement process
+herself familiar with the FIDO2 assertion statement process
 as defined in the Web Authentication (webauthn) standard.
 .Pp
 A brief description follows:

--- a/man/fido_bio_dev_get_info.3
+++ b/man/fido_bio_dev_get_info.3
@@ -13,7 +13,7 @@
 .Nm fido_bio_dev_enroll_remove ,
 .Nm fido_bio_dev_get_template_array ,
 .Nm fido_bio_dev_set_template_name
-.Nd FIDO 2 biometric authenticator API
+.Nd FIDO2 biometric authenticator API
 .Sh SYNOPSIS
 .In fido.h
 .In fido/bio.h

--- a/man/fido_bio_enroll_new.3
+++ b/man/fido_bio_enroll_new.3
@@ -10,7 +10,7 @@
 .Nm fido_bio_enroll_free ,
 .Nm fido_bio_enroll_last_status ,
 .Nm fido_bio_enroll_remaining_samples
-.Nd FIDO 2 biometric enrollment API
+.Nd FIDO2 biometric enrollment API
 .Sh SYNOPSIS
 .In fido.h
 .In fido/bio.h
@@ -40,7 +40,7 @@
 .Ft uint8_t
 .Fn fido_bio_enroll_remaining_samples "const fido_bio_enroll_t *enroll"
 .Sh DESCRIPTION
-Ongoing FIDO 2 biometric enrollments are abstracted in
+Ongoing FIDO2 biometric enrollments are abstracted in
 .Em libfido2
 by the
 .Vt fido_bio_enroll_t

--- a/man/fido_bio_info_new.3
+++ b/man/fido_bio_info_new.3
@@ -10,7 +10,7 @@
 .Nm fido_bio_info_free ,
 .Nm fido_bio_info_type ,
 .Nm fido_bio_info_max_samples
-.Nd FIDO 2 biometric sensor information API
+.Nd FIDO2 biometric sensor information API
 .Sh SYNOPSIS
 .In fido.h
 .In fido/bio.h

--- a/man/fido_bio_template.3
+++ b/man/fido_bio_template.3
@@ -17,7 +17,7 @@
 .Nm fido_bio_template_new ,
 .Nm fido_bio_template_set_id ,
 .Nm fido_bio_template_set_name
-.Nd FIDO 2 biometric template API
+.Nd FIDO2 biometric template API
 .Sh SYNOPSIS
 .In fido.h
 .In fido/bio.h
@@ -44,7 +44,7 @@
 .Ft const fido_bio_template_t *
 .Fn fido_bio_template "const fido_bio_template_array_t *array" "size_t idx"
 .Sh DESCRIPTION
-Existing FIDO 2 biometric enrollments are abstracted in
+Existing FIDO2 biometric enrollments are abstracted in
 .Em libfido2
 by the
 .Vt fido_bio_template_t

--- a/man/fido_cbor_info_new.3
+++ b/man/fido_cbor_info_new.3
@@ -29,7 +29,7 @@
 .Nm fido_cbor_info_maxcredcntlst ,
 .Nm fido_cbor_info_maxcredidlen ,
 .Nm fido_cbor_info_fwversion
-.Nd FIDO 2 CBOR Info API
+.Nd FIDO2 CBOR Info API
 .Sh SYNOPSIS
 .In fido.h
 .Ft fido_cbor_info_t *

--- a/man/fido_cred_exclude.3
+++ b/man/fido_cred_exclude.3
@@ -44,7 +44,7 @@ then
 .Xr fido_dev_make_cred 3
 will fail.
 .Pp
-For the format of a FIDO 2 credential ID, please refer to the
+For the format of a FIDO2 credential ID, please refer to the
 Web Authentication (webauthn) standard.
 .Sh RETURN VALUES
 The error codes returned by

--- a/man/fido_cred_new.3
+++ b/man/fido_cred_new.3
@@ -40,7 +40,7 @@
 .Nm fido_cred_type ,
 .Nm fido_cred_flags ,
 .Nm fido_cred_sigcount
-.Nd FIDO 2 credential API
+.Nd FIDO2 credential API
 .Sh SYNOPSIS
 .In fido.h
 .Ft fido_cred_t *
@@ -112,7 +112,7 @@
 .Ft uint32_t
 .Fn fido_cred_sigcount "const fido_cred_t *cred"
 .Sh DESCRIPTION
-FIDO 2 credentials are abstracted in
+FIDO2 credentials are abstracted in
 .Em libfido2
 by the
 .Vt fido_cred_t
@@ -155,7 +155,7 @@ may be NULL, in which case
 .Fn fido_cred_free
 is a NOP.
 .Pp
-If the FIDO 2.1
+If the CTAP 2.1
 .Dv FIDO_EXT_MINPINLEN
 extension is enabled on
 .Fa cred ,
@@ -170,7 +170,7 @@ See
 .Xr fido_cred_set_pin_minlen 3
 on how to enable this extension.
 .Pp
-If the FIDO 2.1
+If the CTAP 2.1
 .Dv FIDO_EXT_CRED_PROTECT
 extension is enabled on
 .Fa cred ,
@@ -243,7 +243,7 @@ and
 .Fn fido_cred_attstmt_len .
 .Pp
 The authenticator data, x509 certificate, and signature parts of a
-credential are typically passed to a FIDO 2 server for verification.
+credential are typically passed to a FIDO2 server for verification.
 .Pp
 The
 .Fn fido_cred_type

--- a/man/fido_cred_set_authdata.3
+++ b/man/fido_cred_set_authdata.3
@@ -24,7 +24,7 @@
 .Nm fido_cred_set_uv ,
 .Nm fido_cred_set_fmt ,
 .Nm fido_cred_set_type
-.Nd set parameters of a FIDO 2 credential
+.Nd set parameters of a FIDO2 credential
 .Sh SYNOPSIS
 .In fido.h
 .Bd -literal
@@ -73,14 +73,14 @@ typedef enum {
 .Sh DESCRIPTION
 The
 .Nm
-set of functions define the various parameters of a FIDO 2
+set of functions define the various parameters of a FIDO2
 credential, allowing a
 .Fa fido_cred_t
 type to be prepared for a subsequent call to
 .Xr fido_dev_make_cred 3
 or
 .Xr fido_cred_verify 3 .
-For the complete specification of a FIDO 2 credential and the format
+For the complete specification of a FIDO2 credential and the format
 of its constituent parts, please refer to the Web Authentication
 (webauthn) standard.
 .Pp
@@ -229,7 +229,7 @@ bytes long.
 .Pp
 The
 .Fn fido_cred_set_pin_minlen
-function enables the FIDO 2.1
+function enables the CTAP 2.1
 .Dv FIDO_EXT_MINPINLEN
 extension on
 .Fa cred
@@ -249,7 +249,7 @@ extension is disabled on
 .Pp
 The
 .Fn fido_cred_set_prot
-function enables the FIDO 2.1
+function enables the CTAP 2.1
 .Dv FIDO_EXT_CRED_PROTECT
 extension on
 .Fa cred
@@ -325,15 +325,15 @@ Note that not all authenticators support COSE_RS256 or COSE_EDDSA.
 Use of the
 .Nm
 set of functions may happen in two distinct situations:
-when generating a new credential on a FIDO device, prior to
+when generating a new credential on a FIDO2 device, prior to
 .Xr fido_dev_make_cred 3
-(i.e, in the context of a FIDO client), or when validating
+(i.e, in the context of a FIDO2 client), or when validating
 a generated credential using
 .Xr fido_cred_verify 3
-(i.e, in the context of a FIDO server).
+(i.e, in the context of a FIDO2 server).
 .Pp
-For a complete description of the generation of a FIDO 2 credential
-and its verification, please refer to the FIDO 2 specification.
+For a complete description of the generation of a FIDO2 credential
+and its verification, please refer to the FIDO2 specification.
 A concrete utilisation example of the
 .Nm
 set of functions can be found in the

--- a/man/fido_cred_verify.3
+++ b/man/fido_cred_verify.3
@@ -7,7 +7,7 @@
 .Os
 .Sh NAME
 .Nm fido_cred_verify
-.Nd verifies the attestation signature of a FIDO 2 credential
+.Nd verifies the attestation signature of a FIDO2 credential
 .Sh SYNOPSIS
 .In fido.h
 .Ft int
@@ -21,7 +21,7 @@ matches the attributes of the credential.
 Before using
 .Fn fido_cred_verify
 in a sensitive context, the reader is strongly encouraged to make
-herself familiar with the FIDO 2 credential attestation process
+herself familiar with the FIDO2 credential attestation process
 as defined in the Web Authentication (webauthn) standard.
 .Pp
 A brief description follows:

--- a/man/fido_credman_metadata_new.3
+++ b/man/fido_credman_metadata_new.3
@@ -26,7 +26,7 @@
 .Nm fido_credman_set_dev_rk ,
 .Nm fido_credman_del_dev_rk ,
 .Nm fido_credman_get_dev_rp
-.Nd FIDO 2 credential management API
+.Nd FIDO2 credential management API
 .Sh SYNOPSIS
 .In fido.h
 .In fido/credman.h
@@ -323,4 +323,4 @@ should have their return values checked for NULL.
 .Sh CAVEATS
 Resident credentials are called
 .Dq discoverable credentials
-in FIDO 2.1.
+in CTAP 2.1.

--- a/man/fido_dev_enable_entattest.3
+++ b/man/fido_dev_enable_entattest.3
@@ -11,7 +11,7 @@
 .Nm fido_dev_force_pin_change ,
 .Nm fido_dev_set_pin_minlen ,
 .Nm fido_dev_set_pin_minlen_rpid
-.Nd FIDO 2.1 configuration authenticator API
+.Nd CTAP 2.1 configuration authenticator API
 .Sh SYNOPSIS
 .In fido.h
 .In fido/config.h
@@ -27,7 +27,7 @@
 .Fn fido_dev_set_pin_minlen_rpid "fido_dev_t *dev" "const char * const *rpid" "size_t n" "const char *pin"
 .Sh DESCRIPTION
 The functions described in this page allow configuration of a
-FIDO 2.1 authenticator.
+CTAP 2.1 authenticator.
 .Pp
 The
 .Fn fido_dev_enable_entattest
@@ -86,7 +86,7 @@ function sets the list of relying party identifiers
 .Pq RP IDs
 that are allowed to obtain the minimum PIN length of
 .Fa dev
-through the FIDO 2.1
+through the CTAP 2.1
 .Dv FIDO_EXT_MINPINLEN
 extension.
 The list of RP identifiers is denoted by

--- a/man/fido_dev_get_assert.3
+++ b/man/fido_dev_get_assert.3
@@ -7,7 +7,7 @@
 .Os
 .Sh NAME
 .Nm fido_dev_get_assert
-.Nd obtains an assertion from a FIDO device
+.Nd obtains an assertion from a FIDO2 device
 .Sh SYNOPSIS
 .In fido.h
 .Ft int
@@ -15,7 +15,7 @@
 .Sh DESCRIPTION
 The
 .Fn fido_dev_get_assert
-function asks the FIDO device represented by
+function asks the FIDO2 device represented by
 .Fa dev
 for an assertion according to the following parameters defined in
 .Fa assert :

--- a/man/fido_dev_get_touch_begin.3
+++ b/man/fido_dev_get_touch_begin.3
@@ -8,7 +8,7 @@
 .Sh NAME
 .Nm fido_dev_get_touch_begin ,
 .Nm fido_dev_get_touch_status
-.Nd asynchronously wait for touch on a FIDO 2 authenticator
+.Nd asynchronously wait for touch on a FIDO2 authenticator
 .Sh SYNOPSIS
 .In fido.h
 .Ft int
@@ -17,7 +17,7 @@
 .Fn fido_dev_get_touch_status "fido_dev_t *dev" "int *touched" "int ms"
 .Sh DESCRIPTION
 The functions described in this page allow an application to
-asynchronously wait for touch on a FIDO authenticator.
+asynchronously wait for touch on a FIDO2 authenticator.
 This is useful when multiple authenticators are present and
 the application needs to know which one to use.
 .Pp

--- a/man/fido_dev_info_manifest.3
+++ b/man/fido_dev_info_manifest.3
@@ -16,7 +16,7 @@
 .Nm fido_dev_info_manufacturer_string ,
 .Nm fido_dev_info_product_string ,
 .Nm fido_dev_info_set
-.Nd FIDO 2 device discovery functions
+.Nd FIDO2 device discovery functions
 .Sh SYNOPSIS
 .In fido.h
 .Ft int
@@ -46,7 +46,7 @@ function fills
 .Fa devlist
 with up to
 .Fa ilen
-FIDO devices found by the underlying operating system.
+FIDO2 devices found by the underlying operating system.
 Currently only USB HID devices are supported.
 The number of discovered devices is returned in
 .Fa olen ,
@@ -156,7 +156,7 @@ automatically by
 .Xr fido_dev_new_with_info 3
 and
 .Xr fido_dev_open_with_info 3 .
-An application can use this, for example, to substitute mock FIDO
+An application can use this, for example, to substitute mock FIDO2
 devices in testing for the real ones that
 .Fn fido_dev_info_manifest
 would discover.

--- a/man/fido_dev_largeblob_get.3
+++ b/man/fido_dev_largeblob_get.3
@@ -11,7 +11,7 @@
 .Nm fido_dev_largeblob_remove ,
 .Nm fido_dev_largeblob_get_array ,
 .Nm fido_dev_largeblob_set_array
-.Nd FIDO 2 large blob API
+.Nd FIDO2 large blob API
 .Sh SYNOPSIS
 .In fido.h
 .Ft int
@@ -29,10 +29,10 @@ The
 .Dq largeBlobs
 API of
 .Em libfido2
-allows binary blobs residing on a FIDO 2.1 authenticator to be
+allows binary blobs residing on a CTAP 2.1 authenticator to be
 read, written, and inspected.
 .Dq largeBlobs
-is a FIDO 2.1 extension.
+is a CTAP 2.1 extension.
 .Pp
 .Dq largeBlobs
 are stored as elements of a CBOR array.
@@ -58,9 +58,9 @@ The
 .Dq largeBlobs
 CBOR array is opaque to the authenticator.
 Management of the array is left at the discretion of FIDO2 clients.
-For further details on FIDO 2.1's
+For further details on CTAP 2.1's
 .Dq largeBlobs
-extension, please refer to the FIDO 2.1 spec.
+extension, please refer to the CTAP 2.1 spec.
 .Pp
 The
 .Fn fido_dev_largeblob_get

--- a/man/fido_dev_make_cred.3
+++ b/man/fido_dev_make_cred.3
@@ -7,7 +7,7 @@
 .Os
 .Sh NAME
 .Nm fido_dev_make_cred
-.Nd generates a new credential on a FIDO device
+.Nd generates a new credential on a FIDO2 device
 .Sh SYNOPSIS
 .In fido.h
 .Ft int
@@ -15,7 +15,7 @@
 .Sh DESCRIPTION
 The
 .Fn fido_dev_make_cred
-function asks the FIDO device represented by
+function asks the FIDO2 device represented by
 .Fa dev
 to generate a new credential according to the following parameters
 defined in

--- a/man/fido_dev_open.3
+++ b/man/fido_dev_open.3
@@ -28,7 +28,7 @@
 .Nm fido_dev_flags ,
 .Nm fido_dev_major ,
 .Nm fido_dev_minor
-.Nd FIDO 2 device open/close and related functions
+.Nd FIDO2 device open/close and related functions
 .Sh SYNOPSIS
 .In fido.h
 .Ft int
@@ -177,7 +177,7 @@ function returns
 .Dv true
 if
 .Fa dev
-is a FIDO 2 device.
+is a FIDO2 device.
 .Pp
 The
 .Fn fido_dev_is_winhello
@@ -193,7 +193,7 @@ function returns
 .Dv true
 if
 .Fa dev
-supports FIDO 2.1 Credential Management.
+supports CTAP 2.1 Credential Management.
 .Pp
 The
 .Fn fido_dev_supports_cred_prot
@@ -201,7 +201,7 @@ function returns
 .Dv true
 if
 .Fa dev
-supports FIDO 2.1 Credential Protection.
+supports CTAP 2.1 Credential Protection.
 .Pp
 The
 .Fn fido_dev_supports_pin
@@ -209,7 +209,7 @@ function returns
 .Dv true
 if
 .Fa dev
-supports FIDO 2.0 Client PINs.
+supports CTAP 2.0 Client PINs.
 .Pp
 The
 .Fn fido_dev_has_pin
@@ -217,7 +217,7 @@ function returns
 .Dv true
 if
 .Fa dev
-has a FIDO 2.0 Client PIN set.
+has a CTAP 2.0 Client PIN set.
 .Pp
 The
 .Fn fido_dev_supports_uv

--- a/man/fido_dev_set_io_functions.3
+++ b/man/fido_dev_set_io_functions.3
@@ -11,7 +11,7 @@
 .Nm fido_dev_set_timeout ,
 .Nm fido_dev_set_transport_functions ,
 .Nm fido_dev_io_handle
-.Nd FIDO 2 device I/O interface
+.Nd FIDO2 device I/O interface
 .Sh SYNOPSIS
 .In fido.h
 .Bd -literal

--- a/man/fido_dev_set_pin.3
+++ b/man/fido_dev_set_pin.3
@@ -10,7 +10,7 @@
 .Nm fido_dev_get_retry_count ,
 .Nm fido_dev_get_uv_retry_count ,
 .Nm fido_dev_reset
-.Nd FIDO 2 device management functions
+.Nd FIDO2 device management functions
 .Sh SYNOPSIS
 .In fido.h
 .Ft int

--- a/man/fido_init.3
+++ b/man/fido_init.3
@@ -7,7 +7,7 @@
 .Os
 .Sh NAME
 .Nm fido_init
-.Nd initialise the FIDO 2 library
+.Nd initialise the FIDO2 library
 .Sh SYNOPSIS
 .In fido.h
 .Ft void

--- a/man/fido_strerr.3
+++ b/man/fido_strerr.3
@@ -7,7 +7,7 @@
 .Os
 .Sh NAME
 .Nm fido_strerr
-.Nd FIDO 2 error codes
+.Nd FIDO2 error codes
 .Sh SYNOPSIS
 .In fido.h
 .Ft const char *

--- a/man/rs256_pk_new.3
+++ b/man/rs256_pk_new.3
@@ -12,7 +12,7 @@
 .Nm rs256_pk_from_RSA ,
 .Nm rs256_pk_from_ptr ,
 .Nm rs256_pk_to_EVP_PKEY
-.Nd FIDO 2 COSE RS256 API
+.Nd FIDO2 COSE RS256 API
 .Sh SYNOPSIS
 .In openssl/rsa.h
 .In fido/rs256.h

--- a/src/fido/types.h
+++ b/src/fido/types.h
@@ -151,13 +151,13 @@ typedef struct fido_cred {
 	fido_attcred_t    attcred;       /* returned credential (key + id) */
 	fido_attstmt_t    attstmt;       /* attestation statement (x509 + sig) */
 	fido_blob_t       largeblob_key; /* decoded large blob key */
-	fido_blob_t       blob;          /* FIDO 2.1 credBlob */
+	fido_blob_t       blob;          /* CTAP 2.1 credBlob */
 } fido_cred_t;
 
 typedef struct fido_assert_extattr {
 	int         mask;            /* decoded extensions */
 	fido_blob_t hmac_secret_enc; /* hmac secret, encrypted */
-	fido_blob_t blob;            /* decoded FIDO 2.1 credBlob */
+	fido_blob_t blob;            /* decoded CTAP 2.1 credBlob */
 } fido_assert_extattr_t;
 
 typedef struct _fido_assert_stmt {


### PR DESCRIPTION
- use FIDO2 when referring to FIDO2 as a concept;
- use CTAP when talking about a specific protocol version.