### PR TITLE
credman, info: move reply buffer to the heap

### DIFF
--- a/src/credman.c
+++ b/src/credman.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Yubico AB. All rights reserved.
+ * Copyright (c) 2019-2022 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -200,25 +200,34 @@ credman_parse_metadata(const cbor_item_t *key, const cbor_item_t *val,
 static int
 credman_rx_metadata(fido_dev_t *dev, fido_credman_metadata_t *metadata, int *ms)
 {
-	unsigned char	reply[FIDO_MAXMSG];
-	int		reply_len;
-	int		r;
+	unsigned char	*msg;
+	int		 msglen;
+	int		 r;
 
 	memset(metadata, 0, sizeof(*metadata));
 
-	if ((reply_len = fido_rx(dev, CTAP_CMD_CBOR, &reply, sizeof(reply),
-	    ms)) < 0) {
-		fido_log_debug("%s: fido_rx", __func__);
-		return (FIDO_ERR_RX);
+	if ((msg = malloc(FIDO_MAXMSG)) == NULL) {
+		r = FIDO_ERR_INTERNAL;
+		goto out;
 	}
 
-	if ((r = cbor_parse_reply(reply, (size_t)reply_len, metadata,
+	if ((msglen = fido_rx(dev, CTAP_CMD_CBOR, msg, FIDO_MAXMSG, ms)) < 0) {
+		fido_log_debug("%s: fido_rx", __func__);
+		r = FIDO_ERR_RX;
+		goto out;
+	}
+
+	if ((r = cbor_parse_reply(msg, (size_t)msglen, metadata,
 	    credman_parse_metadata)) != FIDO_OK) {
 		fido_log_debug("%s: credman_parse_metadata", __func__);
-		return (r);
+		goto out;
 	}
 
-	return (FIDO_OK);
+	r = FIDO_OK;
+out:
+	freezero(msg, FIDO_MAXMSG);
+
+	return (r);
 }
 
 static int
@@ -325,69 +334,88 @@ credman_parse_rk_count(const cbor_item_t *key, const cbor_item_t *val,
 static int
 credman_rx_rk(fido_dev_t *dev, fido_credman_rk_t *rk, int *ms)
 {
-	unsigned char	reply[FIDO_MAXMSG];
-	int		reply_len;
-	int		r;
+	unsigned char	*msg;
+	int		 msglen;
+	int		 r;
 
 	credman_reset_rk(rk);
 
-	if ((reply_len = fido_rx(dev, CTAP_CMD_CBOR, &reply, sizeof(reply),
-	    ms)) < 0) {
+	if ((msg = malloc(FIDO_MAXMSG)) == NULL) {
+		r = FIDO_ERR_INTERNAL;
+		goto out;
+	}
+
+	if ((msglen = fido_rx(dev, CTAP_CMD_CBOR, msg, FIDO_MAXMSG, ms)) < 0) {
 		fido_log_debug("%s: fido_rx", __func__);
-		return (FIDO_ERR_RX);
+		r = FIDO_ERR_RX;
+		goto out;
 	}
 
 	/* adjust as needed */
-	if ((r = cbor_parse_reply(reply, (size_t)reply_len, rk,
+	if ((r = cbor_parse_reply(msg, (size_t)msglen, rk,
 	    credman_parse_rk_count)) != FIDO_OK) {
 		fido_log_debug("%s: credman_parse_rk_count", __func__);
-		return (r);
+		goto out;
 	}
 
 	if (rk->n_alloc == 0) {
 		fido_log_debug("%s: n_alloc=0", __func__);
-		return (FIDO_OK);
+		r = FIDO_OK;
+		goto out;
 	}
 
 	/* parse the first rk */
-	if ((r = cbor_parse_reply(reply, (size_t)reply_len, &rk->ptr[0],
+	if ((r = cbor_parse_reply(msg, (size_t)msglen, &rk->ptr[0],
 	    credman_parse_rk)) != FIDO_OK) {
 		fido_log_debug("%s: credman_parse_rk", __func__);
-		return (r);
+		goto out;
 	}
-
 	rk->n_rx++;
 
-	return (FIDO_OK);
+	r = FIDO_OK;
+out:
+	freezero(msg, FIDO_MAXMSG);
+
+	return (r);
 }
 
 static int
 credman_rx_next_rk(fido_dev_t *dev, fido_credman_rk_t *rk, int *ms)
 {
-	unsigned char	reply[FIDO_MAXMSG];
-	int		reply_len;
-	int		r;
+	unsigned char	*msg;
+	int		 msglen;
+	int		 r;
 
-	if ((reply_len = fido_rx(dev, CTAP_CMD_CBOR, &reply, sizeof(reply),
-	    ms)) < 0) {
+	if ((msg = malloc(FIDO_MAXMSG)) == NULL) {
+		r = FIDO_ERR_INTERNAL;
+		goto out;
+	}
+
+	if ((msglen = fido_rx(dev, CTAP_CMD_CBOR, msg, FIDO_MAXMSG, ms)) < 0) {
 		fido_log_debug("%s: fido_rx", __func__);
-		return (FIDO_ERR_RX);
+		r = FIDO_ERR_RX;
+		goto out;
 	}
 
 	/* sanity check */
 	if (rk->n_rx >= rk->n_alloc) {
 		fido_log_debug("%s: n_rx=%zu, n_alloc=%zu", __func__, rk->n_rx,
 		    rk->n_alloc);
-		return (FIDO_ERR_INTERNAL);
+		r = FIDO_ERR_INTERNAL;
+		goto out;
 	}
 
-	if ((r = cbor_parse_reply(reply, (size_t)reply_len, &rk->ptr[rk->n_rx],
+	if ((r = cbor_parse_reply(msg, (size_t)msglen, &rk->ptr[rk->n_rx],
 	    credman_parse_rk)) != FIDO_OK) {
 		fido_log_debug("%s: credman_parse_rk", __func__);
-		return (r);
+		goto out;
 	}
 
-	return (FIDO_OK);
+	r = FIDO_OK;
+out:
+	freezero(msg, FIDO_MAXMSG);
+
+	return (r);
 }
 
 static int
@@ -534,69 +562,88 @@ credman_parse_rp_count(const cbor_item_t *key, const cbor_item_t *val,
 static int
 credman_rx_rp(fido_dev_t *dev, fido_credman_rp_t *rp, int *ms)
 {
-	unsigned char	reply[FIDO_MAXMSG];
-	int		reply_len;
-	int		r;
+	unsigned char	*msg;
+	int		 msglen;
+	int		 r;
 
 	credman_reset_rp(rp);
 
-	if ((reply_len = fido_rx(dev, CTAP_CMD_CBOR, &reply, sizeof(reply),
-	    ms)) < 0) {
+	if ((msg = malloc(FIDO_MAXMSG)) == NULL) {
+		r = FIDO_ERR_INTERNAL;
+		goto out;
+	}
+
+	if ((msglen = fido_rx(dev, CTAP_CMD_CBOR, msg, FIDO_MAXMSG, ms)) < 0) {
 		fido_log_debug("%s: fido_rx", __func__);
-		return (FIDO_ERR_RX);
+		r = FIDO_ERR_RX;
+		goto out;
 	}
 
 	/* adjust as needed */
-	if ((r = cbor_parse_reply(reply, (size_t)reply_len, rp,
+	if ((r = cbor_parse_reply(msg, (size_t)msglen, rp,
 	    credman_parse_rp_count)) != FIDO_OK) {
 		fido_log_debug("%s: credman_parse_rp_count", __func__);
-		return (r);
+		goto out;
 	}
 
 	if (rp->n_alloc == 0) {
 		fido_log_debug("%s: n_alloc=0", __func__);
-		return (FIDO_OK);
+		r = FIDO_OK;
+		goto out;
 	}
 
 	/* parse the first rp */
-	if ((r = cbor_parse_reply(reply, (size_t)reply_len, &rp->ptr[0],
+	if ((r = cbor_parse_reply(msg, (size_t)msglen, &rp->ptr[0],
 	    credman_parse_rp)) != FIDO_OK) {
 		fido_log_debug("%s: credman_parse_rp", __func__);
-		return (r);
+		goto out;
 	}
-
 	rp->n_rx++;
 
-	return (FIDO_OK);
+	r = FIDO_OK;
+out:
+	freezero(msg, FIDO_MAXMSG);
+
+	return (r);
 }
 
 static int
 credman_rx_next_rp(fido_dev_t *dev, fido_credman_rp_t *rp, int *ms)
 {
-	unsigned char	reply[FIDO_MAXMSG];
-	int		reply_len;
-	int		r;
+	unsigned char	*msg;
+	int		 msglen;
+	int		 r;
 
-	if ((reply_len = fido_rx(dev, CTAP_CMD_CBOR, &reply, sizeof(reply),
-	    ms)) < 0) {
+	if ((msg = malloc(FIDO_MAXMSG)) == NULL) {
+		r = FIDO_ERR_INTERNAL;
+		goto out;
+	}
+
+	if ((msglen = fido_rx(dev, CTAP_CMD_CBOR, msg, FIDO_MAXMSG, ms)) < 0) {
 		fido_log_debug("%s: fido_rx", __func__);
-		return (FIDO_ERR_RX);
+		r = FIDO_ERR_RX;
+		goto out;
 	}
 
 	/* sanity check */
 	if (rp->n_rx >= rp->n_alloc) {
 		fido_log_debug("%s: n_rx=%zu, n_alloc=%zu", __func__, rp->n_rx,
 		    rp->n_alloc);
-		return (FIDO_ERR_INTERNAL);
+		r = FIDO_ERR_INTERNAL;
+		goto out;
 	}
 
-	if ((r = cbor_parse_reply(reply, (size_t)reply_len, &rp->ptr[rp->n_rx],
+	if ((r = cbor_parse_reply(msg, (size_t)msglen, &rp->ptr[rp->n_rx],
 	    credman_parse_rp)) != FIDO_OK) {
 		fido_log_debug("%s: credman_parse_rp", __func__);
-		return (r);
+		goto out;
 	}
 
-	return (FIDO_OK);
+	r = FIDO_OK;
+out:
+	freezero(msg, FIDO_MAXMSG);
+
+	return (r);
 }
 
 static int


### PR DESCRIPTION
this PR is a continuation of #584:

> FIDO_MAXMSG (2048 bytes) is a bit too large to be allocated on the stack comfortably. while here, make sure to clear the buffer once we're done with it.