### PR TITLE
tools: add FLAG_CD

### DIFF
--- a/man/fido2-assert.1
+++ b/man/fido2-assert.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2018 Yubico AB. All rights reserved.
+.\" Copyright (c) 2018-2023 Yubico AB. All rights reserved.
 .\"
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions are
@@ -25,7 +25,7 @@
 .\"
 .\" SPDX-License-Identifier: BSD-2-Clause
 .\"
-.Dd $Mdocdate: November 5 2019 $
+.Dd $Mdocdate: July 3 2023 $
 .Dt FIDO2-ASSERT 1
 .Os
 .Sh NAME
@@ -34,7 +34,7 @@
 .Sh SYNOPSIS
 .Nm
 .Fl G
-.Op Fl bdhpruv
+.Op Fl bdhpruvw
 .Op Fl t Ar option
 .Op Fl i Ar input_file
 .Op Fl o Ar output_file
@@ -175,6 +175,13 @@ If obtaining an assertion, prompt the user for a PIN and request
 user verification from the authenticator.
 If verifying an assertion, check whether the user verification bit
 was signed by the authenticator.
+.It Fl w
+Tells
+.Nm
+that the first line of input when obtaining an assertion shall be
+interpreted as unhashed client data.
+This is required by Windows Hello, which calculates the client data hash
+internally.
 .El
 .Pp
 If a

--- a/man/fido2-cred.1
+++ b/man/fido2-cred.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2018 Yubico AB. All rights reserved.
+.\" Copyright (c) 2018-2023 Yubico AB. All rights reserved.
 .\"
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions are
@@ -25,7 +25,7 @@
 .\"
 .\" SPDX-License-Identifier: BSD-2-Clause
 .\"
-.Dd $Mdocdate: November 5 2019 $
+.Dd $Mdocdate: July 3 2023 $
 .Dt FIDO2-CRED 1
 .Os
 .Sh NAME
@@ -34,7 +34,7 @@
 .Sh SYNOPSIS
 .Nm
 .Fl M
-.Op Fl bdhqruv
+.Op Fl bdhqruvw
 .Op Fl c Ar cred_protect
 .Op Fl i Ar input_file
 .Op Fl o Ar output_file
@@ -177,6 +177,13 @@ U2F otherwise.
 If making a credential, request user verification.
 If verifying a credential, check whether the user verification bit
 was signed by the authenticator.
+.It Fl w
+Tells
+.Nm
+that the first line of input when making a credential shall be
+interpreted as unhashed client data.
+This is required by Windows Hello, which calculates the client data hash
+internally.
 .El
 .Sh INPUT FORMAT
 The input of

--- a/tools/cred_make.c
+++ b/tools/cred_make.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Yubico AB. All rights reserved.
+ * Copyright (c) 2018-2023 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  * SPDX-License-Identifier: BSD-2-Clause
@@ -37,7 +37,8 @@ prepare_cred(FILE *in_f, int type, int flags)
 		errx(1, "input error");
 
 	if (flags & FLAG_DEBUG) {
-		fprintf(stderr, "client data hash:\n");
+		fprintf(stderr, "client data%s:\n",
+			flags & FLAG_CD ? "" : " hash");
 		xxd(cdh.ptr, cdh.len);
 		fprintf(stderr, "relying party id: %s\n", rpid);
 		fprintf(stderr, "user name: %s\n", uname);
@@ -48,9 +49,13 @@ prepare_cred(FILE *in_f, int type, int flags)
 	if ((cred = fido_cred_new()) == NULL)
 		errx(1, "fido_cred_new");
 
-	if ((r = fido_cred_set_type(cred, type)) != FIDO_OK ||
-	    (r = fido_cred_set_clientdata_hash(cred, cdh.ptr,
-	    cdh.len)) != FIDO_OK ||
+
+	if (flags & FLAG_CD)
+		r = fido_cred_set_clientdata(cred, cdh.ptr, cdh.len);
+	else
+		r = fido_cred_set_clientdata_hash(cred, cdh.ptr, cdh.len);
+
+	if (r != FIDO_OK || (r = fido_cred_set_type(cred, type)) != FIDO_OK ||
 	    (r = fido_cred_set_rp(cred, rpid, NULL)) != FIDO_OK ||
 	    (r = fido_cred_set_user(cred, uid.ptr, uid.len, uname, NULL,
 	    NULL)) != FIDO_OK)
@@ -149,7 +154,7 @@ cred_make(int argc, char **argv)
 	int ch;
 	int r;
 
-	while ((ch = getopt(argc, argv, "bc:dhi:o:qruv")) != -1) {
+	while ((ch = getopt(argc, argv, "bc:dhi:o:qruvw")) != -1) {
 		switch (ch) {
 		case 'b':
 			flags |= FLAG_LARGEBLOB;
@@ -181,6 +186,9 @@ cred_make(int argc, char **argv)
 			break;
 		case 'v':
 			flags |= FLAG_UV;
+			break;
+		case 'w':
+			flags |= FLAG_CD;
 			break;
 		default:
 			usage();

--- a/tools/extern.h
+++ b/tools/extern.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Yubico AB. All rights reserved.
+ * Copyright (c) 2018-2023 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  * SPDX-License-Identifier: BSD-2-Clause
@@ -23,14 +23,15 @@ struct blob {
 
 #define TOKEN_OPT	"CDGILPRSVabcdefi:k:l:m:n:p:ru"
 
-#define FLAG_DEBUG	0x01
-#define FLAG_QUIET	0x02
-#define FLAG_RK		0x04
-#define FLAG_UV		0x08
-#define FLAG_U2F	0x10
-#define FLAG_HMAC	0x20
-#define FLAG_UP		0x40
-#define FLAG_LARGEBLOB	0x80
+#define FLAG_DEBUG	0x001
+#define FLAG_QUIET	0x002
+#define FLAG_RK		0x004
+#define FLAG_UV		0x008
+#define FLAG_U2F	0x010
+#define FLAG_HMAC	0x020
+#define FLAG_UP		0x040
+#define FLAG_LARGEBLOB	0x080
+#define FLAG_CD		0x100
 
 #define PINBUF_LEN	256
 

--- a/tools/fido2-assert.c
+++ b/tools/fido2-assert.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Yubico AB. All rights reserved.
+ * Copyright (c) 2018-2023 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  * SPDX-License-Identifier: BSD-2-Clause
@@ -29,7 +29,7 @@ void
 usage(void)
 {
 	fprintf(stderr,
-"usage: fido2-assert -G [-bdhpruv] [-t option] [-i input_file] [-o output_file] device\n"
+"usage: fido2-assert -G [-bdhpruvw] [-t option] [-i input_file] [-o output_file] device\n"
 "       fido2-assert -V [-dhpv] [-i input_file] key_file [type]\n"
 	);
 

--- a/tools/fido2-cred.c
+++ b/tools/fido2-cred.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Yubico AB. All rights reserved.
+ * Copyright (c) 2018-2023 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  * SPDX-License-Identifier: BSD-2-Clause
@@ -27,7 +27,7 @@ void
 usage(void)
 {
 	fprintf(stderr,
-"usage: fido2-cred -M [-bdhqruv] [-c cred_protect] [-i input_file] [-o output_file] device [type]\n"
+"usage: fido2-cred -M [-bdhqruvw] [-c cred_protect] [-i input_file] [-o output_file] device [type]\n"
 "       fido2-cred -V [-dhv] [-c cred_protect] [-i input_file] [-o output_file] [type]\n"
 	);
 


### PR DESCRIPTION
A flag used to interpret the first line of input as raw client data rather than a hash of the client data. This is useful for `fido2-cred -M` and `fido2-assert -G` under the Windows Hello backend.