### PR TITLE
actions: bump FreeBSD, OpenBSD versions

### DIFF
--- a/.actions/build-bsd
+++ b/.actions/build-bsd
@@ -15,7 +15,7 @@ cat > "${MANIFEST}" <<- EOF
 image: ${IMAGE}
 packages:
   - cmake
-  - llvm
+  - llvm${LLVM_VERSION:+%${LLVM_VERSION}}
   - pcsc-lite
 EOF
 
@@ -38,7 +38,7 @@ tasks:
       else
         SUDO=sudo
       fi
-      SCAN="/usr/local/bin/scan-build --use-cc=/usr/bin/cc --status-bugs"
+      SCAN="/usr/local/bin/scan-build${LLVM_VERSION:+-${LLVM_VERSION}} --use-cc=/usr/bin/cc --status-bugs"
       cd libfido2
       for T in Debug Release; do
         mkdir build-\$T

--- a/.github/workflows/bsd_builds.yml
+++ b/.github/workflows/bsd_builds.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [freebsd/13.x, openbsd/7.3]
+        image: [freebsd/14.x, openbsd/7.3]
     steps:
     - uses: actions/checkout@v4
     - name: dependencies

--- a/.github/workflows/bsd_builds.yml
+++ b/.github/workflows/bsd_builds.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [freebsd/14.x, openbsd/7.3]
+        image: [freebsd/14.x, openbsd/7.4]
     steps:
     - uses: actions/checkout@v4
     - name: dependencies

--- a/.github/workflows/bsd_builds.yml
+++ b/.github/workflows/bsd_builds.yml
@@ -18,7 +18,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [freebsd/14.x, openbsd/7.4]
+        include:
+          - { image: freebsd/14.x }
+          - { image: openbsd/7.4, llvm_version: 16 }
     steps:
     - uses: actions/checkout@v4
     - name: dependencies
@@ -27,6 +29,7 @@ jobs:
         sudo apt install -q -y curl jq
     - name: build
       env:
+        LLVM_VERSION: ${{ matrix.llvm_version }}
         IMAGE: ${{ matrix.image }}
         SOURCEHUT_TOKEN: ${{ secrets.SOURCEHUT_TOKEN }}
       run: ./.actions/build-bsd


### PR DESCRIPTION
While here we had to also disambiguate which LLVM and scan-build version to use.