### PR TITLE
tools: reduce stack usage; detect readpassphrase() truncation

### DIFF
--- a/tools/assert_get.c
+++ b/tools/assert_get.c
@@ -284,6 +284,10 @@ assert_get(int argc, char **argv)
 			errx(1, "snprintf");
 		if (!readpassphrase(prompt, pin, sizeof(pin), RPP_ECHO_OFF))
 			errx(1, "readpassphrase");
+		if (strlen(pin) < 4 || strlen(pin) > 63) {
+			explicit_bzero(pin, sizeof(pin));
+			errx(1, "invalid PIN length");
+		}
 		r = fido_dev_get_assert(dev, assert, pin);
 	} else
 		r = fido_dev_get_assert(dev, assert, NULL);

--- a/tools/assert_get.c
+++ b/tools/assert_get.c
@@ -209,8 +209,8 @@ assert_get(int argc, char **argv)
 	fido_dev_t *dev = NULL;
 	fido_assert_t *assert = NULL;
 	struct toggle opt;
-	char pin[1024];
 	char prompt[1024];
+	char pin[128];
 	char *in_path = NULL;
 	char *out_path = NULL;
 	FILE *in_f = NULL;

--- a/tools/cred_make.c
+++ b/tools/cred_make.c
@@ -221,6 +221,10 @@ cred_make(int argc, char **argv)
 			errx(1, "snprintf");
 		if (!readpassphrase(prompt, pin, sizeof(pin), RPP_ECHO_OFF))
 			errx(1, "readpassphrase");
+		if (strlen(pin) < 4 || strlen(pin) > 63) {
+			explicit_bzero(pin, sizeof(pin));
+			errx(1, "invalid PIN length");
+		}
 		r = fido_dev_make_cred(dev, cred, pin);
 	}
 

--- a/tools/cred_make.c
+++ b/tools/cred_make.c
@@ -137,7 +137,7 @@ cred_make(int argc, char **argv)
 	fido_dev_t *dev = NULL;
 	fido_cred_t *cred = NULL;
 	char prompt[1024];
-	char pin[1024];
+	char pin[128];
 	char *in_path = NULL;
 	char *out_path = NULL;
 	FILE *in_f = NULL;

--- a/tools/pin.c
+++ b/tools/pin.c
@@ -21,8 +21,8 @@ pin_set(char *path)
 {
 	fido_dev_t *dev = NULL;
 	char prompt[1024];
-	char pin1[1024];
-	char pin2[1024];
+	char pin1[128];
+	char pin2[128];
 	int r;
 	int status = 1;
 
@@ -76,9 +76,9 @@ pin_change(char *path)
 {
 	fido_dev_t *dev = NULL;
 	char prompt[1024];
-	char pin0[1024];
-	char pin1[1024];
-	char pin2[1024];
+	char pin0[128];
+	char pin1[128];
+	char pin2[128];
 	int r;
 	int status = 1;
 

--- a/tools/pin.c
+++ b/tools/pin.c
@@ -55,6 +55,11 @@ pin_set(char *path)
 		goto out;
 	}
 
+	if (strlen(pin1) < 4 || strlen(pin1) > 63) {
+		fprintf(stderr, "invalid PIN length\n");
+		goto out;
+	}
+
 	if ((r = fido_dev_set_pin(dev, pin1, NULL)) != FIDO_OK) {
 		warnx("fido_dev_set_pin: %s", fido_strerr(r));
 		goto out;
@@ -98,6 +103,11 @@ pin_change(char *path)
 		goto out;
 	}
 
+	if (strlen(pin0) < 4 || strlen(pin0) > 63) {
+		warnx("invalid PIN length");
+		goto out;
+	}
+
 	r = snprintf(prompt, sizeof(prompt), "Enter new PIN for %s: ", path);
 	if (r < 0 || (size_t)r >= sizeof(prompt)) {
 		warnx("snprintf");
@@ -122,6 +132,11 @@ pin_change(char *path)
 
 	if (strcmp(pin1, pin2) != 0) {
 		fprintf(stderr, "PINs do not match. Try again.\n");
+		goto out;
+	}
+
+	if (strlen(pin1) < 4 || strlen(pin1) > 63) {
+		fprintf(stderr, "invalid PIN length\n");
 		goto out;
 	}
 


### PR DESCRIPTION
there's no point in using 1024-byte buffers when the maximum allowed PIN length is 63; while here, make sure that fido2-{assert,cred,token} detect readpassphrase() truncation.