### PR TITLE
more docs

### DIFF
--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -247,6 +247,7 @@ list(APPEND MAN_ALIAS
 	fido_dev_largeblob_get fido_dev_largeblob_remove
 	fido_dev_largeblob_get fido_dev_largeblob_get_array
 	fido_dev_largeblob_get fido_dev_largeblob_set_array
+	fido_init fido_set_log_handler
 	rs256_pk_new rs256_pk_free
 	rs256_pk_new rs256_pk_from_ptr
 	rs256_pk_new rs256_pk_from_EVP_PKEY

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -234,6 +234,7 @@ list(APPEND MAN_ALIAS
 	fido_dev_open fido_dev_protocol
 	fido_dev_open fido_dev_supports_cred_prot
 	fido_dev_open fido_dev_supports_credman
+	fido_dev_open fido_dev_supports_permissions
 	fido_dev_open fido_dev_supports_pin
 	fido_dev_open fido_dev_supports_uv
 	fido_dev_set_pin fido_dev_get_retry_count

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -165,6 +165,7 @@ list(APPEND MAN_ALIAS
 	fido_cred_new fido_cred_user_name
 	fido_cred_new fido_cred_x5c_len
 	fido_cred_new fido_cred_x5c_ptr
+	fido_cred_verify fido_cred_verify_self
 	fido_credman_metadata_new fido_credman_del_dev_rk
 	fido_credman_metadata_new fido_credman_get_dev_metadata
 	fido_credman_metadata_new fido_credman_get_dev_rk

--- a/man/fido_cred_verify.3
+++ b/man/fido_cred_verify.3
@@ -6,25 +6,30 @@
 .Dt FIDO_CRED_VERIFY 3
 .Os
 .Sh NAME
-.Nm fido_cred_verify
-.Nd verifies the attestation signature of a FIDO2 credential
+.Nm fido_cred_verify ,
+.Nm fido_cred_verify_self
+.Nd verify the attestation signature of a FIDO2 credential
 .Sh SYNOPSIS
 .In fido.h
 .Ft int
 .Fn fido_cred_verify "const fido_cred_t *cred"
+.Ft int
+.Fn fido_cred_verify_self "const fido_cred_t *cred"
 .Sh DESCRIPTION
 The
 .Fn fido_cred_verify
-function verifies whether the attestation signature contained in
+and
+.Fn fido_cred_verify_self
+functions verify whether the attestation signature contained in
 .Fa cred
 matches the attributes of the credential.
 Before using
 .Fn fido_cred_verify
+or
+.Fn fido_cred_verify_self
 in a sensitive context, the reader is strongly encouraged to make
 herself familiar with the FIDO2 credential attestation process
 as defined in the Web Authentication (webauthn) standard.
-.Pp
-A brief description follows:
 .Pp
 The
 .Fn fido_cred_verify
@@ -48,17 +53,34 @@ The attestation type implemented by
 .Fn fido_cred_verify
 is
 .Em Basic Attestation .
+.Pp
+The
+.Fn fido_cred_verify_self
+function verifies whether the client data hash, relying party ID,
+credential ID, type, protection policy, minimum PIN length, and
+resident/discoverable key and user verification attributes of
+.Fa cred
+have been attested by the holder of the credential's private key.
+.Pp
+The attestation statement formats supported by
+.Fn fido_cred_verify_self
+are
+.Em packed
+and
+.Em fido-u2f .
+The attestation type implemented by
+.Fn fido_cred_verify_self
+is
+.Em Self Attestation .
+.Pp
 Other attestation formats and types are not supported.
 .Sh RETURN VALUES
 The error codes returned by
 .Fn fido_cred_verify
+and
+.Fn fido_cred_verify_self
 are defined in
 .In fido/err.h .
-If
-.Fa cred
-does not contain attestation data, then
-.Dv FIDO_ERR_INVALID_ARGUMENT
-is returned.
 If
 .Fa cred
 passes verification, then

--- a/man/fido_credman_metadata_new.3
+++ b/man/fido_credman_metadata_new.3
@@ -307,7 +307,7 @@ The
 .Fn fido_credman_set_dev_rk ,
 .Fn fido_credman_del_dev_rk ,
 and
-.Fn  fido_credman_get_dev_rp
+.Fn fido_credman_get_dev_rp
 functions return
 .Dv FIDO_OK
 on success.

--- a/man/fido_dev_open.3
+++ b/man/fido_dev_open.3
@@ -19,9 +19,10 @@
 .Nm fido_dev_is_winhello ,
 .Nm fido_dev_supports_credman ,
 .Nm fido_dev_supports_cred_prot ,
+.Nm fido_dev_supports_permissions ,
 .Nm fido_dev_supports_pin ,
-.Nm fido_dev_has_pin ,
 .Nm fido_dev_supports_uv ,
+.Nm fido_dev_has_pin ,
 .Nm fido_dev_has_uv ,
 .Nm fido_dev_protocol ,
 .Nm fido_dev_build ,
@@ -58,11 +59,13 @@
 .Ft bool
 .Fn fido_dev_supports_cred_prot "const fido_dev_t *dev"
 .Ft bool
+.Fn fido_dev_supports_permissions "const fido_dev_t *dev"
+.Ft bool
 .Fn fido_dev_supports_pin "const fido_dev_t *dev"
 .Ft bool
-.Fn fido_dev_has_pin "const fido_dev_t *dev"
-.Ft bool
 .Fn fido_dev_supports_uv "const fido_dev_t *dev"
+.Ft bool
+.Fn fido_dev_has_pin "const fido_dev_t *dev"
 .Ft bool
 .Fn fido_dev_has_uv "const fido_dev_t *dev"
 .Ft uint8_t
@@ -205,6 +208,14 @@ if
 supports CTAP 2.1 Credential Protection.
 .Pp
 The
+.Fn fido_dev_supports_permissions
+function returns
+.Dv true
+if
+.Fa dev
+supports CTAP 2.1 UV token permissions.
+.Pp
+The
 .Fn fido_dev_supports_pin
 function returns
 .Dv true
@@ -213,20 +224,20 @@ if
 supports CTAP 2.0 Client PINs.
 .Pp
 The
-.Fn fido_dev_has_pin
-function returns
-.Dv true
-if
-.Fa dev
-has a CTAP 2.0 Client PIN set.
-.Pp
-The
 .Fn fido_dev_supports_uv
 function returns
 .Dv true
 if
 .Fa dev
 supports a built-in user verification method.
+.Pp
+The
+.Fn fido_dev_has_pin
+function returns
+.Dv true
+if
+.Fa dev
+has a CTAP 2.0 Client PIN set.
 .Pp
 The
 .Fn fido_dev_has_uv

--- a/man/fido_init.3
+++ b/man/fido_init.3
@@ -6,12 +6,19 @@
 .Dt FIDO_INIT 3
 .Os
 .Sh NAME
-.Nm fido_init
+.Nm fido_init ,
+.Nm fido_set_log_handler
 .Nd initialise the FIDO2 library
 .Sh SYNOPSIS
 .In fido.h
+.Bd -literal
+typedef void fido_log_handler_t(const char *);
+.Ed
+.Pp
 .Ft void
 .Fn fido_init "int flags"
+.Ft void
+.Fn fido_set_log_handler "fido_log_handler_t *handler"
 .Sh DESCRIPTION
 The
 .Fn fido_init
@@ -43,8 +50,21 @@ then
 .Em libfido2
 will not fallback to U2F in
 .Xr fido_dev_open 3
-if a device claims to be FIDO2 but fails to respond to a
-FIDO2 command.
+if a device claims to be FIDO2 but fails to respond to
+FIDO2 commands.
+.Pp
+The
+.Fn fido_set_log_handler
+function causes
+.Fa handler
+to be called for each log line generated in the context of the
+executing thread.
+Lines passed to
+.Fa handler
+include a trailing newline character and are not printed by
+.Em libfido2
+on
+.Em stderr .
 .Sh SEE ALSO
 .Xr fido_assert_new 3 ,
 .Xr fido_cred_new 3 ,

--- a/man/fido_init.3
+++ b/man/fido_init.3
@@ -50,8 +50,8 @@ then
 .Em libfido2
 will not fallback to U2F in
 .Xr fido_dev_open 3
-if a device claims to be FIDO2 but fails to respond to
-FIDO2 commands.
+if a device claims to support FIDO2 but fails to respond to
+a CTAP 2.0 greeting.
 .Pp
 The
 .Fn fido_set_log_handler

--- a/src/extern.h
+++ b/src/extern.h
@@ -178,7 +178,6 @@ int fido_dev_get_uv_token(fido_dev_t *, uint8_t, const char *,
     int *);
 uint64_t fido_dev_maxmsgsize(const fido_dev_t *);
 int fido_do_ecdh(fido_dev_t *, es256_pk_t **, fido_blob_t **, int *);
-bool fido_dev_supports_permissions(const fido_dev_t *);
 
 /* types */
 void fido_algo_array_free(fido_algo_array_t *);

--- a/src/fido.h
+++ b/src/fido.h
@@ -215,9 +215,10 @@ bool fido_dev_has_pin(const fido_dev_t *);
 bool fido_dev_has_uv(const fido_dev_t *);
 bool fido_dev_is_fido2(const fido_dev_t *);
 bool fido_dev_is_winhello(const fido_dev_t *);
-bool fido_dev_supports_pin(const fido_dev_t *);
-bool fido_dev_supports_cred_prot(const fido_dev_t *);
 bool fido_dev_supports_credman(const fido_dev_t *);
+bool fido_dev_supports_cred_prot(const fido_dev_t *);
+bool fido_dev_supports_permissions(const fido_dev_t *);
+bool fido_dev_supports_pin(const fido_dev_t *);
 bool fido_dev_supports_uv(const fido_dev_t *);
 
 int fido_dev_largeblob_get(fido_dev_t *, const unsigned char *, size_t,


### PR DESCRIPTION
add documentation for:
- fido_set_log_handler;
- fido_cred_verify_self;
- fido_dev_supports_permissions.

while here, move fido_dev_supports_permissions's prototype from extern.h to fido.h, so it is picked up by applications.