### PR TITLE
add fido_cbor_info_uv_modality()

### DIFF
--- a/fuzz/export.gnu
+++ b/fuzz/export.gnu
@@ -103,6 +103,7 @@
 		fido_cbor_info_transports_len;
 		fido_cbor_info_transports_ptr;
 		fido_cbor_info_uv_attempts;
+		fido_cbor_info_uv_modality;
 		fido_cbor_info_versions_len;
 		fido_cbor_info_versions_ptr;
 		fido_cred_attstmt_len;

--- a/fuzz/fuzz_mgmt.c
+++ b/fuzz/fuzz_mgmt.c
@@ -291,10 +291,11 @@ dev_get_cbor_info(const struct param *p)
 	consume(&n, sizeof(n));
 	n = fido_cbor_info_minpinlen(ci);
 	consume(&n, sizeof(n));
+	n = fido_cbor_info_maxrpid_minpinlen(ci);
+	consume(&n, sizeof(n));
 	n = fido_cbor_info_uv_attempts(ci);
 	consume(&n, sizeof(n));
-
-	n = fido_cbor_info_maxrpid_minpinlen(ci);
+	n = fido_cbor_info_uv_modality(ci);
 	consume(&n, sizeof(n));
 
 	consume(fido_cbor_info_aaguid_ptr(ci), fido_cbor_info_aaguid_len(ci));

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -134,6 +134,7 @@ list(APPEND MAN_ALIAS
 	fido_cbor_info_new fido_cbor_info_transports_len
 	fido_cbor_info_new fido_cbor_info_transports_ptr
 	fido_cbor_info_new fido_cbor_info_uv_attempts
+	fido_cbor_info_new fido_cbor_info_uv_modality
 	fido_cbor_info_new fido_cbor_info_versions_len
 	fido_cbor_info_new fido_cbor_info_versions_ptr
 	fido_cbor_info_new fido_dev_get_cbor_info

--- a/man/fido_cbor_info_new.3
+++ b/man/fido_cbor_info_new.3
@@ -34,6 +34,7 @@
 .Nm fido_cbor_info_minpinlen ,
 .Nm fido_cbor_info_fwversion ,
 .Nm fido_cbor_info_uv_attempts ,
+.Nm fido_cbor_info_uv_modality ,
 .Nm fido_cbor_info_new_pin_required
 .Nd FIDO2 CBOR Info API
 .Sh SYNOPSIS
@@ -94,6 +95,8 @@
 .Fn fido_cbor_info_fwversion "const fido_cbor_info_t *ci"
 .Ft uint64_t
 .Fn fido_cbor_info_uv_attempts "const fido_cbor_info_t *ci"
+.Ft uint64_t
+.Fn fido_cbor_info_uv_modality "const fido_cbor_info_t *ci"
 .Ft bool
 .Fn fido_cbor_info_new_pin_required "const fido_cbor_info_t *ci"
 .Sh DESCRIPTION
@@ -262,6 +265,23 @@ the
 function returns zero.
 .Pp
 The
+.Fn fido_cbor_info_uv_modality
+function returns a bitmask representing different UV modes
+supported by the authenticator, as defined in the FIDO Registry of
+Predefined Values and reported in
+.Fa ci .
+See the
+.Em FIDO_UV_MODE_*
+definitions in
+.In fido/param.h
+for the set of values defined by libfido2 and a brief description
+of each.
+The UV modality attribute is a CTAP 2.1 addition.
+If the attribute is not advertised by the authenticator, the
+.Fn fido_cbor_info_uv_modality
+function returns zero.
+.Pp
+The
 .Fn fido_cbor_info_new_pin_required
 function returns whether a new PIN is required by the authenticator
 as reported in
@@ -302,3 +322,10 @@ qualifier is invoked.
 .Xr fido_dev_open 3 ,
 .Xr fido_dev_set_pin 3 ,
 .Xr fido_dev_set_pin_minlen_rpid 3
+.Rs
+.%D 2021-05-25
+.%O Review Draft, Version 2.2
+.%Q FIDO Alliance
+.%R FIDO Registry of Predefined Values
+.%U https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-rd-20210525.html
+.Re

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -103,6 +103,7 @@
 		fido_cbor_info_transports_len;
 		fido_cbor_info_transports_ptr;
 		fido_cbor_info_uv_attempts;
+		fido_cbor_info_uv_modality;
 		fido_cbor_info_versions_len;
 		fido_cbor_info_versions_ptr;
 		fido_cred_attstmt_len;

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -101,6 +101,7 @@ _fido_cbor_info_protocols_ptr
 _fido_cbor_info_transports_len
 _fido_cbor_info_transports_ptr
 _fido_cbor_info_uv_attempts
+_fido_cbor_info_uv_modality
 _fido_cbor_info_versions_len
 _fido_cbor_info_versions_ptr
 _fido_cred_attstmt_len

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -102,6 +102,7 @@ fido_cbor_info_protocols_ptr
 fido_cbor_info_transports_len
 fido_cbor_info_transports_ptr
 fido_cbor_info_uv_attempts
+fido_cbor_info_uv_modality
 fido_cbor_info_versions_len
 fido_cbor_info_versions_ptr
 fido_cred_attstmt_len

--- a/src/fido.h
+++ b/src/fido.h
@@ -216,6 +216,7 @@ uint64_t fido_cbor_info_maxmsgsiz(const fido_cbor_info_t *);
 uint64_t fido_cbor_info_maxrpid_minpinlen(const fido_cbor_info_t *);
 uint64_t fido_cbor_info_minpinlen(const fido_cbor_info_t *);
 uint64_t fido_cbor_info_uv_attempts(const fido_cbor_info_t *);
+uint64_t fido_cbor_info_uv_modality(const fido_cbor_info_t *);
 
 bool fido_dev_has_pin(const fido_dev_t *);
 bool fido_dev_has_uv(const fido_dev_t *);

--- a/src/fido/param.h
+++ b/src/fido/param.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 Yubico AB. All rights reserved.
+ * Copyright (c) 2018-2022 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -117,5 +117,20 @@
 				 FIDO_EXT_LARGEBLOB_KEY|FIDO_EXT_CRED_BLOB| \
 				 FIDO_EXT_MINPINLEN)
 #endif /* _FIDO_INTERNAL */
+
+/* Recognised UV modes. */
+#define FIDO_UV_MODE_TUP	0x0001	/* internal test of user presence */
+#define FIDO_UV_MODE_FP		0x0002	/* internal fingerprint check */
+#define FIDO_UV_MODE_PIN	0x0004	/* internal pin check */
+#define FIDO_UV_MODE_VOICE	0x0008	/* internal voice recognition */
+#define FIDO_UV_MODE_FACE	0x0010	/* internal face recognition */
+#define FIDO_UV_MODE_LOCATION	0x0020	/* internal location check */
+#define FIDO_UV_MODE_EYE	0x0040	/* internal eyeprint check */
+#define FIDO_UV_MODE_DRAWN	0x0080	/* internal drawn pattern check */
+#define FIDO_UV_MODE_HAND	0x0100	/* internal handprint verification */
+#define FIDO_UV_MODE_NONE	0x0200	/* TUP/UV not required */
+#define FIDO_UV_MODE_ALL	0x0400	/* all supported UV modes required */
+#define FIDO_UV_MODE_EXT_PIN	0x0800	/* external pin verification */
+#define FIDO_UV_MODE_EXT_DRAWN	0x1000	/* external drawn pattern check */
 
 #endif /* !_FIDO_PARAM_H */

--- a/src/fido/types.h
+++ b/src/fido/types.h
@@ -236,6 +236,7 @@ typedef struct fido_cbor_info {
 	uint64_t          maxrpid_minlen; /* max rpid in set_pin_minlen_rpid */
 	uint64_t          minpinlen;      /* min pin len enforced */
 	uint64_t          uv_attempts;    /* platform uv attempts */
+	uint64_t          uv_modality;    /* bitmask of supported uv types */
 	bool              new_pin_reqd;   /* new pin required */
 } fido_cbor_info_t;
 

--- a/src/info.c
+++ b/src/info.c
@@ -280,6 +280,8 @@ parse_reply_element(const cbor_item_t *key, const cbor_item_t *val, void *arg)
 		return (cbor_decode_uint64(val, &ci->maxrpid_minlen));
 	case 17: /* preferredPlatformUvAttempts */
 		return (cbor_decode_uint64(val, &ci->uv_attempts));
+	case 18: /* uvModality */
+		return (cbor_decode_uint64(val, &ci->uv_modality));
 	default: /* ignore */
 		fido_log_debug("%s: cbor type", __func__);
 		return (0);
@@ -506,6 +508,12 @@ uint64_t
 fido_cbor_info_uv_attempts(const fido_cbor_info_t *ci)
 {
 	return (ci->uv_attempts);
+}
+
+uint64_t
+fido_cbor_info_uv_modality(const fido_cbor_info_t *ci)
+{
+	return (ci->uv_modality);
 }
 
 const uint8_t *

--- a/tools/token.c
+++ b/tools/token.c
@@ -183,6 +183,73 @@ print_uv_attempts(uint64_t uv_attempts)
 }
 
 static void
+print_uv_modality(uint64_t uv_modality)
+{
+	uint64_t mode;
+	bool printed = false;
+
+	if (uv_modality == 0)
+		return;
+
+	printf("uv modality: 0x%x (", (int)uv_modality);
+
+	for (size_t i = 0; i < 64; i++) {
+		mode = 1ULL << i;
+		if ((uv_modality & mode) == 0)
+			continue;
+		if (printed)
+			printf(", ");
+		switch (mode) {
+		case FIDO_UV_MODE_TUP:
+			printf("test of user presence");
+			break;
+		case FIDO_UV_MODE_FP:
+			printf("fingerprint check");
+			break;
+		case FIDO_UV_MODE_PIN:
+			printf("pin check");
+			break;
+		case FIDO_UV_MODE_VOICE:
+			printf("voice recognition");
+			break;
+		case FIDO_UV_MODE_FACE:
+			printf("face recognition");
+			break;
+		case FIDO_UV_MODE_LOCATION:
+			printf("location check");
+			break;
+		case FIDO_UV_MODE_EYE:
+			printf("eyeprint check");
+			break;
+		case FIDO_UV_MODE_DRAWN:
+			printf("drawn pattern check");
+			break;
+		case FIDO_UV_MODE_HAND:
+			printf("handprint verification");
+			break;
+		case FIDO_UV_MODE_NONE:
+			printf("none");
+			break;
+		case FIDO_UV_MODE_ALL:
+			printf("all required");
+			break;
+		case FIDO_UV_MODE_EXT_PIN:
+			printf("external pin");
+			break;
+		case FIDO_UV_MODE_EXT_DRAWN:
+			printf("external drawn pattern check");
+			break;
+		default:
+			printf("unknown 0x%llx", (unsigned long long)mode);
+			break;
+		}
+		printed = true;
+	}
+
+	printf(")\n");
+}
+
+static void
 print_fwversion(uint64_t fwversion)
 {
 	printf("fwversion: 0x%x\n", (int)fwversion);
@@ -317,6 +384,9 @@ token_info(int argc, char **argv, char *path)
 
 	/* print platform uv attempts */
 	print_uv_attempts(fido_cbor_info_uv_attempts(ci));
+
+	/* print supported uv mechanisms */
+	print_uv_modality(fido_cbor_info_uv_modality(ci));
 
 	bio_info(dev);
 


### PR DESCRIPTION
parse field 0x12 (uvModality) of a ctap 2.1 authenticatorGetInfo response and make the result available through fido_cbor_info_uv_modality().