### PR TITLE
actions: disable use-keyboxd

### DIFF
--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -98,6 +98,13 @@ New-Item -Type Directory "${STAGE}\${LIBRESSL}" -Force
 New-Item -Type Directory "${STAGE}\${LIBCBOR}" -Force
 New-Item -Type Directory "${STAGE}\${ZLIB}" -Force
 
+# Create GNUPGHOME with an empty common.conf to disable use-keyboxd.
+# Recent default is to enable keyboxd which in turn ignores --keyring
+# arguments.
+$GpgHome = "${BUILD}\.gnupg"
+New-Item -Type Directory "${GpgHome}" -Force
+New-Item -Type File "${GpgHome}\common.conf" -Force
+
 # Create output directories.
 New-Item -Type Directory "${OUTPUT}" -Force
 New-Item -Type Directory "${OUTPUT}\${Arch}" -Force
@@ -117,8 +124,9 @@ try {
 		}
 
 		Copy-Item "$PSScriptRoot\libressl.gpg" -Destination "${BUILD}"
-		& $GPG --list-keys
-		& $GPG --quiet --no-default-keyring --keyring ./libressl.gpg `
+		& $GPG --homedir ${GpgHome} --list-keys
+		& $GPG --homedir ${GpgHome} --quiet --no-default-keyring `
+		    --keyring ./libressl.gpg `
 		    --verify .\${LIBRESSL}.tar.gz.asc .\${LIBRESSL}.tar.gz
 		if ($LastExitCode -ne 0) {
 			throw "GPG signature verification failed"

--- a/windows/cygwin.ps1
+++ b/windows/cygwin.ps1
@@ -38,6 +38,13 @@ Write-Host "GPG: $GPG"
 New-Item -Type Directory "${Cygwin}" -Force
 New-Item -Type Directory "${Root}" -Force
 
+# Create GNUPGHOME with an empty common.conf to disable use-keyboxd.
+# Recent default is to enable keyboxd which in turn ignores --keyring
+# arguments.
+$GpgHome = "${Cygwin}\.gnupg"
+New-Item -Type Directory "${GpgHome}" -Force
+New-Item -Type File "${GpgHome}\common.conf" -Force
+
 # Fetch and verify Cygwin.
 try {
 	if (-Not (Test-Path ${Cygwin}\${Setup} -PathType leaf)) {
@@ -48,8 +55,8 @@ try {
 		Invoke-WebRequest ${URL}/${Setup}.sig `
 		    -OutFile ${Cygwin}\${Setup}.sig
 	}
-	& $GPG --list-keys
-	& $GPG --quiet --no-default-keyring `
+	& $GPG --homedir ${GpgHome} --list-keys
+	& $GPG --homedir ${GpgHome} --quiet --no-default-keyring `
 	    --keyring ${PSScriptRoot}/cygwin.gpg `
 	    --verify ${Cygwin}\${Setup}.sig ${Cygwin}\${Setup}
 	if ($LastExitCode -ne 0) {


### PR DESCRIPTION
If the default home directory ~/.gnupg does not exist, GnuPG creates this directory and a common.conf file with "use-keyboxd". If the option use-keyboxd is enabled in common.conf, no keyrings are used at all and keys are all maintained by the keyboxd process in its own database. This seemingly includes any keyring specified via the --keyring option and this breaks our signature verification of dependencies that we download in our Windows pipelines (see e.g. https://github.com/Yubico/libfido2/actions/runs/8082292785/job/22083086167#step:3:23).