### PR TITLE
Add support for unicode in winhello.c

### DIFF
--- a/src/winhello.c
+++ b/src/winhello.c
@@ -85,7 +85,7 @@ webauthn_load(void)
 		fido_log_debug("%s: already loaded", __func__);
 		return -1;
 	}
-	if ((webauthn_handle = LoadLibrary("webauthn.dll")) == NULL) {
+	if ((webauthn_handle = LoadLibrary(TEXT("webauthn.dll"))) == NULL) {
 		fido_log_debug("%s: LoadLibrary", __func__);
 		return -1;
 	}


### PR DESCRIPTION
Wrap parameter in the LoadLibrary() call with the TEXT macro so that the code can be used in projects supporting wide strings