### PR TITLE
fuzz: add temporary ASLR workaround

### DIFF
--- a/.github/workflows/linux_fuzz.yml
+++ b/.github/workflows/linux_fuzz.yml
@@ -34,6 +34,9 @@ jobs:
         CC: ${{ matrix.cc }}
       run: |
         sudo ./.actions/setup_clang "${CC}"
+    # XXX https://github.com/actions/runner-images/issues/9491
+    - name: workaround
+      run: sudo sysctl vm.mmap_rnd_bits=28
     - name: fuzz
       env:
         CC: ${{ matrix.cc }}


### PR DESCRIPTION
MSAN pipeline is currently failing because of the issue explained in https://github.com/actions/runner-images/issues/9491, revisit once resolved.