### PR TITLE
.actions: git -> https

### DIFF
--- a/.actions/build-linux-i686-w64-mingw32-gcc
+++ b/.actions/build-linux-i686-w64-mingw32-gcc
@@ -18,7 +18,7 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 EOF
 
 # Build and install libcbor.
-git clone --depth=1 git://github.com/pjk/libcbor -b v0.9.0
+git clone --depth=1 https://github.com/pjk/libcbor -b v0.9.0
 cd libcbor
 mkdir build
 (cd build && cmake -DCMAKE_TOOLCHAIN_FILE=/tmp/mingw.cmake \
@@ -28,7 +28,7 @@ sudo make -C build install
 cd ..
 
 # Build and install OpenSSL 1.1.1l.
-git clone --depth=1 git://github.com/openssl/openssl -b OpenSSL_1_1_1l
+git clone --depth=1 https://github.com/openssl/openssl -b OpenSSL_1_1_1l
 cd openssl
 ./Configure mingw --prefix=/fakeroot --openssldir=/fakeroot/openssl \
 	--cross-compile-prefix=i686-w64-mingw32-

--- a/.actions/build-linux-openssl3-i686-w64-mingw32-gcc
+++ b/.actions/build-linux-openssl3-i686-w64-mingw32-gcc
@@ -18,7 +18,7 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 EOF
 
 # Build and install libcbor.
-git clone --depth=1 git://github.com/pjk/libcbor -b v0.9.0
+git clone --depth=1 https://github.com/pjk/libcbor -b v0.9.0
 cd libcbor
 mkdir build
 (cd build && cmake -DCMAKE_TOOLCHAIN_FILE=/tmp/mingw.cmake \
@@ -29,7 +29,7 @@ cd ..
 
 # Build and install OpenSSL 3.0.1.
 git clone --branch openssl-3.0.1 \
-	--depth=1 git://github.com/openssl/openssl
+	--depth=1 https://github.com/openssl/openssl
 cd openssl
 ./Configure mingw --prefix=/fakeroot --openssldir=/fakeroot/openssl \
 	--cross-compile-prefix=i686-w64-mingw32- --libdir=lib

--- a/.actions/fuzz-linux
+++ b/.actions/fuzz-linux
@@ -4,13 +4,13 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-LIBCBOR_URL="git://github.com/pjk/libcbor"
+LIBCBOR_URL="https://github.com/pjk/libcbor"
 LIBCBOR_TAG="v0.9.0"
 LIBCBOR_ASAN="address alignment bounds"
 LIBCBOR_MSAN="memory"
-OPENSSL_URL="git://github.com/openssl/openssl"
+OPENSSL_URL="https://github.com/openssl/openssl"
 OPENSSL_TAG="OpenSSL_1_1_1l"
-ZLIB_URL="git://github.com/madler/zlib"
+ZLIB_URL="https://github.com/madler/zlib"
 ZLIB_TAG="v1.2.11"
 ZLIB_ASAN="address alignment bounds undefined"
 ZLIB_MSAN="memory"


### PR DESCRIPTION
the unauthenticated git protocol on port 9418 (git://) is no longer supported by github.