### PR TITLE
hid_linux: move struct hidraw_report_descriptor to the heap

### DIFF
--- a/src/hid_linux.c
+++ b/src/hid_linux.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Yubico AB. All rights reserved.
+ * Copyright (c) 2019-2022 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -54,20 +54,21 @@ get_report_descriptor(int fd, struct hidraw_report_descriptor *hrd)
 static bool
 is_fido(const char *path)
 {
-	int				fd;
-	uint32_t			usage_page = 0;
-	struct hidraw_report_descriptor	hrd;
+	int				 fd = -1;
+	uint32_t			 usage_page = 0;
+	struct hidraw_report_descriptor	*hrd = NULL;
 
-	memset(&hrd, 0, sizeof(hrd));
-
-	if ((fd = fido_hid_unix_open(path)) == -1)
-		return (false);
-
-	if (get_report_descriptor(fd, &hrd) < 0 ||
-	    fido_hid_get_usage(hrd.value, hrd.size, &usage_page) < 0)
+	if ((hrd = calloc(1, sizeof(*hrd))) == NULL ||
+	    (fd = fido_hid_unix_open(path)) == -1)
+		goto out;
+	if (get_report_descriptor(fd, hrd) < 0 ||
+	    fido_hid_get_usage(hrd->value, hrd->size, &usage_page) < 0)
 		usage_page = 0;
 
-	if (close(fd) == -1)
+out:
+	free(hrd);
+
+	if (fd != -1 && close(fd) == -1)
 		fido_log_error(errno, "%s: close", __func__);
 
 	return (usage_page == 0xf1d0);
@@ -240,7 +241,7 @@ void *
 fido_hid_open(const char *path)
 {
 	struct hid_linux *ctx;
-	struct hidraw_report_descriptor hrd;
+	struct hidraw_report_descriptor *hrd;
 	struct timespec tv_pause;
 	long interval_ms, retries = 0;
 
@@ -271,14 +272,17 @@ fido_hid_open(const char *path)
 		}
 	}
 
-	if (get_report_descriptor(ctx->fd, &hrd) < 0 ||
-	    fido_hid_get_report_len(hrd.value, hrd.size, &ctx->report_in_len,
+	if ((hrd = calloc(1, sizeof(*hrd))) == NULL ||
+	    get_report_descriptor(ctx->fd, hrd) < 0 ||
+	    fido_hid_get_report_len(hrd->value, hrd->size, &ctx->report_in_len,
 	    &ctx->report_out_len) < 0 || ctx->report_in_len == 0 ||
 	    ctx->report_out_len == 0) {
 		fido_log_debug("%s: using default report sizes", __func__);
 		ctx->report_in_len = CTAP_MAX_REPORT_LEN;
 		ctx->report_out_len = CTAP_MAX_REPORT_LEN;
 	}
+
+	free(hrd);
 
 	return (ctx);
 }


### PR DESCRIPTION
struct hidraw_report_descriptor is over a page long; allocate it on the heap. this PR concludes #584.