### PR TITLE
actions/cifuzz: use asan, msan, and ubsan

### DIFF
--- a/.github/workflows/cifuzz_oss.yml
+++ b/.github/workflows/cifuzz_oss.yml
@@ -13,21 +13,29 @@ jobs:
   fuzzing:
     if: github.repository == 'Yubico/libfido2'
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address, undefined, memory]
     steps:
-    - name: build fuzzers
+    - name: build fuzzers (${{ matrix.sanitizer }})
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
       with:
         oss-fuzz-project-name: 'libfido2'
+        language: c
+        sanitizer: ${{ matrix.sanitizer }}
         dry-run: false
-    - name: run fuzzers
+    - name: run fuzzers (${{ matrix.sanitizer }})
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
         oss-fuzz-project-name: 'libfido2'
+        language: c
+        sanitizer: ${{ matrix.sanitizer }}
         fuzz-seconds: 600
         dry-run: false
     - name: upload crash
       uses: actions/upload-artifact@v1
       if: failure()
       with:
-        name: artifacts
+        name: ${{ matrix.sanitizer }}-artifacts
         path: ./out/artifacts


### PR DESCRIPTION
we already have separate asan and msan runners, but they use ubuntu's llvm-12, while oss-fuzz's cifuzz typically runs on newer llvm.