### PR TITLE
man: specify es384 as a valid type for fido2-{cred,assert}

### DIFF
--- a/man/fido2-assert.1
+++ b/man/fido2-assert.1
@@ -89,6 +89,8 @@ where
 may be
 .Em es256
 (denoting ECDSA over NIST P-256 with SHA-256),
+.Em es384
+(denoting ECDSA over NIST P-384 with SHA-384),
 .Em rs256
 (denoting 2048-bit RSA with PKCS#1.5 padding and SHA-256), or
 .Em eddsa

--- a/man/fido2-cred.1
+++ b/man/fido2-cred.1
@@ -56,6 +56,8 @@ A credential
 may be
 .Em es256
 (denoting ECDSA over NIST P-256 with SHA-256),
+.Em es384
+(denoting ECDSA over NIST P-384 with SHA-384),
 .Em rs256
 (denoting 2048-bit RSA with PKCS#1.5 padding and SHA-256), or
 .Em eddsa


### PR DESCRIPTION
Supported since 1.12.0.