### PR TITLE
Allow len < 16 for aes256-gcm encryption

### DIFF
--- a/src/aes256.c
+++ b/src/aes256.c
@@ -128,7 +128,11 @@ aes256_gcm(const fido_blob_t *key, const fido_blob_t *nonce,
 		    nonce->len, key->len, aad->len);
 		goto fail;
 	}
-	if (in->len > UINT_MAX || in->len > SIZE_MAX - 16 || in->len < 16) {
+	if (in->len > UINT_MAX || in->len > SIZE_MAX - 16) {
+		fido_log_debug("%s: invalid input len %zu", __func__, in->len);
+		goto fail;
+	}
+	if (!encrypt && in->len < 16) {
 		fido_log_debug("%s: invalid input len %zu", __func__, in->len);
 		goto fail;
 	}


### PR DESCRIPTION
Only decryption should check `len < 16`.