### PR TITLE
translate_fido_assert: return matching error code for up required

### DIFF
--- a/src/winhello.c
+++ b/src/winhello.c
@@ -508,7 +508,7 @@ translate_fido_assert(struct winhello_assert *ctx, const fido_assert_t *assert,
 	/* not supported by webauthn.h */
 	if (assert->up == FIDO_OPT_FALSE) {
 		fido_log_debug("%s: up %d", __func__, assert->up);
-		return FIDO_ERR_UNSUPPORTED_OPTION;
+		return FIDO_ERR_USER_PRESENCE_REQUIRED;
 	}
 	/* not implemented */
 	if (assert->ext.mask) {

--- a/src/winhello.c
+++ b/src/winhello.c
@@ -883,7 +883,7 @@ fido_winhello_get_cbor_info(fido_dev_t *dev, fido_cbor_info_t *ci)
 	const char *v[3] = { "U2F_V2", "FIDO_2_0", "FIDO_2_1_PRE" };
 	const char *e[2] = { "credProtect", "hmac-secret" };
 	const char *t[2] = { "nfc", "usb" };
-	const char *o[4] = { "rk", "up", "plat", "clientPin" };
+	const char *o[4] = { "rk", "up", "plat", "uv" };
 
 	(void)dev;
 


### PR DESCRIPTION
A call to fido_dev_get_assert not requesting user presence should
return FIDO_ERR_USER_PRESENCE_REQUIRED for WinHello devices.

This is, for instance, expected by OpenSSH code.

Signed-off-by: Corinna Vinschen <vinschen@redhat.com>