### PR TITLE
regress: portability fixes

### DIFF
--- a/regress/assert.c
+++ b/regress/assert.c
@@ -16,7 +16,7 @@
 #include <fido/rs256.h>
 #include <fido/eddsa.h>
 
-#define FAKE_DEV_HANDLE	((void *)0xdeadbeef)
+static int fake_dev_handle;
 
 static const unsigned char es256_pk[64] = {
 	0x34, 0xeb, 0x99, 0x77, 0x02, 0x9c, 0x36, 0x38,
@@ -97,13 +97,13 @@ dummy_open(const char *path)
 {
 	(void)path;
 
-	return (FAKE_DEV_HANDLE);
+	return (&fake_dev_handle);
 }
 
 static void
 dummy_close(void *handle)
 {
-	assert(handle == FAKE_DEV_HANDLE);
+	assert(handle == &fake_dev_handle);
 }
 
 static int

--- a/regress/assert.c
+++ b/regress/assert.c
@@ -4,14 +4,17 @@
  * license that can be found in the LICENSE file.
  */
 
-#define _FIDO_INTERNAL
+#undef NDEBUG
 
 #include <assert.h>
+#include <string.h>
+
+#define _FIDO_INTERNAL
+
 #include <fido.h>
 #include <fido/es256.h>
 #include <fido/rs256.h>
 #include <fido/eddsa.h>
-#include <string.h>
 
 #define FAKE_DEV_HANDLE	((void *)0xdeadbeef)
 

--- a/regress/cred.c
+++ b/regress/cred.c
@@ -4,7 +4,10 @@
  * license that can be found in the LICENSE file.
  */
 
+#undef NDEBUG
+
 #include <assert.h>
+
 #include <cbor.h>
 #include <fido.h>
 #include <string.h>

--- a/regress/cred.c
+++ b/regress/cred.c
@@ -13,7 +13,7 @@
 
 #include <fido.h>
 
-#define FAKE_DEV_HANDLE	((void *)0xdeadbeef)
+static int fake_dev_handle;
 
 static const unsigned char cdh[32] = {
 	0xf9, 0x64, 0x57, 0xe7, 0x2d, 0x97, 0xf6, 0xbb,
@@ -1388,13 +1388,13 @@ dummy_open(const char *path)
 {
 	(void)path;
 
-	return (FAKE_DEV_HANDLE);
+	return (&fake_dev_handle);
 }
 
 static void
 dummy_close(void *handle)
 {
-	assert(handle == FAKE_DEV_HANDLE);
+	assert(handle == &fake_dev_handle);
 }
 
 static int

--- a/regress/cred.c
+++ b/regress/cred.c
@@ -7,10 +7,11 @@
 #undef NDEBUG
 
 #include <assert.h>
-
-#include <cbor.h>
-#include <fido.h>
 #include <string.h>
+
+#define _FIDO_INTERNAL
+
+#include <fido.h>
 
 #define FAKE_DEV_HANDLE	((void *)0xdeadbeef)
 

--- a/regress/dev.c
+++ b/regress/dev.c
@@ -4,7 +4,10 @@
  * license that can be found in the LICENSE file.
  */
 
+#undef NDEBUG
+
 #include <assert.h>
+
 #include <err.h>
 #include <fido.h>
 #include <string.h>

--- a/regress/dev.c
+++ b/regress/dev.c
@@ -16,12 +16,12 @@
 
 #include "../fuzz/wiredata_fido2.h"
 
-#define FAKE_DEV_HANDLE	((void *)0xdeadbeef)
 #define REPORT_LEN	(64 + 1)
 
 static uint8_t	 ctap_nonce[8];
 static uint8_t	*wiredata_ptr;
 static size_t	 wiredata_len;
+static int	 fake_dev_handle;
 static int	 initialised;
 static long	 interval_ms;
 
@@ -30,13 +30,13 @@ dummy_open(const char *path)
 {
 	(void)path;
 
-	return (FAKE_DEV_HANDLE);
+	return (&fake_dev_handle);
 }
 
 static void
 dummy_close(void *handle)
 {
-	assert(handle == FAKE_DEV_HANDLE);
+	assert(handle == &fake_dev_handle);
 }
 
 static int
@@ -46,7 +46,7 @@ dummy_read(void *handle, unsigned char *ptr, size_t len, int ms)
 	size_t		n;
 	long		d;
 
-	assert(handle == FAKE_DEV_HANDLE);
+	assert(handle == &fake_dev_handle);
 	assert(ptr != NULL);
 	assert(len == REPORT_LEN - 1);
 
@@ -91,7 +91,7 @@ dummy_write(void *handle, const unsigned char *ptr, size_t len)
 {
 	struct timespec tv;
 
-	assert(handle == FAKE_DEV_HANDLE);
+	assert(handle == &fake_dev_handle);
 	assert(ptr != NULL);
 	assert(len == REPORT_LEN);
 

--- a/regress/dev.c
+++ b/regress/dev.c
@@ -7,11 +7,12 @@
 #undef NDEBUG
 
 #include <assert.h>
-
-#include <err.h>
-#include <fido.h>
 #include <string.h>
 #include <time.h>
+
+#define _FIDO_INTERNAL
+
+#include <fido.h>
 
 #include "../fuzz/wiredata_fido2.h"
 

--- a/regress/es256.c
+++ b/regress/es256.c
@@ -8,9 +8,11 @@
 
 #include <assert.h>
 
-#include <err.h>
+#define _FIDO_INTERNAL
+
 #include <fido.h>
 #include <fido/es256.h>
+
 #include <openssl/bio.h>
 #include <openssl/pem.h>
 

--- a/regress/es256.c
+++ b/regress/es256.c
@@ -4,9 +4,11 @@
  * license that can be found in the LICENSE file.
  */
 
-#include <assert.h>
-#include <err.h>
+#undef NDEBUG
 
+#include <assert.h>
+
+#include <err.h>
 #include <fido.h>
 #include <fido/es256.h>
 #include <openssl/bio.h>


### PR DESCRIPTION
- prefer openssl's BIO interface over fmemopen();
- undef NDEBUG;
- define _FIDO_INTERNAL;
- avoid casting integers to pointers.