### PR TITLE
nfc_linux: reset pointer after failed asprintf()

### DIFF
--- a/src/nfc_linux.c
+++ b/src/nfc_linux.c
@@ -364,8 +364,10 @@ copy_info(fido_dev_info_t *di, struct udev *udev,
 	if ((name = udev_list_entry_get_name(udev_entry)) == NULL ||
 	    (dev = udev_device_new_from_syspath(udev, name)) == NULL)
 		goto fail;
-	if (asprintf(&di->path, "%s/%s", FIDO_NFC_PREFIX, name) == -1)
+	if (asprintf(&di->path, "%s/%s", FIDO_NFC_PREFIX, name) == -1) {
+		di->path = NULL;
 		goto fail;
+	}
 	if ((di->manufacturer = get_usb_attr(dev, "manufacturer")) == NULL)
 		di->manufacturer = strdup("");
 	if ((di->product = get_usb_attr(dev, "product")) == NULL)


### PR DESCRIPTION
Reset pointer after failed asprintf(), as its value is potentially undefined. Discussed with @LDVG.