### PR TITLE
nfc/pcsc: select applet on manifest

### DIFF
--- a/fuzz/fuzz_pcsc.c
+++ b/fuzz/fuzz_pcsc.c
@@ -231,7 +231,9 @@ test(const struct param *p)
 	set_pcsc_parameters(&p->pcsc_list);
 	set_pcsc_io_functions(nfc_read, nfc_write, consume);
 
+	set_wire_data(p->wiredata_init.body, p->wiredata_init.len);
 	test_manifest();
+
 	test_misc();
 
 	set_wire_data(p->wiredata_init.body, p->wiredata_init.len);

--- a/src/extern.h
+++ b/src/extern.h
@@ -119,6 +119,7 @@ size_t fido_hid_report_out_len(void *);
 
 /* nfc i/o */
 bool fido_is_nfc(const char *);
+bool nfc_is_fido(const char *);
 void *fido_nfc_open(const char *);
 void  fido_nfc_close(void *);
 int fido_nfc_read(void *, unsigned char *, size_t, int);

--- a/src/nfc.c
+++ b/src/nfc.c
@@ -289,6 +289,35 @@ fido_nfc_rx(fido_dev_t *d, uint8_t cmd, unsigned char *buf, size_t count, int ms
 	}
 }
 
+bool
+nfc_is_fido(const char *path)
+{
+	bool fido = false;
+	fido_dev_t *d;
+	int r;
+
+	if ((d = fido_dev_new()) == NULL) {
+		fido_log_debug("%s: fido_dev_new", __func__);
+		goto fail;
+	}
+	/* fido_dev_open selects the fido applet */
+	if ((r = fido_dev_open(d, path)) != FIDO_OK) {
+		fido_log_debug("%s: fido_dev_open: 0x%x", __func__, r);
+		goto fail;
+	}
+	if ((r = fido_dev_close(d)) != FIDO_OK) {
+		fido_log_debug("%s: fido_dev_close: 0x%x", __func__, r);
+		goto fail;
+
+	}
+
+	fido = true;
+fail:
+	fido_dev_free(&d);
+
+	return fido;
+}
+
 #ifdef USE_NFC
 bool
 fido_is_nfc(const char *path)

--- a/src/pcsc.c
+++ b/src/pcsc.c
@@ -149,6 +149,10 @@ copy_info(fido_dev_info_t *di, SCARDCONTEXT ctx, const char *reader, size_t idx)
 		fido_log_debug("%s: asprintf", __func__);
 		goto fail;
 	}
+	if (nfc_is_fido(di->path) == false) {
+		fido_log_debug("%s: nfc_is_fido: %s", __func__, di->path);
+		goto fail;
+	}
 	if ((di->manufacturer = strdup("PC/SC")) == NULL ||
 	    (di->product = strdup(reader)) == NULL)
 		goto fail;


### PR DESCRIPTION
select the fido applet on nfc/pcsc manifest. mainly to avoid the duplicate detection of CCID+HID yubikeys, but also to prevent non-fido smartcards or nfc tags from being listed. discussed with @LDVG.