### PR TITLE
es384: define a basic API, largely after es256

### DIFF
--- a/src/es384.c
+++ b/src/es384.c
@@ -9,6 +9,7 @@
 #include <openssl/obj_mac.h>
 
 #include "fido.h"
+#include "fido/es384.h"
 
 static int
 decode_coord(const cbor_item_t *item, void *xy, size_t xy_len)
@@ -55,4 +56,115 @@ es384_pk_decode(const cbor_item_t *item, es384_pk_t *k)
 	}
 
 	return (0);
+}
+
+es384_pk_t *
+es384_pk_new(void)
+{
+	return (calloc(1, sizeof(es384_pk_t)));
+}
+
+void
+es384_pk_free(es384_pk_t **pkp)
+{
+	es384_pk_t *pk;
+
+	if (pkp == NULL || (pk = *pkp) == NULL)
+		return;
+
+	freezero(pk, sizeof(*pk));
+	*pkp = NULL;
+}
+
+int
+es384_pk_from_ptr(es384_pk_t *pk, const void *ptr, size_t len)
+{
+	const uint8_t	*p = ptr;
+	EVP_PKEY	*pkey;
+
+	if (len < sizeof(*pk))
+		return (FIDO_ERR_INVALID_ARGUMENT);
+
+	if (len == sizeof(*pk) + 1 && *p == 0x04)
+		memcpy(pk, ++p, sizeof(*pk)); /* uncompressed format */
+	else
+		memcpy(pk, ptr, sizeof(*pk)); /* libfido2 x||y format */
+
+	if ((pkey = es384_pk_to_EVP_PKEY(pk)) == NULL) {
+		fido_log_debug("%s: es384_pk_to_EVP_PKEY", __func__);
+		explicit_bzero(pk, sizeof(*pk));
+		return (FIDO_ERR_INVALID_ARGUMENT);
+	}
+
+	EVP_PKEY_free(pkey);
+
+	return (FIDO_OK);
+}
+
+EVP_PKEY *
+es384_pk_to_EVP_PKEY(const es384_pk_t *k)
+{
+	BN_CTX		*bnctx = NULL;
+	EC_KEY		*ec = NULL;
+	EC_POINT	*q = NULL;
+	EVP_PKEY	*pkey = NULL;
+	BIGNUM		*x = NULL;
+	BIGNUM		*y = NULL;
+	const EC_GROUP	*g = NULL;
+	int		 ok = -1;
+
+	if ((bnctx = BN_CTX_new()) == NULL)
+		goto fail;
+
+	BN_CTX_start(bnctx);
+
+	if ((x = BN_CTX_get(bnctx)) == NULL ||
+	    (y = BN_CTX_get(bnctx)) == NULL)
+		goto fail;
+
+	if (BN_bin2bn(k->x, sizeof(k->x), x) == NULL ||
+	    BN_bin2bn(k->y, sizeof(k->y), y) == NULL) {
+		fido_log_debug("%s: BN_bin2bn", __func__);
+		goto fail;
+	}
+
+	if ((ec = EC_KEY_new_by_curve_name(NID_secp384r1)) == NULL ||
+	    (g = EC_KEY_get0_group(ec)) == NULL) {
+		fido_log_debug("%s: EC_KEY init", __func__);
+		goto fail;
+	}
+
+	if ((q = EC_POINT_new(g)) == NULL ||
+	    EC_POINT_set_affine_coordinates_GFp(g, q, x, y, bnctx) == 0 ||
+	    EC_KEY_set_public_key(ec, q) == 0) {
+		fido_log_debug("%s: EC_KEY_set_public_key", __func__);
+		goto fail;
+	}
+
+	if ((pkey = EVP_PKEY_new()) == NULL ||
+	    EVP_PKEY_assign_EC_KEY(pkey, ec) == 0) {
+		fido_log_debug("%s: EVP_PKEY_assign_EC_KEY", __func__);
+		goto fail;
+	}
+
+	ec = NULL; /* at this point, ec belongs to evp */
+
+	ok = 0;
+fail:
+	if (bnctx != NULL) {
+		BN_CTX_end(bnctx);
+		BN_CTX_free(bnctx);
+	}
+
+	if (ec != NULL)
+		EC_KEY_free(ec);
+	if (q != NULL)
+		EC_POINT_free(q);
+
+	if (ok < 0 && pkey != NULL) {
+		EVP_PKEY_free(pkey);
+		pkey = NULL;
+	}
+
+	return (pkey);
 }

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -11,6 +11,10 @@
 		es256_pk_from_ptr;
 		es256_pk_new;
 		es256_pk_to_EVP_PKEY;
+		es384_pk_free;
+		es384_pk_from_ptr;
+		es384_pk_new;
+		es384_pk_to_EVP_PKEY;
 		fido_assert_allow_cred;
 		fido_assert_authdata_len;
 		fido_assert_authdata_ptr;

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -9,6 +9,10 @@ _es256_pk_from_EVP_PKEY
 _es256_pk_from_ptr
 _es256_pk_new
 _es256_pk_to_EVP_PKEY
+_es384_pk_free
+_es384_pk_from_ptr
+_es384_pk_new
+_es384_pk_to_EVP_PKEY
 _fido_assert_allow_cred
 _fido_assert_authdata_len
 _fido_assert_authdata_ptr

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -10,6 +10,10 @@ es256_pk_from_EVP_PKEY
 es256_pk_from_ptr
 es256_pk_new
 es256_pk_to_EVP_PKEY
+es384_pk_free
+es384_pk_from_ptr
+es384_pk_new
+es384_pk_to_EVP_PKEY
 fido_assert_allow_cred
 fido_assert_authdata_len
 fido_assert_authdata_ptr

--- a/src/fido/es384.h
+++ b/src/fido/es384.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Yubico AB. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
+#ifndef _FIDO_ES384_H
+#define _FIDO_ES384_H
+
+#include <openssl/ec.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef _FIDO_INTERNAL
+#include "types.h"
+#else
+#include <fido.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+es384_pk_t *es384_pk_new(void);
+void es384_pk_free(es384_pk_t **);
+EVP_PKEY *es384_pk_to_EVP_PKEY(const es384_pk_t *);
+int es384_pk_from_ptr(es384_pk_t *, const void *, size_t);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* !_FIDO_ES384_H */


### PR DESCRIPTION
provide enough functionality for es384 keys to be allocated, deallocated, populated from memory, and converted to EVP_PKEY.