### PR TITLE
fuzz: document the wrapping of symbols for fuzzing purposes

### DIFF
--- a/fuzz/README
+++ b/fuzz/README
@@ -10,6 +10,13 @@ libFuzzer is better suited for bespoke fuzzers; see fuzz_cred.c, fuzz_credman.c,
 fuzz_assert.c, fuzz_hid.c, and fuzz_mgmt.c for examples. To build these
 harnesses, use -DFUZZ=ON -DLIBFUZZER=ON.
 
+If -DFUZZ=ON is enabled, symbols listed in wrapped.sym are wrapped in the
+resulting shared object. The wrapper functions simulate failure according to a
+deterministic RNG and probabilities defined in wrap.c. Harnesses wishing to
+use this functionality should call prng_init() with a seed obtained from the
+corpus. To mutate only the seed part of a libFuzzer harness's corpora,
+use '-reduce_inputs=0 --fido-mutate=seed'.
+
 To run under ASAN/MSAN/UBSAN, libfido2 needs to be linked against flavours of
 libcbor and OpenSSL built with the respective sanitiser. In order to keep
 memory utilisation at a manageable level, you can either enforce limits at

--- a/fuzz/wrap.c
+++ b/fuzz/wrap.c
@@ -25,7 +25,9 @@ extern int prng_up;
 
 /*
  * Build wrappers around functions of interest, and have them fail
- * in a pseudo-random manner.
+ * in a pseudo-random manner. A uniform probability of 0.25% (1/400)
+ * allows for a depth of log(0.5)/log(399/400) = 276 operations
+ * before simulated errors become statistically more likely. 
  */
 
 #define WRAP(type, name, args, retval, param, prob)	\


### PR DESCRIPTION
add some words around fuzz/wrapped.sym, fuzz/wrap.c, and the probabilities chosen.