### PR TITLE
fuzz/coverage: explicitly pass libfuzzer options

### DIFF
--- a/fuzz/build-coverage
+++ b/fuzz/build-coverage
@@ -26,6 +26,9 @@ make -C "${LIBCBOR}/build" VERBOSE=1 all install
 # Build libfido2.
 mkdir -p "${LIBFIDO2}/build"
 export CFLAGS="-fprofile-instr-generate -fcoverage-mapping"
+export CFLAGS="${CFLAGS} -fsanitize=fuzzer-no-link"
 export LDFLAGS="${CFLAGS}"
-(cd "${LIBFIDO2}/build" && cmake -DFUZZ=ON -DCMAKE_BUILD_TYPE=Debug ..)
+export FUZZ_LDFLAGS="${LDFLAGS} -fsanitize=fuzzer"
+(cd "${LIBFIDO2}/build" && cmake -DFUZZ=ON -DFUZZ_LDFLAGS="${FUZZ_LDFLAGS}" \
+	-DCMAKE_BUILD_TYPE=Debug ..)
 make -C "${LIBFIDO2}/build"


### PR DESCRIPTION
The build system no longer does this work for us. Accidentally left broken by #662.