### PR TITLE
winhello: soften assertion version check for hmac-secret

### DIFF
--- a/src/webauthn.h
+++ b/src/webauthn.h
@@ -67,6 +67,11 @@ extern "C" {
 //          - WebAuthNCancelCurrentOperation
 //          - WebAuthNGetErrorName
 //          - WebAuthNGetW3CExceptionDOMError
+//      Transports:
+//          - WEBAUTHN_CTAP_TRANSPORT_USB
+//          - WEBAUTHN_CTAP_TRANSPORT_NFC
+//          - WEBAUTHN_CTAP_TRANSPORT_BLE
+//          - WEBAUTHN_CTAP_TRANSPORT_INTERNAL
 
 #define WEBAUTHN_API_VERSION_2          2
 // WEBAUTHN_API_VERSION_2 : Delta From WEBAUTHN_API_VERSION_1
@@ -92,12 +97,39 @@ extern "C" {
 //          - WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS    :   5
 //          - WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS      :   6
 //          - WEBAUTHN_ASSERTION                                :   3
+//          - WEBAUTHN_CREDENTIAL_DETAILS                       :   1
 //      APIs:
 //          - WebAuthNGetPlatformCredentialList
 //          - WebAuthNFreePlatformCredentialList
+//          - WebAuthNDeletePlatformCredential
 //
 
-#define WEBAUTHN_API_CURRENT_VERSION    WEBAUTHN_API_VERSION_4
+#define WEBAUTHN_API_VERSION_5          5
+// WEBAUTHN_API_VERSION_5 : Delta From WEBAUTHN_API_VERSION_4
+//      Data Structures and their sub versions:
+//          - WEBAUTHN_CREDENTIAL_DETAILS                       :   2
+//      Extension Changes:
+//          - Enabled LARGE_BLOB Support
+//
+
+#define WEBAUTHN_API_VERSION_6          6
+// WEBAUTHN_API_VERSION_6 : Delta From WEBAUTHN_API_VERSION_5
+//      Data Structures and their sub versions:
+//          - WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS    :   6
+//          - WEBAUTHN_CREDENTIAL_ATTESTATION                   :   5
+//          - WEBAUTHN_ASSERTION                                :   4
+//      Transports:
+//          - WEBAUTHN_CTAP_TRANSPORT_HYBRID
+
+#define WEBAUTHN_API_VERSION_7          7
+// WEBAUTHN_API_VERSION_7 : Delta From WEBAUTHN_API_VERSION_6
+//      Data Structures and their sub versions:
+//          - WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS    :   7
+//          - WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS      :   7
+//          - WEBAUTHN_CREDENTIAL_ATTESTATION                   :   6
+//          - WEBAUTHN_ASSERTION                                :   5
+
+#define WEBAUTHN_API_CURRENT_VERSION    WEBAUTHN_API_VERSION_7
 
 //+------------------------------------------------------------------------------------------
 // Information about an RP Entity
@@ -252,7 +284,8 @@ typedef const WEBAUTHN_CREDENTIALS *PCWEBAUTHN_CREDENTIALS;
 #define WEBAUTHN_CTAP_TRANSPORT_BLE         0x00000004
 #define WEBAUTHN_CTAP_TRANSPORT_TEST        0x00000008
 #define WEBAUTHN_CTAP_TRANSPORT_INTERNAL    0x00000010
-#define WEBAUTHN_CTAP_TRANSPORT_FLAGS_MASK  0x0000001F
+#define WEBAUTHN_CTAP_TRANSPORT_HYBRID      0x00000020
+#define WEBAUTHN_CTAP_TRANSPORT_FLAGS_MASK  0x0000003F
 
 #define WEBAUTHN_CREDENTIAL_EX_CURRENT_VERSION                         1
 
@@ -286,11 +319,52 @@ typedef struct _WEBAUTHN_CREDENTIAL_LIST {
 typedef const WEBAUTHN_CREDENTIAL_LIST *PCWEBAUTHN_CREDENTIAL_LIST;
 
 //+------------------------------------------------------------------------------------------
+// Information about linked devices
+//-------------------------------------------------------------------------------------------
+
+#define CTAPCBOR_HYBRID_STORAGE_LINKED_DATA_VERSION_1       1
+#define CTAPCBOR_HYBRID_STORAGE_LINKED_DATA_CURRENT_VERSION CTAPCBOR_HYBRID_STORAGE_LINKED_DATA_VERSION_1
+
+typedef struct _CTAPCBOR_HYBRID_STORAGE_LINKED_DATA
+{
+    // Version
+    DWORD dwVersion;
+
+    // Contact Id
+    DWORD cbContactId;
+    _Field_size_bytes_(cbContactId)
+    PBYTE pbContactId;
+
+    // Link Id
+    DWORD cbLinkId;
+    _Field_size_bytes_(cbLinkId)
+    PBYTE pbLinkId;
+
+    // Link secret
+    DWORD cbLinkSecret;
+    _Field_size_bytes_(cbLinkSecret)
+    PBYTE pbLinkSecret;
+
+    // Authenticator Public Key
+    DWORD cbPublicKey;
+    _Field_size_bytes_(cbPublicKey)
+    PBYTE pbPublicKey;
+
+    // Authenticator Name
+    PCWSTR pwszAuthenticatorName;
+
+    // Tunnel server domain
+    WORD wEncodedTunnelServerDomain;
+} CTAPCBOR_HYBRID_STORAGE_LINKED_DATA, *PCTAPCBOR_HYBRID_STORAGE_LINKED_DATA;
+typedef const CTAPCBOR_HYBRID_STORAGE_LINKED_DATA *PCCTAPCBOR_HYBRID_STORAGE_LINKED_DATA;
+
+//+------------------------------------------------------------------------------------------
 // Credential Information for WebAuthNGetPlatformCredentialList API
 //-------------------------------------------------------------------------------------------
 
 #define WEBAUTHN_CREDENTIAL_DETAILS_VERSION_1           1
-#define WEBAUTHN_CREDENTIAL_DETAILS_CURRENT_VERSION     WEBAUTHN_CREDENTIAL_DETAILS_VERSION_1
+#define WEBAUTHN_CREDENTIAL_DETAILS_VERSION_2           2
+#define WEBAUTHN_CREDENTIAL_DETAILS_CURRENT_VERSION     WEBAUTHN_CREDENTIAL_DETAILS_VERSION_2
 
 typedef struct _WEBAUTHN_CREDENTIAL_DETAILS {
     // Version of this structure, to allow for modifications in the future.
@@ -306,6 +380,16 @@ typedef struct _WEBAUTHN_CREDENTIAL_DETAILS {
 
     // User Info
     PWEBAUTHN_USER_ENTITY_INFORMATION   pUserInformation;
+
+    // Removable or not.
+    BOOL bRemovable;
+
+    //
+    // The following fields have been added in WEBAUTHN_CREDENTIAL_DETAILS_VERSION_2
+    //
+
+    // Backed Up or not.
+    BOOL bBackedUp;
 } WEBAUTHN_CREDENTIAL_DETAILS, *PWEBAUTHN_CREDENTIAL_DETAILS;
 typedef const WEBAUTHN_CREDENTIAL_DETAILS *PCWEBAUTHN_CREDENTIAL_DETAILS;
 
@@ -323,7 +407,7 @@ typedef struct _WEBAUTHN_GET_CREDENTIALS_OPTIONS {
     // Version of this structure, to allow for modifications in the future.
     DWORD dwVersion;
 
-    // RPID
+    // Optional.
     LPCWSTR pwszRpId;
 
     // Optional. BrowserInPrivate Mode. Defaulting to FALSE.
@@ -340,7 +424,7 @@ typedef const WEBAUTHN_GET_CREDENTIALS_OPTIONS *PCWEBAUTHN_GET_CREDENTIALS_OPTIO
 // SALT values below by default are converted into RAW Hmac-Secret values as per PRF extension.
 //   - SHA-256(UTF8Encode("WebAuthn PRF") || 0x00 || Value)
 //
-// Set WEBAUTHN_CTAP_HMAC_SECRET_VALUES_FLAG in dwFlags in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS,
+// Set WEBAUTHN_AUTHENTICATOR_HMAC_SECRET_VALUES_FLAG in dwFlags in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS,
 //   if caller wants to provide RAW Hmac-Secret SALT values directly. In that case,
 //   values if provided MUST be of WEBAUTHN_CTAP_ONE_HMAC_SECRET_LENGTH size.
 
@@ -516,7 +600,9 @@ typedef const WEBAUTHN_EXTENSIONS *PCWEBAUTHN_EXTENSIONS;
 #define WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_3            3
 #define WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_4            4
 #define WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_5            5
-#define WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_CURRENT_VERSION      WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_5
+#define WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_6            6
+#define WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_7            7
+#define WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_CURRENT_VERSION      WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_7
 
 typedef struct _WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS {
     // Version of this structure, to allow for modifications in the future.
@@ -585,6 +671,24 @@ typedef struct _WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS {
     // Optional. BrowserInPrivate Mode. Defaulting to FALSE.
     BOOL bBrowserInPrivateMode;
 
+    //
+    // The following fields have been added in WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_6
+    //
+
+    // Enable PRF
+    BOOL bEnablePrf;
+
+    //
+    // The following fields have been added in WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_7
+    //
+
+    // Optional. Linked Device Connection Info.
+    PCTAPCBOR_HYBRID_STORAGE_LINKED_DATA pLinkedDevice;
+
+    // Size of pbJsonExt
+    DWORD cbJsonExt;
+    _Field_size_bytes_(cbJsonExt)
+    PBYTE pbJsonExt;
 } WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS, *PWEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS;
 typedef const WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS *PCWEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS;
 
@@ -599,7 +703,8 @@ typedef const WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS *PCWEBAUTHN_AUTHENT
 #define WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_4          4
 #define WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_5          5
 #define WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_6          6
-#define WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_CURRENT_VERSION    WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_6
+#define WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_7          7
+#define WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_CURRENT_VERSION    WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_7
 
 /*
     Information about flags.
@@ -676,6 +781,20 @@ typedef struct _WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS {
     // Optional. BrowserInPrivate Mode. Defaulting to FALSE.
     BOOL bBrowserInPrivateMode;
 
+    //
+    // The following fields have been added in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_7
+    //
+
+    // Optional. Linked Device Connection Info.
+    PCTAPCBOR_HYBRID_STORAGE_LINKED_DATA pLinkedDevice;
+
+    // Optional. Allowlist MUST contain 1 credential applicable for Hybrid transport.
+    BOOL bAutoFill;
+
+    // Size of pbJsonExt
+    DWORD cbJsonExt;
+    _Field_size_bytes_(cbJsonExt)
+    PBYTE pbJsonExt;
 } WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS,  *PWEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS;
 typedef const WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS  *PCWEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS;
 
@@ -752,7 +871,9 @@ typedef const WEBAUTHN_COMMON_ATTESTATION *PCWEBAUTHN_COMMON_ATTESTATION;
 #define WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_2               2
 #define WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_3               3
 #define WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_4               4
-#define WEBAUTHN_CREDENTIAL_ATTESTATION_CURRENT_VERSION         WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_4
+#define WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_5               5
+#define WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_6               6
+#define WEBAUTHN_CREDENTIAL_ATTESTATION_CURRENT_VERSION         WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_6
 
 typedef struct _WEBAUTHN_CREDENTIAL_ATTESTATION {
     // Version of this structure, to allow for modifications in the future.
@@ -815,6 +936,19 @@ typedef struct _WEBAUTHN_CREDENTIAL_ATTESTATION {
     BOOL bLargeBlobSupported;
     BOOL bResidentKey;
 
+    //
+    // Following fields have been added in WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_5
+    //
+
+    BOOL bPrfEnabled;
+
+    //
+    // Following fields have been added in WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_6
+    //
+
+    DWORD cbUnsignedExtensionOutputs;
+    _Field_size_bytes_(cbUnsignedExtensionOutputs)
+    PBYTE pbUnsignedExtensionOutputs;
 } WEBAUTHN_CREDENTIAL_ATTESTATION, *PWEBAUTHN_CREDENTIAL_ATTESTATION;
 typedef const WEBAUTHN_CREDENTIAL_ATTESTATION *PCWEBAUTHN_CREDENTIAL_ATTESTATION;
 
@@ -837,7 +971,9 @@ typedef const WEBAUTHN_CREDENTIAL_ATTESTATION *PCWEBAUTHN_CREDENTIAL_ATTESTATION
 #define WEBAUTHN_ASSERTION_VERSION_1                            1
 #define WEBAUTHN_ASSERTION_VERSION_2                            2
 #define WEBAUTHN_ASSERTION_VERSION_3                            3
-#define WEBAUTHN_ASSERTION_CURRENT_VERSION                      WEBAUTHN_ASSERTION_VERSION_3
+#define WEBAUTHN_ASSERTION_VERSION_4                            4
+#define WEBAUTHN_ASSERTION_VERSION_5                            5
+#define WEBAUTHN_ASSERTION_CURRENT_VERSION                      WEBAUTHN_ASSERTION_VERSION_5
 
 typedef struct _WEBAUTHN_ASSERTION {
     // Version of this structure, to allow for modifications in the future.
@@ -883,6 +1019,21 @@ typedef struct _WEBAUTHN_ASSERTION {
 
     PWEBAUTHN_HMAC_SECRET_SALT pHmacSecret;
 
+    //
+    // Following fields have been added in WEBAUTHN_ASSERTION_VERSION_4
+    //
+
+    // One of the WEBAUTHN_CTAP_TRANSPORT_* bits will be set corresponding to
+    // the transport that was used.
+    DWORD dwUsedTransport;
+
+    //
+    // Following fields have been added in WEBAUTHN_ASSERTION_VERSION_5
+    //
+
+    DWORD cbUnsignedExtensionOutputs;
+    _Field_size_bytes_(cbUnsignedExtensionOutputs)
+    PBYTE pbUnsignedExtensionOutputs;
 } WEBAUTHN_ASSERTION, *PWEBAUTHN_ASSERTION;
 typedef const WEBAUTHN_ASSERTION *PCWEBAUTHN_ASSERTION;
 
@@ -941,6 +1092,7 @@ WINAPI
 WebAuthNCancelCurrentOperation(
     _In_ const GUID* pCancellationId);
 
+// Returns NTE_NOT_FOUND when credentials are not found.
 HRESULT
 WINAPI
 WebAuthNGetPlatformCredentialList(
@@ -951,6 +1103,13 @@ void
 WINAPI
 WebAuthNFreePlatformCredentialList(
     _In_ PWEBAUTHN_CREDENTIAL_DETAILS_LIST  pCredentialDetailsList);
+
+HRESULT
+WINAPI
+WebAuthNDeletePlatformCredential(
+    _In_ DWORD cbCredentialId,
+    _In_reads_bytes_(cbCredentialId) const BYTE *pbCredentialId
+    );
 
 //
 // Returns the following Error Names:

--- a/src/winhello.c
+++ b/src/winhello.c
@@ -408,6 +408,10 @@ pack_cred_ext(WEBAUTHN_EXTENSIONS *out, const fido_cred_ext_t *in)
 	}
 	out->cExtensions = (DWORD)n;
 	if (in->mask & FIDO_EXT_HMAC_SECRET) {
+		/*
+		 * NOTE: webauthn.dll ignores requests to enable hmac-secret
+		 * unless a discoverable credential is also requested.
+		 */
 		if ((b = calloc(1, sizeof(*b))) == NULL) {
 			fido_log_debug("%s: calloc", __func__);
 			return -1;

--- a/src/winhello.c
+++ b/src/winhello.c
@@ -570,7 +570,7 @@ unpack_user_id(fido_assert_t *assert, const WEBAUTHN_ASSERTION *wa)
 static int
 unpack_hmac_secret(fido_assert_t *assert, const WEBAUTHN_ASSERTION *wa)
 {
-	if (wa->dwVersion != WEBAUTHN_ASSERTION_VERSION_3) {
+	if (wa->dwVersion < WEBAUTHN_ASSERTION_VERSION_3) {
 		fido_log_debug("%s: dwVersion %u", __func__,
 		    (unsigned)wa->dwVersion);
 		return 0; /* proceed without hmac-secret */


### PR DESCRIPTION
We are unnecessarily strict when checking the presence of the `pHmacSecret` attribute in the assertion.

While here, add a note about credential creation quirks and fetch the latest available version of `webauthn.h`.