### PR TITLE
rename hid_osx.c's to_uint64() to fido_to_uint64(), and move it to util.c

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ list(APPEND FIDO_SOURCES
 	tpm.c
 	types.c
 	u2f.c
+	util.c
 )
 
 if(FUZZ)

--- a/src/extern.h
+++ b/src/extern.h
@@ -212,6 +212,7 @@ int fido_get_random(void *, size_t);
 int fido_sha256(fido_blob_t *, const u_char *, size_t);
 int fido_time_now(struct timespec *);
 int fido_time_delta(const struct timespec *, int *);
+int fido_to_uint64(const char *, int, uint64_t *);
 
 /* crypto */
 int es256_verify_sig(const fido_blob_t *, EVP_PKEY *, const fido_blob_t *);

--- a/src/hid_osx.c
+++ b/src/hid_osx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Yubico AB. All rights reserved.
+ * Copyright (c) 2019-2022 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -374,25 +374,6 @@ disable_sigpipe(int fd)
 	return (0);
 }
 
-static int
-to_uint64(const char *str, uint64_t *out)
-{
-	char *ep;
-	unsigned long long ull;
-
-	errno = 0;
-	ull = strtoull(str, &ep, 10);
-	if (str == ep || *ep != '\0')
-		return (-1);
-	else if (ull == ULLONG_MAX && errno == ERANGE)
-		return (-1);
-	else if (ull > UINT64_MAX)
-		return (-1);
-	*out = (uint64_t)ull;
-
-	return (0);
-}
-
 static io_registry_entry_t
 get_ioreg_entry(const char *path)
 {
@@ -401,8 +382,8 @@ get_ioreg_entry(const char *path)
 	if (strncmp(path, IOREG, strlen(IOREG)) != 0)
 		return (IORegistryEntryFromPath(kIOMainPortDefault, path));
 
-	if (to_uint64(path + strlen(IOREG), &id) == -1) {
-		fido_log_debug("%s: to_uint64", __func__);
+	if (fido_to_uint64(path + strlen(IOREG), 10, &id) == -1) {
+		fido_log_debug("%s: fido_to_uint64", __func__);
 		return (MACH_PORT_NULL);
 	}
 

--- a/src/pcsc.c
+++ b/src/pcsc.c
@@ -38,25 +38,6 @@ struct pcsc {
 	size_t           rx_len;
 };
 
-static int
-to_int(const char *str, int base)
-{
-	char *ep;
-	long long ll;
-
-	ll = strtoll(str, &ep, base);
-	if (str == ep || *ep != '\0')
-		return -1;
-	else if (ll == LLONG_MIN && errno == ERANGE)
-		return -1;
-	else if (ll == LLONG_MAX && errno == ERANGE)
-		return -1;
-	else if (ll < 0 || ll > INT_MAX)
-		return -1;
-
-	return (int)ll;
-}
-
 static LONG
 list_readers(SCARDCONTEXT ctx, char **buf)
 {
@@ -96,12 +77,12 @@ static char *
 get_reader(SCARDCONTEXT ctx, const char *path)
 {
 	char *reader = NULL, *buf = NULL;
-	int n;
+	uint64_t n;
 
 	if (path == NULL)
 		goto out;
 	if (strncmp(path, FIDO_PCSC_PREFIX, strlen(FIDO_PCSC_PREFIX)) != 0 ||
-	    (n = to_int(path + strlen(FIDO_PCSC_PREFIX), 10)) < 0 ||
+	    fido_to_uint64(path + strlen(FIDO_PCSC_PREFIX), 10, &n) < 0 ||
 	    n > READERS - 1) {
 		fido_log_debug("%s: invalid path %s", __func__, path);
 		goto out;

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Yubico AB. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "fido.h"
+
+int
+fido_to_uint64(const char *str, int base, uint64_t *out)
+{
+	char *ep;
+	unsigned long long ull;
+
+	errno = 0;
+	ull = strtoull(str, &ep, base);
+	if (str == ep || *ep != '\0')
+		return -1;
+	else if (ull == ULLONG_MAX && errno == ERANGE)
+		return -1;
+	else if (ull > UINT64_MAX)
+		return -1;
+	*out = (uint64_t)ull;
+
+	return 0;
+}


### PR DESCRIPTION
while here, adapt callers of similar functions accordingly. shrinks the code a bit.