### PR TITLE
U2F key_lookup: do not fail upon SW_WRONG_LENGTH (0x6700)

### DIFF
--- a/src/fido/param.h
+++ b/src/fido/param.h
@@ -74,6 +74,7 @@
 
 /* ISO7816-4 status words. */
 #define SW1_MORE_DATA			0x61
+#define SW_WRONG_LENGTH			0x6700
 #define SW_CONDITIONS_NOT_SATISFIED	0x6985
 #define SW_WRONG_DATA			0x6a80
 #define SW_NO_ERROR			0x9000

--- a/src/u2f.c
+++ b/src/u2f.c
@@ -260,6 +260,7 @@ key_lookup(fido_dev_t *dev, const char *rp_id, const fido_blob_t *key_id,
 		*found = 1; /* key exists */
 		break;
 	case SW_WRONG_DATA:
+	case SW_WRONG_LENGTH:
 		*found = 0; /* key does not exist */
 		break;
 	default:


### PR DESCRIPTION
According to u2f spec: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html#status-codes, U2F security keys can return `0x6700` in addition to `0x6A80` when given invalid key handles.

This occurs to our internally developed security keys when the key handle is too long.