### PR TITLE
assert: add fido_assert_empty_allow_list

### DIFF
--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -59,6 +59,7 @@ list(APPEND MAN_ALIAS
 	es384_pk_new es384_pk_from_EVP_PKEY
 	es384_pk_new es384_pk_from_ptr
 	es384_pk_new es384_pk_to_EVP_PKEY
+	fido_assert_allow_cred fido_assert_empty_allow_list
 	fido_assert_new fido_assert_authdata_len
 	fido_assert_new fido_assert_authdata_ptr
 	fido_assert_new fido_assert_blob_len

--- a/man/fido_assert_allow_cred.3
+++ b/man/fido_assert_allow_cred.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2018 Yubico AB. All rights reserved.
+.\" Copyright (c) 2018-2022 Yubico AB. All rights reserved.
 .\"
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions are
@@ -25,16 +25,19 @@
 .\"
 .\" SPDX-License-Identifier: BSD-2-Clause
 .\"
-.Dd $Mdocdate: May 23 2018 $
+.Dd $Mdocdate: December 1 2022 $
 .Dt FIDO_ASSERT_ALLOW_CRED 3
 .Os
 .Sh NAME
-.Nm fido_assert_allow_cred
-.Nd allow a credential in a FIDO2 assertion
+.Nm fido_assert_allow_cred ,
+.Nm fido_assert_empty_allow_list
+.Nd manage allow lists in a FIDO2 assertion
 .Sh SYNOPSIS
 .In fido.h
 .Ft int
 .Fn fido_assert_allow_cred "fido_assert_t *assert" "const unsigned char *ptr" "size_t len"
+.Ft int
+.Fn fido_assert_empty_allow_list "fido_assert_t *assert"
 .Sh DESCRIPTION
 The
 .Fn fido_assert_allow_cred
@@ -56,9 +59,16 @@ fails, the existing list of allowed credentials is preserved.
 .Pp
 For the format of a FIDO2 credential ID, please refer to the
 Web Authentication (webauthn) standard.
+.Pp
+The
+.Fn fido_assert_empty_allow_list
+function empties the list of credentials allowed in
+.Fa assert .
 .Sh RETURN VALUES
 The error codes returned by
 .Fn fido_assert_allow_cred
+and
+.Fn fido_assert_empty_allow_list
 are defined in
 .In fido/err.h .
 On success,

--- a/src/assert.c
+++ b/src/assert.c
@@ -748,9 +748,8 @@ fido_assert_reset_tx(fido_assert_t *assert)
 	fido_blob_reset(&assert->cd);
 	fido_blob_reset(&assert->cdh);
 	fido_blob_reset(&assert->ext.hmac_salt);
-	fido_free_blob_array(&assert->allow_list);
+	fido_assert_empty_allow_list(assert);
 	memset(&assert->ext, 0, sizeof(assert->ext));
-	memset(&assert->allow_list, 0, sizeof(assert->allow_list));
 	assert->rp_id = NULL;
 	assert->up = FIDO_OPT_OMIT;
 	assert->uv = FIDO_OPT_OMIT;

--- a/src/assert.c
+++ b/src/assert.c
@@ -673,7 +673,15 @@ fail:
 	free(id.ptr);
 
 	return (r);
+}
 
+int
+fido_assert_empty_allow_list(fido_assert_t *assert)
+{
+	fido_free_blob_array(&assert->allow_list);
+	memset(&assert->allow_list, 0, sizeof(assert->allow_list));
+
+	return (FIDO_OK);
 }
 
 int

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -25,6 +25,7 @@
 		fido_assert_clientdata_hash_len;
 		fido_assert_clientdata_hash_ptr;
 		fido_assert_count;
+		fido_assert_empty_allow_list;
 		fido_assert_flags;
 		fido_assert_free;
 		fido_assert_hmac_secret_len;

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -23,6 +23,7 @@ _fido_assert_blob_ptr
 _fido_assert_clientdata_hash_len
 _fido_assert_clientdata_hash_ptr
 _fido_assert_count
+_fido_assert_empty_allow_list
 _fido_assert_flags
 _fido_assert_free
 _fido_assert_hmac_secret_len

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -24,6 +24,7 @@ fido_assert_blob_ptr
 fido_assert_clientdata_hash_len
 fido_assert_clientdata_hash_ptr
 fido_assert_count
+fido_assert_empty_allow_list
 fido_assert_flags
 fido_assert_free
 fido_assert_hmac_secret_len

--- a/src/fido.h
+++ b/src/fido.h
@@ -124,6 +124,7 @@ const unsigned char *fido_cred_user_id_ptr(const fido_cred_t *);
 const unsigned char *fido_cred_x5c_ptr(const fido_cred_t *);
 
 int fido_assert_allow_cred(fido_assert_t *, const unsigned char *, size_t);
+int fido_assert_empty_allow_list(fido_assert_t *);
 int fido_assert_set_authdata(fido_assert_t *, size_t, const unsigned char *,
     size_t);
 int fido_assert_set_authdata_raw(fido_assert_t *, size_t, const unsigned char *,


### PR DESCRIPTION
Useful for clients that may want to iterate over batches of credential ID:s after examining `maxCredentialCountInList`.