### PR TITLE
use a portable way to annotate fallthroughs

### DIFF
--- a/src/fallthrough.h
+++ b/src/fallthrough.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Yubico AB. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
+#ifndef _FALLTHROUGH_H
+#define _FALLTHROUGH_H
+
+#if defined(__GNUC__)
+#if __has_attribute(fallthrough)
+#define FALLTHROUGH	__attribute__((fallthrough));
+#endif
+#endif /* __GNUC__ */
+
+#ifndef FALLTHROUGH
+#define FALLTHROUGH	/* FALLTHROUGH */
+#endif
+
+#endif /* !_FALLTHROUGH_H */

--- a/src/u2f.c
+++ b/src/u2f.c
@@ -14,6 +14,7 @@
 
 #include "fido.h"
 #include "fido/es256.h"
+#include "fallthrough.h"
 
 #define U2F_PACE_MS (100)
 
@@ -832,7 +833,7 @@ u2f_authenticate(fido_dev_t *dev, fido_assert_t *fa, int *ms)
 		    &fa->allow_list.ptr[i], fa, nfound, ms))) {
 		case FIDO_OK:
 			nauth_ok++;
-			/* FALLTHROUGH */
+			FALLTHROUGH
 		case FIDO_ERR_USER_PRESENCE_REQUIRED:
 			nfound++;
 			break;


### PR DESCRIPTION
`/* FALLTHROUGH */` might not be recognised by the compiler; pointed out by @jpalus in #591; discussed with @LDVG.