### PR TITLE
windows: bump LibreSSL to 3.5.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ if(MSVC)
 	endif()
 	set(CBOR_LIBRARIES cbor)
 	set(ZLIB_LIBRARIES zlib1)
-	set(CRYPTO_LIBRARIES crypto-47)
+	set(CRYPTO_LIBRARIES crypto-49)
 	set(MSVC_DISABLED_WARNINGS_LIST
 		"C4152" # nonstandard extension used: function/data pointer
 			# conversion in expression;

--- a/src/rs1.c
+++ b/src/rs1.c
@@ -9,7 +9,7 @@
 
 #include "fido.h"
 
-#if defined(LIBRESSL_VERSION_NUMBER)
+#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x3050200fL
 static EVP_MD *
 rs1_get_EVP_MD(void)
 {

--- a/src/rs256.c
+++ b/src/rs256.c
@@ -11,7 +11,7 @@
 #include "fido.h"
 #include "fido/rs256.h"
 
-#if defined(LIBRESSL_VERSION_NUMBER)
+#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x3050200fL
 static EVP_MD *
 rs256_get_EVP_MD(void)
 {

--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -229,7 +229,7 @@ try {
 	    ExitOnError
 	# Copy DLLs.
 	if ("${SHARED}" -eq "ON") {
-		"cbor.dll", "crypto-47.dll", "zlib1.dll" | `
+		"cbor.dll", "crypto-49.dll", "zlib1.dll" | `
 		    %{ Copy-Item "${PREFIX}\bin\$_" `
 		    -Destination "examples\${Config}" }
 	}

--- a/windows/const.ps1
+++ b/windows/const.ps1
@@ -6,7 +6,7 @@
 New-Variable -Name 'LIBRESSL_URL' `
     -Value 'https://fastly.cdn.openbsd.org/pub/OpenBSD/LibreSSL' `
     -Option Constant
-New-Variable -Name 'LIBRESSL' -Value 'libressl-3.4.3' -Option Constant
+New-Variable -Name 'LIBRESSL' -Value 'libressl-3.5.2' -Option Constant
 
 # libcbor coordinates.
 New-Variable -Name 'LIBCBOR' -Value 'libcbor-0.9.0' -Option Constant

--- a/windows/release.ps1
+++ b/windows/release.ps1
@@ -7,7 +7,7 @@ $Architectures = @('x64', 'Win32', 'ARM64', 'ARM')
 $InstallPrefixes =  @('Win64', 'Win32', 'ARM64', 'ARM')
 $Types = @('dynamic', 'static')
 $Config = 'Release'
-$LibCrypto = '47'
+$LibCrypto = '49'
 $SDK = '143'
 
 . "$PSScriptRoot\const.ps1"


### PR DESCRIPTION
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.5.2-relnotes.txt

of particular relevance to us is that LibreSSL 3.5.2 defines EVP_MD_meth_dup() and treats EVP_MD as a opaque pointer.