### PR TITLE
tools: add CLI flag to force FIDO2

### DIFF
--- a/man/fido2-assert.1
+++ b/man/fido2-assert.1
@@ -170,6 +170,12 @@ By default,
 .Nm
 will use FIDO2 if supported by the authenticator, and fallback to
 U2F otherwise.
+.It Fl 2
+Obtain an assertion using only FIDO2.
+By default,
+.Nm
+will use FIDO2 if supported by the authenticator, and fallback to
+U2F otherwise.
 .It Fl v
 If obtaining an assertion, prompt the user for a PIN and request
 user verification from the authenticator.

--- a/man/fido2-cred.1
+++ b/man/fido2-cred.1
@@ -173,6 +173,12 @@ By default,
 .Nm
 will use FIDO2 if supported by the authenticator, and fallback to
 U2F otherwise.
+.It Fl 2
+Create a FIDO2 credential.
+By default,
+.Nm
+will use FIDO2 if supported by the authenticator, and fallback to
+U2F otherwise.
 .It Fl v
 If making a credential, request user verification.
 If verifying a credential, check whether the user verification bit

--- a/tools/assert_get.c
+++ b/tools/assert_get.c
@@ -226,7 +226,7 @@ assert_get(int argc, char **argv)
 
 	opt.up = opt.uv = opt.pin = FIDO_OPT_OMIT;
 
-	while ((ch = getopt(argc, argv, "bdhi:o:prt:uvw")) != -1) {
+	while ((ch = getopt(argc, argv, "bdhi:o:prt:u2vw")) != -1) {
 		switch (ch) {
 		case 'b':
 			flags |= FLAG_LARGEBLOB;
@@ -255,6 +255,9 @@ assert_get(int argc, char **argv)
 		case 'u':
 			flags |= FLAG_U2F;
 			break;
+		case '2':
+			flags |= FLAG_FIDO2;
+			break;
 		case 'v':
 			/* -v implies both pin and uv for historical reasons */
 			opt.pin = FIDO_OPT_TRUE;
@@ -282,8 +285,13 @@ assert_get(int argc, char **argv)
 	assert = prepare_assert(in_f, flags, &opt);
 
 	dev = open_dev(argv[0]);
-	if (flags & FLAG_U2F)
+	if (flags & FLAG_U2F) {
 		fido_dev_force_u2f(dev);
+		if (flags & FLAG_DEBUG) fprintf(stderr, "Forcing U2F (CTAP1).\n");
+	} else if (flags & FLAG_FIDO2) {
+		fido_dev_force_fido2(dev);
+		if (flags & FLAG_DEBUG) fprintf(stderr, "Forcing FIDO2 (CTAP2).\n");
+	}
 
 	if (opt.pin == FIDO_OPT_TRUE) {
 		r = snprintf(prompt, sizeof(prompt), "Enter PIN for %s: ",

--- a/tools/cred_make.c
+++ b/tools/cred_make.c
@@ -154,7 +154,7 @@ cred_make(int argc, char **argv)
 	int ch;
 	int r;
 
-	while ((ch = getopt(argc, argv, "bc:dhi:o:qruvw")) != -1) {
+	while ((ch = getopt(argc, argv, "bc:dhi:o:qru2vw")) != -1) {
 		switch (ch) {
 		case 'b':
 			flags |= FLAG_LARGEBLOB;
@@ -184,6 +184,9 @@ cred_make(int argc, char **argv)
 		case 'u':
 			flags |= FLAG_U2F;
 			break;
+		case '2':
+			flags |= FLAG_FIDO2;
+			break;
 		case 'v':
 			flags |= FLAG_UV;
 			break;
@@ -212,8 +215,13 @@ cred_make(int argc, char **argv)
 	cred = prepare_cred(in_f, type, flags);
 
 	dev = open_dev(argv[0]);
-	if (flags & FLAG_U2F)
+	if (flags & FLAG_U2F) {
 		fido_dev_force_u2f(dev);
+		if (flags & FLAG_DEBUG) fprintf(stderr, "Forcing U2F (CTAP1).\n");
+	} else if (flags & FLAG_FIDO2) {
+		fido_dev_force_fido2(dev);
+		if (flags & FLAG_DEBUG) fprintf(stderr, "Forcing FIDO2 (CTAP2).\n");
+	}
 
 	if (cred_protect > 0) {
 		r = fido_cred_set_prot(cred, cred_protect);

--- a/tools/extern.h
+++ b/tools/extern.h
@@ -32,6 +32,7 @@ struct blob {
 #define FLAG_UP		0x040
 #define FLAG_LARGEBLOB	0x080
 #define FLAG_CD		0x100
+#define FLAG_FIDO2	0x200
 
 #define PINBUF_LEN	256
 

--- a/tools/fido2-assert.c
+++ b/tools/fido2-assert.c
@@ -29,7 +29,7 @@ void
 usage(void)
 {
 	fprintf(stderr,
-"usage: fido2-assert -G [-bdhpruvw] [-t option] [-i input_file] [-o output_file] device\n"
+"usage: fido2-assert -G [-bdhpru2vw] [-t option] [-i input_file] [-o output_file] device\n"
 "       fido2-assert -V [-dhpv] [-i input_file] key_file [type]\n"
 	);
 

--- a/tools/fido2-cred.c
+++ b/tools/fido2-cred.c
@@ -27,7 +27,7 @@ void
 usage(void)
 {
 	fprintf(stderr,
-"usage: fido2-cred -M [-bdhqruvw] [-c cred_protect] [-i input_file] [-o output_file] device [type]\n"
+"usage: fido2-cred -M [-bdhqru2vw] [-c cred_protect] [-i input_file] [-o output_file] device [type]\n"
 "       fido2-cred -V [-dhv] [-c cred_protect] [-i input_file] [-o output_file] [type]\n"
 	);
 


### PR DESCRIPTION
Matching the exisitng `-u` flag to force U2F.
This can be convenient for checking that a device works correctly under FIDO2 and does not rely on fallback to U2F.

Specifically I’m currently investigating a device which should support FIDO2, failing under the CTAP2/FIDO2 mode of another implementation and wanted to cross-check that the device actually works with CTAP2 in libfido2 *(it does)*. I thought this may also be helpful to other so here’s the patch I used including documentation updates.