### PR TITLE
fuzz: try to wrap getrandom() (again)

### DIFF
--- a/fuzz/wrap.c
+++ b/fuzz/wrap.c
@@ -5,6 +5,7 @@
  */
 
 #include <sys/types.h>
+#include <sys/random.h>
 #include <sys/socket.h>
 
 #include <openssl/bn.h>
@@ -67,6 +68,14 @@ WRAP(char *,
 	(const char *s),
 	NULL,
 	(s),
+	1
+)
+
+WRAP(ssize_t,
+	getrandom,
+	(void *buf, size_t buflen, unsigned int flags),
+	-1,
+	(buf, buflen, flags),
 	1
 )
 

--- a/fuzz/wrapped.sym
+++ b/fuzz/wrapped.sym
@@ -63,6 +63,7 @@ EVP_PKEY_verify_init
 EVP_sha1
 EVP_sha256
 fido_tx
+getrandom
 HMAC
 HMAC_CTX_new
 HMAC_Final


### PR DESCRIPTION
previous attempts were blocked by oss-fuzz running on xenial, which lacks getrandom(). hopefully that's no longer the case.