### PR TITLE
hid_netbsd: move null pointer check before dereference

### DIFF
--- a/src/hid_netbsd.c
+++ b/src/hid_netbsd.c
@@ -127,13 +127,13 @@ fido_hid_manifest(fido_dev_info_t *devlist, size_t ilen, size_t *olen)
 	char	path[64];
 	size_t	i;
 
+	if (devlist == NULL || olen == NULL)
+		return (FIDO_ERR_INVALID_ARGUMENT);
+
 	*olen = 0;
 
 	if (ilen == 0)
 		return (FIDO_OK); /* nothing to do */
-
-	if (devlist == NULL || olen == NULL)
-		return (FIDO_ERR_INVALID_ARGUMENT);
 
 	for (i = *olen = 0; i < MAX_UHID && *olen < ilen; i++) {
 		snprintf(path, sizeof(path), "/dev/uhid%zu", i);


### PR DESCRIPTION
Found when trying out smatch