### PR TITLE
Add -Wno-deprecated-declarations for Linux/Mac build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,8 @@ else()
 	add_compile_options(-Wmissing-prototypes)
 	add_compile_options(-Wbad-function-cast)
 	add_compile_options(-Wimplicit-fallthrough)
+	# TODO: remove the following line after we stop supporting OpenSSL@1.1
+	add_compile_options(-Wno-deprecated-declarations)
 	add_compile_options(-pedantic)
 	add_compile_options(-pedantic-errors)
 


### PR DESCRIPTION
We witnessed the following compile errors when building libfido2 on our MacOS build environment (Ventura with Xcode 14.3.1):

```
<our custom path>/libfido2/src/cbor.c:759:13: error: 'HMAC_CTX_new' is deprecated [-Werror,-Wdeprecated-declarations]
        if ((ctx = HMAC_CTX_new()) == NULL ||
                   ^
/usr/local/include/openssl/hmac.h:33:1: note: 'HMAC_CTX_new' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 HMAC_CTX *HMAC_CTX_new(void);
^
/usr/local/include/openssl/macros.h:193:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)
                                                ^
/usr/local/include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))
```

IIUC this is because either `-Wall` or `-Wextra` includes `-Wdeprecated-declarations` and `-Werror` turns that into an error.

I'm not sure why the upstream did not have this error: maybe it's a specific issue for XCode 14.3.1 only?

Since we are still supporting OpenSSL 1.1, I think it makes sense to add `-Wno-deprecated-declarations` explicitly until we bump OpenSSL version to 3.0 (from the NEWS file Yubico is going to do so in 1.16?).