### PR TITLE
Revert temporary ASLR workaround

### DIFF
--- a/.github/workflows/linux_fuzz.yml
+++ b/.github/workflows/linux_fuzz.yml
@@ -34,9 +34,6 @@ jobs:
         CC: ${{ matrix.cc }}
       run: |
         sudo ./.actions/setup_clang "${CC}"
-    # XXX https://github.com/actions/runner-images/issues/9491
-    - name: workaround
-      run: sudo sysctl vm.mmap_rnd_bits=28
     - name: fuzz
       env:
         CC: ${{ matrix.cc }}


### PR DESCRIPTION
This reverts commit f80654cfc523ef3f8ca24c9bac5aa5811189f999 since actions/runner-images#9491 was closed.