### PR TITLE
actions: crank OpenBSD build to 7.1

### DIFF
--- a/.github/workflows/bsd_builds.yml
+++ b/.github/workflows/bsd_builds.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [freebsd/13.x, openbsd/7.0]
+        image: [freebsd/13.x, openbsd/7.1]
     steps:
     - uses: actions/checkout@v2
     - name: dependencies


### PR DESCRIPTION
OpenBSD 7.1 is now supported by builds.sr.ht (as per https://man.sr.ht/builds.sr.ht/compatibility.md#openbsd), so bump the version number in `.github/workflows/bsd_builds.yml` accordingly.