### PR TITLE
actions: bump libcbor to v0.11.0

### DIFF
--- a/.actions/build-linux-i686-w64-mingw32-gcc
+++ b/.actions/build-linux-i686-w64-mingw32-gcc
@@ -23,7 +23,7 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 EOF
 
 # Build and install libcbor.
-git clone --depth=1 https://github.com/pjk/libcbor -b v0.10.1
+git clone --depth=1 https://github.com/pjk/libcbor -b v0.11.0
 cd libcbor
 mkdir build
 (cd build && cmake -DCMAKE_TOOLCHAIN_FILE=/tmp/mingw.cmake \

--- a/.actions/build-linux-openssl3-i686-w64-mingw32-gcc
+++ b/.actions/build-linux-openssl3-i686-w64-mingw32-gcc
@@ -23,7 +23,7 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 EOF
 
 # Build and install libcbor.
-git clone --depth=1 https://github.com/pjk/libcbor -b v0.10.1
+git clone --depth=1 https://github.com/pjk/libcbor -b v0.11.0
 cd libcbor
 mkdir build
 (cd build && cmake -DCMAKE_TOOLCHAIN_FILE=/tmp/mingw.cmake \

--- a/.actions/fuzz-linux
+++ b/.actions/fuzz-linux
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 LIBCBOR_URL="https://github.com/pjk/libcbor"
-LIBCBOR_TAG="v0.10.2"
+LIBCBOR_TAG="v0.11.0"
 LIBCBOR_ASAN="address alignment bounds"
 LIBCBOR_MSAN="memory"
 OPENSSL_URL="https://github.com/openssl/openssl"

--- a/fuzz/Dockerfile
+++ b/fuzz/Dockerfile
@@ -10,7 +10,7 @@ RUN apk -q update
 RUN apk add build-base clang clang-analyzer cmake compiler-rt coreutils
 RUN apk add eudev-dev git linux-headers llvm openssl-dev pcsc-lite-dev
 RUN apk add sudo tar zlib-dev
-RUN git clone --branch v0.10.2 --depth=1 https://github.com/PJK/libcbor
+RUN git clone --branch v0.11.0 --depth=1 https://github.com/PJK/libcbor
 RUN git clone --depth=1 https://github.com/yubico/libfido2
 WORKDIR /libfido2
 RUN ./fuzz/build-coverage /libcbor /libfido2

--- a/windows/const.ps1
+++ b/windows/const.ps1
@@ -11,8 +11,8 @@ New-Variable -Name 'LIBRESSL' -Value 'libressl-3.8.2' -Option Constant
 New-Variable -Name 'CRYPTO_LIBRARIES' -Value 'crypto' -Option Constant
 
 # libcbor coordinates.
-New-Variable -Name 'LIBCBOR' -Value 'libcbor-0.10.2' -Option Constant
-New-Variable -Name 'LIBCBOR_BRANCH' -Value 'v0.10.2' -Option Constant
+New-Variable -Name 'LIBCBOR' -Value 'libcbor-0.11.0' -Option Constant
+New-Variable -Name 'LIBCBOR_BRANCH' -Value 'v0.11.0' -Option Constant
 New-Variable -Name 'LIBCBOR_GIT' -Value 'https://github.com/pjk/libcbor' `
     -Option Constant
 


### PR DESCRIPTION
libcbor 0.11.0 was released on 2024-02-04: https://github.com/PJK/libcbor/releases/tag/v0.11.0.