### PR TITLE
Add TrustKey `G310H`/`G320H` IDs

### DIFF
--- a/udev/70-u2f.rules
+++ b/udev/70-u2f.rules
@@ -216,6 +216,9 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2ccf", ATTRS{idProduct
 # TrustKey Solutions FIDO2 G310 by eWBM Co., Ltd.
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="4a1a", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
+# TrustKey Solutions FIDO2 G310H/G320H by eWBM Co., Ltd.
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="4a1a", TAG+="uaccess", GROUP="plugdev", MODE="0660"
+
 # TrustKey Solutions FIDO2 G320 by eWBM Co., Ltd.
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="4c2a", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 

--- a/udev/fidodevs
+++ b/udev/fidodevs
@@ -115,6 +115,7 @@ product LEDGER		0x4015	Ledger Nano X Legacy
 product HYPERSECU	0x0880	Hypersecu HyperFIDO
 
 product EWBM		0x4a1a	TrustKey Solutions FIDO2 G310
+product EWBM		0x4a2a	TrustKey Solutions FIDO2 G310H/G320H
 product EWBM		0x4c2a	TrustKey Solutions FIDO2 G320
 product EWBM		0x5c2f	eWBM FIDO2 Goldengate G500
 product EWBM		0xa6e9	TrustKey Solutions FIDO2 T120


### PR DESCRIPTION
Running `lsusb` for both devices shows the following outputs which seem to be missing here:

ID 311f:4a2a eWBM eWBM G310H
ID 311f:4a2a TrustKey TrustKey G320H