### PR TITLE
add fido_cbor_info_maxrpid_minpinlen()

### DIFF
--- a/fuzz/export.gnu
+++ b/fuzz/export.gnu
@@ -91,6 +91,7 @@
 		fido_cbor_info_maxcredidlen;
 		fido_cbor_info_maxlargeblob;
 		fido_cbor_info_maxmsgsiz;
+		fido_cbor_info_maxrpid_minpinlen;
 		fido_cbor_info_minpinlen;
 		fido_cbor_info_new;
 		fido_cbor_info_new_pin_required;

--- a/fuzz/fuzz_mgmt.c
+++ b/fuzz/fuzz_mgmt.c
@@ -298,6 +298,9 @@ dev_get_cbor_info(const struct param *p)
 	n = fido_cbor_info_minpinlen(ci);
 	consume(&n, sizeof(n));
 
+	n = fido_cbor_info_maxrpid_minpinlen(ci);
+	consume(&n, sizeof(n));
+
 	consume(fido_cbor_info_aaguid_ptr(ci), fido_cbor_info_aaguid_len(ci));
 	consume(fido_cbor_info_protocols_ptr(ci),
 	    fido_cbor_info_protocols_len(ci));

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -123,6 +123,7 @@ list(APPEND MAN_ALIAS
 	fido_cbor_info_new fido_cbor_info_maxcredidlen
 	fido_cbor_info_new fido_cbor_info_maxlargeblob
 	fido_cbor_info_new fido_cbor_info_maxmsgsiz
+	fido_cbor_info_new fido_cbor_info_maxrpid_minpinlen
 	fido_cbor_info_new fido_cbor_info_minpinlen
 	fido_cbor_info_new fido_cbor_info_new_pin_required
 	fido_cbor_info_new fido_cbor_info_options_len

--- a/man/fido_cbor_info_new.3
+++ b/man/fido_cbor_info_new.3
@@ -30,6 +30,7 @@
 .Nm fido_cbor_info_maxcredcntlst ,
 .Nm fido_cbor_info_maxcredidlen ,
 .Nm fido_cbor_info_maxlargeblob ,
+.Nm fido_cbor_info_maxrpid_minpinlen ,
 .Nm fido_cbor_info_minpinlen ,
 .Nm fido_cbor_info_fwversion ,
 .Nm fido_cbor_info_new_pin_required
@@ -84,6 +85,8 @@
 .Fn fido_cbor_info_maxcredidlen "const fido_cbor_info_t *ci"
 .Ft uint64_t
 .Fn fido_cbor_info_maxlargeblob "const fido_cbor_info_t *ci"
+.Ft uint64_t
+.Fn fido_cbor_info_maxrpid_minpinlen "const fido_cbor_info_t *ci"
 .Ft uint64_t
 .Fn fido_cbor_info_minpinlen "const fido_cbor_info_t *ci"
 .Ft uint64_t
@@ -210,6 +213,17 @@ as reported in
 .Fa ci .
 .Pp
 The
+.Fn fido_cbor_info_maxrpid_minpinlen
+function returns the maximum number of RP IDs that may be passed to
+.Xr fido_dev_set_pin_minlen_rpid 3 ,
+as reported in
+.Fa ci .
+The minimum PIN length attribute is a CTAP 2.1 addition.
+If the attribute is not advertised by the authenticator, the
+.Fn fido_cbor_info_maxrpid_minpinlen
+function returns zero.
+.Pp
+The
 .Fn fido_cbor_info_maxlargeblob
 function returns the maximum length in bytes of an authenticator's
 serialized largeBlob array as reported in
@@ -268,4 +282,5 @@ without the
 qualifier is invoked.
 .Sh SEE ALSO
 .Xr fido_dev_open 3 ,
-.Xr fido_dev_set_pin 3
+.Xr fido_dev_set_pin 3 ,
+.Xr fido_dev_set_pin_minlen_rpid 3

--- a/man/fido_dev_enable_entattest.3
+++ b/man/fido_dev_enable_entattest.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2020 Yubico AB. All rights reserved.
+.\" Copyright (c) 2020-2022 Yubico AB. All rights reserved.
 .\" Use of this source code is governed by a BSD-style
 .\" license that can be found in the LICENSE file.
 .\"
@@ -97,6 +97,10 @@ NUL-terminated UTF-8 strings.
 A copy of
 .Fa rpid
 is made, and no reference to it or its contents is kept.
+The maximum value of
+.Fa n
+supported by the authenticator can be obtained using
+.Xr fido_cbor_info_maxrpid_minpinlen 3 .
 .Pp
 Configuration settings are reflected in the payload returned by the
 authenticator in response to a
@@ -116,6 +120,7 @@ On success,
 .Dv FIDO_OK
 is returned.
 .Sh SEE ALSO
+.Xr fido_cbor_info_maxrpid_minpinlen 3 ,
 .Xr fido_cred_pin_minlen 3 ,
 .Xr fido_dev_get_cbor_info 3 ,
 .Xr fido_dev_reset 3

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -91,6 +91,7 @@
 		fido_cbor_info_maxcredidlen;
 		fido_cbor_info_maxlargeblob;
 		fido_cbor_info_maxmsgsiz;
+		fido_cbor_info_maxrpid_minpinlen;
 		fido_cbor_info_minpinlen;
 		fido_cbor_info_new;
 		fido_cbor_info_new_pin_required;

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -89,6 +89,7 @@ _fido_cbor_info_maxcredcntlst
 _fido_cbor_info_maxcredidlen
 _fido_cbor_info_maxlargeblob
 _fido_cbor_info_maxmsgsiz
+_fido_cbor_info_maxrpid_minpinlen
 _fido_cbor_info_minpinlen
 _fido_cbor_info_new
 _fido_cbor_info_new_pin_required

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -90,6 +90,7 @@ fido_cbor_info_maxcredcntlst
 fido_cbor_info_maxcredidlen
 fido_cbor_info_maxlargeblob
 fido_cbor_info_maxmsgsiz
+fido_cbor_info_maxrpid_minpinlen
 fido_cbor_info_minpinlen
 fido_cbor_info_new
 fido_cbor_info_new_pin_required

--- a/src/fido.h
+++ b/src/fido.h
@@ -213,6 +213,7 @@ uint64_t fido_cbor_info_maxcredcntlst(const fido_cbor_info_t *);
 uint64_t fido_cbor_info_maxcredidlen(const fido_cbor_info_t *);
 uint64_t fido_cbor_info_maxlargeblob(const fido_cbor_info_t *);
 uint64_t fido_cbor_info_maxmsgsiz(const fido_cbor_info_t *);
+uint64_t fido_cbor_info_maxrpid_minpinlen(const fido_cbor_info_t *);
 uint64_t fido_cbor_info_minpinlen(const fido_cbor_info_t *);
 
 bool fido_dev_has_pin(const fido_dev_t *);

--- a/src/fido/types.h
+++ b/src/fido/types.h
@@ -233,6 +233,7 @@ typedef struct fido_cbor_info {
 	uint64_t          fwversion;      /* firmware version */
 	uint64_t          maxcredbloblen; /* max credBlob length */
 	uint64_t          maxlargeblob;   /* max largeBlob array length */
+	uint64_t          maxrpid_minlen; /* max rpid in set_pin_minlen_rpid */
 	uint64_t          minpinlen;      /* min pin len enforced */
 	bool              new_pin_reqd;   /* new pin required */
 } fido_cbor_info_t;

--- a/src/info.c
+++ b/src/info.c
@@ -276,6 +276,8 @@ parse_reply_element(const cbor_item_t *key, const cbor_item_t *val, void *arg)
 		return (cbor_decode_uint64(val, &ci->fwversion));
 	case 15: /* maxCredBlobLen */
 		return (cbor_decode_uint64(val, &ci->maxcredbloblen));
+	case 16: /* maxRPIDsForSetMinPINLength */
+		return (cbor_decode_uint64(val, &ci->maxrpid_minlen));
 	default: /* ignore */
 		fido_log_debug("%s: cbor type", __func__);
 		return (0);
@@ -490,6 +492,12 @@ uint64_t
 fido_cbor_info_minpinlen(const fido_cbor_info_t *ci)
 {
 	return (ci->minpinlen);
+}
+
+uint64_t
+fido_cbor_info_maxrpid_minpinlen(const fido_cbor_info_t *ci)
+{
+	return (ci->maxrpid_minlen);
 }
 
 const uint8_t *

--- a/tools/token.c
+++ b/tools/token.c
@@ -162,6 +162,13 @@ print_maxlargeblob(uint64_t maxlargeblob)
 }
 
 static void
+print_maxrpid_minpinlen(uint64_t maxrpid)
+{
+	if (maxrpid > 0)
+		printf("maxrpids in minpinlen: %d\n", (int)maxrpid);
+}
+
+static void
 print_minpinlen(uint64_t minpinlen)
 {
 	if (minpinlen > 0)
@@ -277,6 +284,9 @@ token_info(int argc, char **argv, char *path)
 
 	/* print maximum length of serialized largeBlob array */
 	print_maxlargeblob(fido_cbor_info_maxlargeblob(ci));
+
+	/* print maximum number of RP IDs in fido_dev_set_pin_minlen_rpid() */
+	print_maxrpid_minpinlen(fido_cbor_info_maxrpid_minpinlen(ci));
 
 	/* print minimum pin length */
 	print_minpinlen(fido_cbor_info_minpinlen(ci));


### PR DESCRIPTION
parse field 0x10 (maxRPIDsForSetMinPINLength) of a ctap 2.1 authenticatorGetInfo response and make the result available through fido_cbor_info_maxrpid_minpinlen().