### PR TITLE
actions/build-osx-clang: tweak brew

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: dependencies
+      env:
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: brew install libcbor llvm mandoc openssl@3.0 pkg-config zlib
     - name: build
       env:


### PR DESCRIPTION
set HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK, so that 'brew install' does not imply the upgrade or reinstallation of dependent packages. this is needed as github actions' image comes with a significant amount of pre-installed packages, and given we install llvm and zlib, a bunch of unrelated packages were being reinstalled. the corollary is that it is now our responsibility to manually upgrade/reinstall any dependents we are interested in. at the moment that's an empty set, and while it is likely to remain that way, here's a note of caution to future readers.