### PR TITLE
actions: switch fuzz, macos builds to OpenSSL 3.0

### DIFF
--- a/.actions/build-osx-clang
+++ b/.actions/build-osx-clang
@@ -5,7 +5,7 @@
 # license that can be found in the LICENSE file.
 # SPDX-License-Identifier: BSD-2-Clause
 
-export PKG_CONFIG_PATH="$(brew --prefix openssl@1.1)/lib/pkgconfig"
+export PKG_CONFIG_PATH="$(brew --prefix openssl@3.0)/lib/pkgconfig"
 SCAN="$(brew --prefix llvm)/bin/scan-build"
 
 # Build, analyze, and install libfido2.

--- a/.actions/fuzz-linux
+++ b/.actions/fuzz-linux
@@ -10,7 +10,7 @@ LIBCBOR_TAG="v0.10.1"
 LIBCBOR_ASAN="address alignment bounds"
 LIBCBOR_MSAN="memory"
 OPENSSL_URL="https://github.com/openssl/openssl"
-OPENSSL_TAG="OpenSSL_1_1_1u"
+OPENSSL_TAG="openssl-3.0.9"
 ZLIB_URL="https://github.com/madler/zlib"
 ZLIB_TAG="v1.2.13"
 ZLIB_ASAN="address alignment bounds undefined"
@@ -62,7 +62,7 @@ cd -
 git clone --depth=1 "${OPENSSL_URL}" -b "${OPENSSL_TAG}"
 cd openssl
 ./Configure linux-x86_64-clang "enable-$1" --prefix="${FAKEROOT}" \
-    --openssldir="${FAKEROOT}/openssl"
+    --openssldir="${FAKEROOT}/openssl" --libdir=lib
 make install_sw
 cd -
 

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: dependencies
-      run: brew install libcbor llvm mandoc pkg-config zlib
+      run: brew install libcbor llvm mandoc openssl@3.0 pkg-config zlib
     - name: build
       env:
         CC: ${{ matrix.cc }}


### PR DESCRIPTION
With OpenSSL 1.1.1's EOL around the corner (2023-09-11, according to https://www.openssl.org/policies/releasestrat.html), this PR switches libfido2's fuzz and macOS builds to use OpenSSL 3.0.

N.B. we still need to update https://github.com/google/oss-fuzz.