### PR TITLE
actions: bump OpenBSD build to 7.2

### DIFF
--- a/.github/workflows/bsd_builds.yml
+++ b/.github/workflows/bsd_builds.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [freebsd/13.x, openbsd/7.1]
+        image: [freebsd/13.x, openbsd/7.2]
     steps:
     - uses: actions/checkout@v2
     - name: dependencies


### PR DESCRIPTION
I have no way to test this at the moment (can't push to Yubico/libfido2), but it should work.