### PR TITLE
windows: patch up zlib's various names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ if(MSVC)
 		   "building under msvc")
 	endif()
 	set(CBOR_LIBRARIES cbor)
-	set(ZLIB_LIBRARIES zlib)
+	set(ZLIB_LIBRARIES zlib1)
 	set(CRYPTO_LIBRARIES crypto-47)
 	set(MSVC_DISABLED_WARNINGS_LIST
 		"C4152" # nonstandard extension used: function/data pointer

--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Yubico AB. All rights reserved.
+# Copyright (c) 2021-2022 Yubico AB. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -187,17 +187,15 @@ try {
 	& $CMake --build . --config ${Config} --verbose; ExitOnError
 	& $CMake --build . --config ${Config} --target install --verbose; `
 	    ExitOnError
-	# Patch up zlib's resulting names when built with --config Debug.
-	if ("${Config}" -eq "Debug") {
-		if ("${Type}" -eq "Dynamic") {
-			Copy-Item "${PREFIX}/lib/zlibd.lib" `
-			    -Destination "${PREFIX}/lib/zlib.lib" -Force
-			Copy-Item "${PREFIX}/bin/zlibd1.dll" `
-			    -Destination "${PREFIX}/bin/zlib1.dll" -Force
-		} else {
-			Copy-Item "${PREFIX}/lib/zlibstaticd.lib" `
-			    -Destination "${PREFIX}/lib/zlib.lib" -Force
-		}
+	# Patch up zlib's various names.
+	if ("${Type}" -eq "Dynamic") {
+		((Get-ChildItem -Path "${PREFIX}/lib") -Match "zlib[d]?.lib") |
+		    Copy-Item -Destination "${PREFIX}/lib/zlib1.lib" -Force
+		((Get-ChildItem -Path "${PREFIX}/bin") -Match "zlibd1.dll") |
+		    Copy-Item -Destination "${PREFIX}/bin/zlib1.dll" -Force
+	} else {
+		((Get-ChildItem -Path "${PREFIX}/lib") -Match "zlibstatic[d]?.lib") |
+		    Copy-item -Destination "${PREFIX}/lib/zlib1.lib" -Force
 	}
 } catch {
 	throw "Failed to build zlib"

--- a/windows/release.ps1
+++ b/windows/release.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Yubico AB. All rights reserved.
+# Copyright (c) 2021-2022 Yubico AB. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -34,7 +34,7 @@ Function Package-Dynamic(${SRC}, ${DEST}) {
 	Copy-Item "${SRC}\bin\cbor.dll" "${DEST}"
 	Copy-Item "${SRC}\lib\cbor.lib" "${DEST}"
 	Copy-Item "${SRC}\bin\zlib1.dll" "${DEST}"
-	Copy-Item "${SRC}\lib\zlib.lib" "${DEST}"
+	Copy-Item "${SRC}\lib\zlib1.lib" "${DEST}"
 	Copy-Item "${SRC}\bin\crypto-${LibCrypto}.dll" "${DEST}"
 	Copy-Item "${SRC}\lib\crypto-${LibCrypto}.lib" "${DEST}"
 	Copy-Item "${SRC}\bin\fido2.dll" "${DEST}"
@@ -43,7 +43,7 @@ Function Package-Dynamic(${SRC}, ${DEST}) {
 
 Function Package-Static(${SRC}, ${DEST}) {
 	Copy-Item "${SRC}/lib/cbor.lib" "${DEST}"
-	Copy-Item "${SRC}/lib/zlib.lib" "${DEST}"
+	Copy-Item "${SRC}/lib/zlib1.lib" "${DEST}"
 	Copy-Item "${SRC}/lib/crypto-${LibCrypto}.lib" "${DEST}"
 	Copy-Item "${SRC}/lib/fido2_static.lib" "${DEST}/fido2.lib"
 }
@@ -54,7 +54,7 @@ Function Package-PDBs(${SRC}, ${DEST}) {
 	Copy-Item "${SRC}\${LIBCBOR}\src\cbor.dir\${Config}\vc${SDK}.pdb" `
 	    "${DEST}\cbor.pdb"
 	Copy-Item "${SRC}\${ZLIB}\zlib.dir\${Config}\vc${SDK}.pdb" `
-	    "${DEST}\zlib.pdb"
+	    "${DEST}\zlib1.pdb"
 	Copy-Item "${SRC}\src\fido2_shared.dir\${Config}\vc${SDK}.pdb" `
 	    "${DEST}\fido2.pdb"
 }
@@ -65,7 +65,7 @@ Function Package-StaticPDBs(${SRC}, ${DEST}) {
 	Copy-Item "${SRC}\${LIBCBOR}\src\${Config}\cbor.pdb" `
 	    "${DEST}\cbor.pdb"
 	Copy-Item "${SRC}\${ZLIB}\${Config}\zlibstatic.pdb" `
-	    "${DEST}\zlib.pdb"
+	    "${DEST}\zlib1.pdb"
 	Copy-Item "${SRC}\src\${Config}\fido2_static.pdb" `
 	    "${DEST}\fido2.pdb"
 }


### PR DESCRIPTION
zlib on windows can exist as zlib, zlib1, zlibd, zlibd1, zlibstatic, or zlibstaticd. patch up the various names and work with zlib1 only.