### PR TITLE
openbsd-compat: add a asprintf() compatibility shim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ check_include_files(sys/random.h HAVE_SYS_RANDOM_H)
 check_include_files(unistd.h HAVE_UNISTD_H)
 
 check_symbol_exists(arc4random_buf stdlib.h HAVE_ARC4RANDOM_BUF)
+check_symbol_exists(asprintf stdio.h HAVE_ASPRINTF)
 check_symbol_exists(clock_gettime time.h HAVE_CLOCK_GETTIME)
 check_symbol_exists(explicit_bzero string.h HAVE_EXPLICIT_BZERO)
 check_symbol_exists(freezero stdlib.h HAVE_FREEZERO)
@@ -121,6 +122,7 @@ try_compile(HAVE_POSIX_IOCTL
 
 list(APPEND CHECK_VARIABLES
 	HAVE_ARC4RANDOM_BUF
+	HAVE_ASPRINTF
 	HAVE_CBOR_H
 	HAVE_CLOCK_GETTIME
 	HAVE_ENDIAN_H

--- a/openbsd-compat/bsd-asprintf.c
+++ b/openbsd-compat/bsd-asprintf.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2004 Darren Tucker.
+ *
+ * Based originally on asprintf.c from OpenBSD:
+ * Copyright (c) 1997 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "openbsd-compat.h"
+
+#ifndef HAVE_ASPRINTF
+
+#include <errno.h>
+#include <limits.h> /* for INT_MAX */
+#include <stdarg.h>
+#include <stdio.h> /* for vsnprintf */
+#include <stdlib.h>
+
+#define VA_COPY(dest, src) va_copy(dest, src)
+
+#define INIT_SZ	128
+
+int
+vasprintf(char **str, const char *fmt, va_list ap)
+{
+	int ret;
+	va_list ap2;
+	char *string, *newstr;
+	size_t len;
+
+	if ((string = malloc(INIT_SZ)) == NULL)
+		goto fail;
+
+	VA_COPY(ap2, ap);
+	ret = vsnprintf(string, INIT_SZ, fmt, ap2);
+	va_end(ap2);
+	if (ret >= 0 && ret < INIT_SZ) { /* succeeded with initial alloc */
+		*str = string;
+	} else if (ret == INT_MAX || ret < 0) { /* Bad length */
+		free(string);
+		goto fail;
+	} else {	/* bigger than initial, realloc allowing for nul */
+		len = (size_t)ret + 1;
+		if ((newstr = realloc(string, len)) == NULL) {
+			free(string);
+			goto fail;
+		}
+		VA_COPY(ap2, ap);
+		ret = vsnprintf(newstr, len, fmt, ap2);
+		va_end(ap2);
+		if (ret < 0 || (size_t)ret >= len) { /* failed with realloc'ed string */
+			free(newstr);
+			goto fail;
+		}
+		*str = newstr;
+	}
+	return (ret);
+
+fail:
+	*str = NULL;
+	errno = ENOMEM;
+	return (-1);
+}
+
+int asprintf(char **str, const char *fmt, ...)
+{
+	va_list ap;
+	int ret;
+	
+	*str = NULL;
+	va_start(ap, fmt);
+	ret = vasprintf(str, fmt, ap);
+	va_end(ap);
+
+	return ret;
+}
+#endif

--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -115,4 +115,8 @@ ssize_t getline(char **, size_t *, FILE *);
 #define IOCTL_REQ(x)	((int)(x))
 #endif
 
+#if !defined(HAVE_ASPRINTF)
+int asprintf(char **, const char *, ...);
+#endif
+
 #endif /* !_OPENBSD_COMPAT_H */


### PR DESCRIPTION
Add a asprintf() compatibility shim so that we can use asprintf() on Windows. From OpenSSH via LibreSSL.