### PR TITLE
windows: bump libressl to 3.7.2

### DIFF
--- a/regress/eddsa.c
+++ b/regress/eddsa.c
@@ -123,7 +123,7 @@ valid_key(void)
 	eddsa_pk_t *pkA = NULL;
 	eddsa_pk_t *pkB = NULL;
 
-#if defined(LIBRESSL_VERSION_NUMBER)
+#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x3070000f
 	/* incomplete support; test what we can */
 	ASSERT_NULL(EVP_PKEY_from_PEM(eddsa, sizeof(eddsa)));
 	ASSERT_NOT_NULL((pkB = eddsa_pk_new()));

--- a/windows/const.ps1
+++ b/windows/const.ps1
@@ -7,7 +7,7 @@
 New-Variable -Name 'LIBRESSL_URL' `
     -Value 'https://fastly.cdn.openbsd.org/pub/OpenBSD/LibreSSL' `
     -Option Constant
-New-Variable -Name 'LIBRESSL' -Value 'libressl-3.6.2' -Option Constant
+New-Variable -Name 'LIBRESSL' -Value 'libressl-3.7.2' -Option Constant
 New-Variable -Name 'CRYPTO_LIBRARIES' -Value 'crypto-50' -Option Constant
 
 # libcbor coordinates.


### PR DESCRIPTION
Bump LibreSSL to 3.7.2, released 2023-04-08; https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.7.2-relnotes.txt