### PR TITLE
osx: handle report_callback() firing multiple times

### DIFF
--- a/src/hid_osx.c
+++ b/src/hid_osx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 Yubico AB. All rights reserved.
+ * Copyright (c) 2019-2023 Yubico AB. All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  * SPDX-License-Identifier: BSD-2-Clause
@@ -523,6 +523,21 @@ fido_hid_set_sigmask(void *handle, const fido_sigset_t *sigmask)
 	return (FIDO_ERR_INTERNAL);
 }
 
+static void
+schedule_io_loop(struct hid_osx *ctx, int ms)
+{
+	IOHIDDeviceScheduleWithRunLoop(ctx->ref, CFRunLoopGetCurrent(),
+	    ctx->loop_id);
+
+	if (ms == -1)
+		ms = 5000; /* wait 5 seconds by default */
+
+	CFRunLoopRunInMode(ctx->loop_id, (double)ms/1000.0, true);
+
+	IOHIDDeviceUnscheduleFromRunLoop(ctx->ref, CFRunLoopGetCurrent(),
+	    ctx->loop_id);
+}
+
 int
 fido_hid_read(void *handle, unsigned char *buf, size_t len, int ms)
 {
@@ -537,16 +552,7 @@ fido_hid_read(void *handle, unsigned char *buf, size_t len, int ms)
 		return (-1);
 	}
 
-	IOHIDDeviceScheduleWithRunLoop(ctx->ref, CFRunLoopGetCurrent(),
-	    ctx->loop_id);
-
-	if (ms == -1)
-		ms = 5000; /* wait 5 seconds by default */
-
-	CFRunLoopRunInMode(ctx->loop_id, (double)ms/1000.0, true);
-
-	IOHIDDeviceUnscheduleFromRunLoop(ctx->ref, CFRunLoopGetCurrent(),
-	    ctx->loop_id);
+	schedule_io_loop(ctx, ms);
 
 	if ((r = read(ctx->report_pipe[0], buf, len)) == -1) {
 		fido_log_error(errno, "%s: read", __func__);


### PR DESCRIPTION
One invocation of `CFRunLoopRunInMode()` may fire `report_callback()`
multiple times. In such a case, the next call to `fido_hid_read()` may
block for the full duration of the timeout. We can handle this by
querying the (non-blocking) pipe for any readily available data on
entering `fido_hid_read()` and fall back to executing the run loop if it
was empty.

Debugged with @elibon99 and @martelletto.

Resolves #763 