### PR TITLE
dev: restrict visibility of fido_dev_set_sigmask

### DIFF
--- a/src/fido.h
+++ b/src/fido.h
@@ -144,7 +144,9 @@ int fido_cred_set_user(fido_cred_t *, const unsigned char *, size_t,
 int fido_cred_set_x509(fido_cred_t *, const unsigned char *, size_t);
 int fido_cred_verify(const fido_cred_t *);
 int fido_cred_verify_self(const fido_cred_t *);
+#ifdef _FIDO_SIGSET_DEFINED
 int fido_dev_set_sigmask(fido_dev_t *, const fido_sigset_t *);
+#endif
 int fido_dev_cancel(fido_dev_t *);
 int fido_dev_close(fido_dev_t *);
 int fido_dev_get_assert(fido_dev_t *, fido_assert_t *, const char *);

--- a/src/fido/types.h
+++ b/src/fido/types.h
@@ -48,10 +48,14 @@ typedef enum {
 
 typedef void fido_log_handler_t(const char *);
 
+#undef  _FIDO_SIGSET_DEFINED
+#define _FIDO_SIGSET_DEFINED
 #ifdef _WIN32
 typedef int fido_sigset_t;
-#else
+#elif defined(SIG_BLOCK)
 typedef sigset_t fido_sigset_t;
+#else
+#undef _FIDO_SIGSET_DEFINED
 #endif
 
 #ifdef _FIDO_INTERNAL


### PR DESCRIPTION
On UNIX-like systems, an application compiled using strict ISO C may
fail to build if it includes libfido2 headers due to `sigset_t` being
a POSIX extension. Determine whether `sigset_t` is defined by checking
for a known POSIX macro from the same header, hide the declaration of
`fido_dev_set_sigmask()` and `fido_sigset_t` otherwise.