### PR TITLE
cmake: bump cmake_minimum_required()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 # SPDX-License-Identifier: BSD-2-Clause
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.7)
 
 # detect AppleClang; needs to come before project()
 cmake_policy(SET CMP0025 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,12 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 # SPDX-License-Identifier: BSD-2-Clause
+cmake_minimum_required(VERSION 3.0)
 
 # detect AppleClang; needs to come before project()
 cmake_policy(SET CMP0025 NEW)
 
 project(libfido2 C)
-cmake_minimum_required(VERSION 3.0)
 # Set PIE flags for POSITION_INDEPENDENT_CODE targets, added in CMake 3.14.
 if(POLICY CMP0083)
 	cmake_policy(SET CMP0083 NEW)


### PR DESCRIPTION
We are using `VERSION_GREATER_EQUAL` [1] which was added in CMake 3.7
(released in November 2016). The distributions that we perform releases
for are all running at least this version, further substantiated by the fact
that we've used this feature since libfido2 1.9.0 (released in October
2021).

Moreover, this change silences a warning on modern CMake versions that
compatilibity with versions less than CMake 3.5 is going to be removed
in a future CMake release [2].

While here, fix another warning that `cmake_minumum_required()` has to
be called before invoking any other command, see note in [1].

[1] https://cmake.org/cmake/help/latest/command/if.html#version-greater-equal
[2] https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-settings