### PR TITLE
pcsc: use shorter paths

### DIFF
--- a/src/extern.h
+++ b/src/extern.h
@@ -263,7 +263,7 @@ uint32_t uniform_random(uint32_t);
 #define FIDO_DUMMY_USER_ID	1
 #define FIDO_WINHELLO_PATH	"windows://hello"
 #define FIDO_NFC_PREFIX		"nfc:"
-#define FIDO_PCSC_PREFIX	"pcsc:"
+#define FIDO_PCSC_PREFIX	"pcsc"
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
use the reader name (potentially a long string) as the product string, and enumerate pcsc readers as 'pcsc0', 'pcsc1', ..., 'pcscN'.