### PR TITLE
ci: add macos-14 runner

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-13, macos-12 ]
+        os: [ macos-14, macos-13, macos-12 ]
         cc: [ clang ]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/