### PR TITLE
cmake: drop FUZZ_PCSC

### DIFF
--- a/.actions/fuzz-linux
+++ b/.actions/fuzz-linux
@@ -74,7 +74,7 @@ mkdir build
 export PKG_CONFIG_PATH="${FAKEROOT}/lib/pkgconfig"
 (cd build && cmake -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_C_FLAGS_DEBUG="${FIDO2_CFLAGS} ${COMMON_CFLAGS}" -DFUZZ=ON \
-    -DFUZZ_PCSC=ON -DLIBFUZZER=ON "${WORKDIR}")
+    -DLIBFUZZER=ON "${WORKDIR}")
 make -j"$(nproc)" -C build
 
 # fuzz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,10 +52,6 @@ if(CYGWIN OR MSYS OR MINGW)
 	set(WIN32 1)
 endif()
 
-if(FUZZ AND NOT FUZZ_PCSC)
-	set(USE_PCSC OFF)
-endif()
-
 if(WIN32)
 	add_definitions(-DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0600)
 endif()

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -63,9 +63,7 @@ set_target_properties(fuzz_largeblob PROPERTIES LINK_FLAGS ${FUZZ_LDFLAGS})
 target_link_libraries(fuzz_largeblob fido2_shared)
 
 # fuzz_pcsc
-if(FUZZ_PCSC)
-	add_executable(fuzz_pcsc fuzz_pcsc.c ${COMMON_SOURCES} ${COMPAT_SOURCES})
-	target_compile_options(fuzz_pcsc PRIVATE ${FUZZ_LDFLAGS})
-	set_target_properties(fuzz_pcsc PROPERTIES LINK_FLAGS ${FUZZ_LDFLAGS})
-	target_link_libraries(fuzz_pcsc fido2_shared)
-endif()
+add_executable(fuzz_pcsc fuzz_pcsc.c ${COMMON_SOURCES} ${COMPAT_SOURCES})
+target_compile_options(fuzz_pcsc PRIVATE ${FUZZ_LDFLAGS})
+set_target_properties(fuzz_pcsc PROPERTIES LINK_FLAGS ${FUZZ_LDFLAGS})
+target_link_libraries(fuzz_pcsc fido2_shared)

--- a/fuzz/build-coverage
+++ b/fuzz/build-coverage
@@ -26,6 +26,6 @@ make -C "${LIBCBOR}/build" VERBOSE=1 all install
 mkdir -p "${LIBFIDO2}/build"
 export CFLAGS="-fprofile-instr-generate -fcoverage-mapping"
 export LDFLAGS="${CFLAGS}"
-(cd "${LIBFIDO2}/build" && cmake -DFUZZ=ON -DFUZZ_PCSC=ON -DLIBFUZZER=ON \
+(cd "${LIBFIDO2}/build" && cmake -DFUZZ=ON -DLIBFUZZER=ON \
     -DCMAKE_BUILD_TYPE=Debug ..)
 make -C "${LIBFIDO2}/build"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,17 +41,17 @@ list(APPEND FIDO_SOURCES
 
 if(FUZZ)
 	list(APPEND FIDO_SOURCES ../fuzz/clock.c)
+	list(APPEND FIDO_SOURCES ../fuzz/pcsc.c)
 	list(APPEND FIDO_SOURCES ../fuzz/prng.c)
 	list(APPEND FIDO_SOURCES ../fuzz/udev.c)
 	list(APPEND FIDO_SOURCES ../fuzz/uniform_random.c)
 	list(APPEND FIDO_SOURCES ../fuzz/wrap.c)
 endif()
-if(FUZZ_PCSC)
-	list(APPEND FIDO_SOURCES ../fuzz/pcsc.c)
-endif()
+
 if(NFC_LINUX)
 	list(APPEND FIDO_SOURCES netlink.c nfc.c nfc_linux.c)
 endif()
+
 if(USE_PCSC)
 	list(APPEND FIDO_SOURCES nfc.c pcsc.c)
 endif()


### PR DESCRIPTION
the FUZZ_PCSC cmake option was a stopgap solution to keep oss-fuzz builds running without pcsclite headers. with the headers in place, FUZZ_PCSC is no longer needed.