### PR TITLE
ci: bump actions/checkout

### DIFF
--- a/.github/workflows/alpine_builds.yml
+++ b/.github/workflows/alpine_builds.yml
@@ -32,7 +32,7 @@ jobs:
     - name: fix permissions on workdir
       run: chown root:wheel "${GITHUB_WORKSPACE}"
     - name: checkout libfido2
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: build libfido2
       env:
         CC: ${{ matrix.cc }}

--- a/.github/workflows/bsd_builds.yml
+++ b/.github/workflows/bsd_builds.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         image: [freebsd/13.x, openbsd/7.2]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: dependencies
       run: |
         sudo apt -q update

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 2
     - name: init codeql

--- a/.github/workflows/cygwin_builds.yml
+++ b/.github/workflows/cygwin_builds.yml
@@ -24,7 +24,7 @@ jobs:
         arch: [ x64 ]
         config: [ "Debug", "Release" ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: build
       run: |
         .\windows\cygwin.ps1 -Config ${{ matrix.config }}

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -33,7 +33,7 @@ jobs:
           - { os: ubuntu-20.04, cc: i686-w64-mingw32-gcc-9 }
           - { os: ubuntu-22.04, cc: i686-w64-mingw32-gcc-10 }
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: dependencies
       run: |
         sudo apt -q update

--- a/.github/workflows/linux_fuzz.yml
+++ b/.github/workflows/linux_fuzz.yml
@@ -24,7 +24,7 @@ jobs:
         cc: [ clang-16 ]
         sanitizer: [ asan, msan ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: dependencies
       run: |
         sudo apt -q update

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -23,7 +23,7 @@ jobs:
         os: [ macos-13, macos-12, macos-11 ]
         cc: [ clang ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: dependencies
       run: brew install libcbor llvm mandoc openssl@3.0 pkg-config zlib
     - name: build

--- a/.github/workflows/openssl3.yml
+++ b/.github/workflows/openssl3.yml
@@ -28,7 +28,7 @@ jobs:
           - os: ubuntu-22.04
             cc: i686-w64-mingw32-gcc-10
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: dependencies
       env:
         CC: ${{ matrix.cc }}

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -25,7 +25,7 @@ jobs:
         type: [ dynamic, static ]
         config: [ "Release" ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: build
       run: |
         .\windows\build.ps1 -Fido2Flags '/analyze' -Arch ${{ matrix.arch }} `


### PR DESCRIPTION
Silences warnings on Node.js 12 actions being deprecated.