### PR TITLE
regress: link/run against chosen library

### DIFF
--- a/regress/CMakeLists.txt
+++ b/regress/CMakeLists.txt
@@ -4,11 +4,11 @@
 
 add_custom_target(regress)
 
-macro(add_regress_test NAME SOURCES)
+macro(add_regress_test NAME SOURCES LIB)
 	add_executable(${NAME} ${SOURCES})
-	target_link_libraries(${NAME} fido2)
 	add_test(${NAME} ${NAME})
 	add_dependencies(regress ${NAME})
+	target_link_libraries(${NAME} ${LIB})
 endmacro()
 
 if(MSVC AND BUILD_SHARED_LIBS)
@@ -17,6 +17,14 @@ if(MSVC AND BUILD_SHARED_LIBS)
 		"${CBOR_BIN_DIRS}/${CBOR_LIBRARIES}.dll"
 		"${CRYPTO_BIN_DIRS}/${CRYPTO_LIBRARIES}.dll"
 		"${ZLIB_BIN_DIRS}/${ZLIB_LIBRARIES}.dll"
+		"$<TARGET_FILE:${_FIDO2_LIBRARY}>"
+		"${CMAKE_CURRENT_BINARY_DIR}")
+endif()
+
+if(CYGWIN AND BUILD_SHARED_LIBS)
+	add_custom_command(TARGET regress POST_BUILD
+	    COMMAND "${CMAKE_COMMAND}" -E copy
+		"$<TARGET_FILE:${_FIDO2_LIBRARY}>"
 		"${CMAKE_CURRENT_BINARY_DIR}")
 endif()
 
@@ -31,13 +39,15 @@ else()
 	    WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 endif()
 
-add_regress_test(regress_assert assert.c)
-add_regress_test(regress_compress compress.c)
-add_regress_test(regress_cred cred.c)
-add_regress_test(regress_dev dev.c)
-add_regress_test(regress_eddsa eddsa.c)
-add_regress_test(regress_es256 es256.c)
-add_regress_test(regress_rs256 rs256.c)
+add_regress_test(regress_assert assert.c ${_FIDO2_LIBRARY})
+add_regress_test(regress_cred cred.c ${_FIDO2_LIBRARY})
+add_regress_test(regress_dev dev.c ${_FIDO2_LIBRARY})
+add_regress_test(regress_eddsa eddsa.c ${_FIDO2_LIBRARY})
+add_regress_test(regress_es256 es256.c ${_FIDO2_LIBRARY})
+add_regress_test(regress_rs256 rs256.c ${_FIDO2_LIBRARY})
+if(BUILD_STATIC_LIBS)
+	add_regress_test(regress_compress compress.c fido2)
+endif()
 
 if(MINGW)
 	# needed for nanosleep() in mingw


### PR DESCRIPTION
- Compile `regress` against `${_FIDO2_LIBRARY}` so it links against the shared library when building with `BUILD_STATIC_LIBS=OFF`.
- Export the symbols required for `regress/compress`.
- Run the Linux CI tests for both static and dynamic libraries.