### PR TITLE
actions: drop the macos-11 runner

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-13, macos-12, macos-11 ]
+        os: [ macos-13, macos-12 ]
         cc: [ clang ]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Brew no longer officially supports macOS Big Sur, resulting in [CI pipelines taking almost 5 hours to complete](https://github.com/Yubico/libfido2/actions/runs/6767944187/job/18391442595).