### PR TITLE
Advertise "uv" capability, not "clientPin".

### DIFF
--- a/src/winhello.c
+++ b/src/winhello.c
@@ -883,7 +883,7 @@ fido_winhello_get_cbor_info(fido_dev_t *dev, fido_cbor_info_t *ci)
 	const char *v[3] = { "U2F_V2", "FIDO_2_0", "FIDO_2_1_PRE" };
 	const char *e[2] = { "credProtect", "hmac-secret" };
 	const char *t[2] = { "nfc", "usb" };
-	const char *o[4] = { "rk", "up", "plat", "uv" };
+	const char *o[4] = { "rk", "up", "uv", "plat" };
 
 	(void)dev;
 

--- a/src/winhello.c
+++ b/src/winhello.c
@@ -883,7 +883,7 @@ fido_winhello_get_cbor_info(fido_dev_t *dev, fido_cbor_info_t *ci)
 	const char *v[3] = { "U2F_V2", "FIDO_2_0", "FIDO_2_1_PRE" };
 	const char *e[2] = { "credProtect", "hmac-secret" };
 	const char *t[2] = { "nfc", "usb" };
-	const char *o[4] = { "rk", "up", "plat", "clientPin" };
+	const char *o[4] = { "rk", "up", "plat", "uv" };
 
 	(void)dev;
 


### PR DESCRIPTION
Per the CTAP protocol the "uv" capability indicates that the device is
capable of verifying the user within itself, while "clientPin" indicates
that the device is capable of accepting a PIN from the client.  WinHello
only supports "uv", but not "clientPin", but current libfido2 advertises
"clientPin", not "uv".  Change this in fido_winhello_get_cbor_info.

Signed-off-by: Corinna Vinschen <vinschen@redhat.com>