### PR TITLE
Add option to allow building with BoringSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ option(USE_HIDAPI        "Use hidapi as the HID backend"           OFF)
 option(USE_PCSC          "Enable experimental PCSC support"        ON)
 option(USE_WINHELLO      "Abstract Windows Hello as a FIDO device" ON)
 option(NFC_LINUX         "Enable NFC support on Linux"             ON)
+option(USE_BORINGSSL     "Build with BoringSSL"                    OFF)
 
 add_definitions(-D_FIDO_MAJOR=${FIDO_MAJOR})
 add_definitions(-D_FIDO_MINOR=${FIDO_MINOR})
@@ -85,7 +86,12 @@ if(NOT MSVC)
 	elseif(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
 		set(FIDO_CFLAGS "${FIDO_CFLAGS} -D_NETBSD_SOURCE")
 	endif()
-	set(FIDO_CFLAGS "${FIDO_CFLAGS} -std=c99")
+
+	# With BoringSSL we need a newer standard than c99
+	if(NOT USE_BORINGSSL)
+		set(FIDO_CFLAGS "${FIDO_CFLAGS} -std=c99")
+	endif()
+
 	set(CMAKE_C_FLAGS "${FIDO_CFLAGS} ${CMAKE_C_FLAGS}")
 endif()
 
@@ -219,8 +225,17 @@ if(MSVC)
 else()
 	include(FindPkgConfig)
 	pkg_search_module(CBOR libcbor)
-	pkg_search_module(CRYPTO libcrypto)
 	pkg_search_module(ZLIB zlib)
+
+	if(USE_BORINGSSL)
+		if((NOT CRYPTO_INCLUDE_DIRS) OR (NOT CRYPTO_LIBRARY_DIRS))
+			message(FATAL_ERROR "please define "
+			   "{CBOR,CRYPTO,ZLIB}_{INCLUDE,LIBRARY}_DIRS when "
+			   "building with BoringSSL")
+		endif()
+	else()
+		pkg_search_module(CRYPTO libcrypto)
+	endif()
 
 	if(NOT CBOR_FOUND AND NOT HAVE_CBOR_H)
 		message(FATAL_ERROR "could not find libcbor")

--- a/src/ecdh.c
+++ b/src/ecdh.c
@@ -7,7 +7,7 @@
 
 #include <openssl/evp.h>
 #include <openssl/sha.h>
-#if defined(LIBRESSL_VERSION_NUMBER)
+#if defined(LIBRESSL_VERSION_NUMBER) || defined(OPENSSL_IS_BORINGSSL)
 #include <openssl/hkdf.h>
 #else
 #include <openssl/kdf.h>
@@ -16,7 +16,7 @@
 #include "fido.h"
 #include "fido/es256.h"
 
-#if defined(LIBRESSL_VERSION_NUMBER)
+#if defined(LIBRESSL_VERSION_NUMBER) || defined(OPENSSL_IS_BORINGSSL)
 static int
 hkdf_sha256(uint8_t *key, const char *info, const fido_blob_t *secret)
 {

--- a/src/rs1.c
+++ b/src/rs1.c
@@ -28,6 +28,27 @@ rs1_free_EVP_MD(EVP_MD *md)
 {
 	freezero(md, sizeof(*md));
 }
+#elif defined(OPENSSL_IS_BORINGSSL)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wcast-qual"
+static EVP_MD *
+rs1_get_EVP_MD(void)
+{
+	const EVP_MD *md;
+
+	if ((md = EVP_sha1()) == NULL)
+		return (NULL);
+
+	return (EVP_MD *)md;
+}
+# pragma GCC diagnostic pop
+
+static void
+rs1_free_EVP_MD(EVP_MD *md)
+{
+	// Do not free it
+	(void)md;
+}
 #elif OPENSSL_VERSION_NUMBER >= 0x30000000
 static EVP_MD *
 rs1_get_EVP_MD(void)


### PR DESCRIPTION
To build with BoringSSL CRYPTO_INCLUDE_DIRS
and CRYPTO_LIBRARY_DIRS must be defined

Also fix all the compile issues when building
with BoringSSL