### PR TITLE
fuzz: wrap asprintf

### DIFF
--- a/fuzz/wrap.c
+++ b/fuzz/wrap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Yubico AB. All rights reserved.
+ * Copyright (c) 2019-2022 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -635,3 +635,23 @@ WRAP(int,
 	(sockfd, addr, addrlen),
 	1
 )
+
+int __wrap_asprintf(char **, const char *, ...);
+
+int
+__wrap_asprintf(char **strp, const char *fmt, ...)
+{
+	va_list ap;
+	int r;
+
+	if (uniform_random(400) < 1) {
+		*strp = (void *)0xdeadbeef;
+		return -1;
+	}
+
+	va_start(ap, fmt);
+	r = vasprintf(strp, fmt, ap);
+	va_end(ap);
+
+	return r;
+}

--- a/fuzz/wrapped.sym
+++ b/fuzz/wrapped.sym
@@ -1,3 +1,4 @@
+asprintf
 bind
 BN_bin2bn
 BN_bn2bin


### PR DESCRIPTION
when fuzzing, wrap asprintf (used in a couple of places) to ensure that failure is properly handled, and that the string pointer is
correctly reset by the caller.