### PR TITLE
bump/adjust various things

### DIFF
--- a/.actions/build-linux-openssl3-i686-w64-mingw32-gcc
+++ b/.actions/build-linux-openssl3-i686-w64-mingw32-gcc
@@ -32,7 +32,7 @@ make -j"$(nproc)" -C build
 sudo make -C build install
 cd ..
 
-# Build and install OpenSSL 3.0.11.
+# Build and install OpenSSL 3.0.12.
 git clone --branch openssl-3.0.12 \
 	--depth=1 https://github.com/openssl/openssl
 cd openssl

--- a/.github/workflows/alpine_builds.yml
+++ b/.github/workflows/alpine_builds.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: alpine:latest
     strategy:
       fail-fast: false

--- a/.github/workflows/cifuzz_oss.yml
+++ b/.github/workflows/cifuzz_oss.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   fuzzing:
     if: github.repository == 'Yubico/libfido2'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -26,10 +26,10 @@ jobs:
           - { os: ubuntu-22.04, cc: gcc-10 }
           - { os: ubuntu-22.04, cc: gcc-11 }
           - { os: ubuntu-22.04, cc: gcc-12 }
-          - { os: ubuntu-22.04, cc: clang-13 }
           - { os: ubuntu-22.04, cc: clang-14 }
           - { os: ubuntu-22.04, cc: clang-15 }
           - { os: ubuntu-22.04, cc: clang-16 }
+          - { os: ubuntu-22.04, cc: clang-17 }
           - { os: ubuntu-20.04, cc: i686-w64-mingw32-gcc-9 }
           - { os: ubuntu-22.04, cc: i686-w64-mingw32-gcc-10 }
     steps:

--- a/.github/workflows/linux_fuzz.yml
+++ b/.github/workflows/linux_fuzz.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-22.04 ]
-        cc: [ clang-16 ]
+        cc: [ clang-17 ]
         sanitizer: [ asan, msan ]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/openssl3.yml
+++ b/.github/workflows/openssl3.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            cc: gcc-11
+            cc: gcc-12
           - os: ubuntu-22.04
             cc: clang-16
           - os: ubuntu-22.04

--- a/.github/workflows/openssl3.yml
+++ b/.github/workflows/openssl3.yml
@@ -24,7 +24,7 @@ jobs:
           - os: ubuntu-22.04
             cc: gcc-12
           - os: ubuntu-22.04
-            cc: clang-16
+            cc: clang-17
           - os: ubuntu-22.04
             cc: i686-w64-mingw32-gcc-10
     steps:

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+* Version 1.15.0 (unreleased)
+ ** 1.15.0 will be the last release to support OpenSSL 1.1.
+
 * Version 1.14.0 (2023-11-13)
  ** fido2-cred -M, fido2-token -G: support raw client data via -w flag.
  ** winhello: support U2F AppID extension for assertions.


### PR DESCRIPTION
- actions: adjust OpenSSL 3.0.12 comment;
- actions: move alpine, cifuzz builds to ubuntu-22.04;
- actions: move OpenSSL 3.0 to gcc-12;
- actions: build, fuzz with clang-17;
- NEWS: mention plans to drop OpenSSL 1.1 after 1.15.0.