### PR TITLE
Fix potential memory leak

### DIFF
--- a/tools/credman.c
+++ b/tools/credman.c
@@ -119,6 +119,7 @@ print_rk(const fido_credman_rk_t *rk, size_t idx)
 	char *user_id = NULL;
 	const char *type;
 	const char *prot;
+	int r = -1;
 
 	if ((cred = fido_credman_rk(rk, idx)) == NULL) {
 		warnx("fido_credman_rk");
@@ -127,10 +128,8 @@ print_rk(const fido_credman_rk_t *rk, size_t idx)
 	if (base64_encode(fido_cred_id_ptr(cred), fido_cred_id_len(cred),
 	    &id) < 0 || base64_encode(fido_cred_user_id_ptr(cred),
 	    fido_cred_user_id_len(cred), &user_id) < 0) {
-		free(user_id);
-		free(id);
 		warnx("output error");
-		return -1;
+		goto out;
 	}
 
 	type = cose_string(fido_cred_type(cred));
@@ -139,10 +138,12 @@ print_rk(const fido_credman_rk_t *rk, size_t idx)
 	printf("%02u: %s %s %s %s %s\n", (unsigned)idx, id,
 	    fido_cred_display_name(cred), user_id, type, prot);
 
+	r = 0;
+out:
 	free(user_id);
 	free(id);
 
-	return 0;
+	return r;
 }
 
 int

--- a/tools/credman.c
+++ b/tools/credman.c
@@ -127,6 +127,8 @@ print_rk(const fido_credman_rk_t *rk, size_t idx)
 	if (base64_encode(fido_cred_id_ptr(cred), fido_cred_id_len(cred),
 	    &id) < 0 || base64_encode(fido_cred_user_id_ptr(cred),
 	    fido_cred_user_id_len(cred), &user_id) < 0) {
+		free(user_id);
+		free(id);
 		warnx("output error");
 		return -1;
 	}


### PR DESCRIPTION
If first allocation succeeds and the 2nd fails, the `id` variable may be allocated and not freed. It's probably near to impossible case but it's worth fixing it for automation scan's sake