### PR TITLE
ci: pin Windows SDK for ARM builds

### DIFF
--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -74,11 +74,13 @@ if (-Not (Test-Path $GPG)) {
 	throw "Unable to find GPG at $GPG"
 }
 
-# Override CMAKE_SYSTEM_VERSION if $WinSDK is set.
+# 10.0.261000.0 appear to have dropped ARM32 support, pin the SDK version
+if ($Arch -eq "ARM" -and [string]::IsNullOrEmpty($WinSDK)) {
+	$WinSDK = '10.0.22621.0'
+}
+# Override Windows SDK version if $WinSDK is set.
 if (-Not ([string]::IsNullOrEmpty($WinSDK))) {
-	$CMAKE_SYSTEM_VERSION = "-DCMAKE_SYSTEM_VERSION='$WinSDK'"
-} else {
-	$CMAKE_SYSTEM_VERSION = ''
+	$Arch = "$Arch,version=$WinSDK"
 }
 
 Write-Host "WinSDK: $WinSDK"
@@ -155,7 +157,7 @@ try {
 	    -DLIBRESSL_APPS=OFF -DCMAKE_C_FLAGS_DEBUG="${CFLAGS_DEBUG}" `
 	    -DCMAKE_C_FLAGS_RELEASE="${CFLAGS_RELEASE}" `
 	    -DCMAKE_MSVC_RUNTIME_LIBRARY="${CMAKE_MSVC_RUNTIME_LIBRARY}" `
-	    -DCMAKE_INSTALL_PREFIX="${PREFIX}" "${CMAKE_SYSTEM_VERSION}"; `
+	    -DCMAKE_INSTALL_PREFIX="${PREFIX}"; `
 	    ExitOnError
 	& $CMake --build . --config ${Config} --verbose; ExitOnError
 	& $CMake --build . --config ${Config} --target install --verbose; `
@@ -174,7 +176,7 @@ try {
 	    -DBUILD_SHARED_LIBS="${SHARED}" `
 	    -DCMAKE_C_FLAGS_DEBUG="${CFLAGS_DEBUG} /wd4703" `
 	    -DCMAKE_C_FLAGS_RELEASE="${CFLAGS_RELEASE} /wd4703" `
-	    -DCMAKE_INSTALL_PREFIX="${PREFIX}" "${CMAKE_SYSTEM_VERSION}"; `
+	    -DCMAKE_INSTALL_PREFIX="${PREFIX}"; `
 	    ExitOnError
 	& $CMake --build . --config ${Config} --verbose; ExitOnError
 	& $CMake --build . --config ${Config} --target install --verbose; `
@@ -193,7 +195,7 @@ try {
 	    -DCMAKE_C_FLAGS_DEBUG="${CFLAGS_DEBUG}" `
 	    -DCMAKE_C_FLAGS_RELEASE="${CFLAGS_RELEASE}" `
 	    -DCMAKE_MSVC_RUNTIME_LIBRARY="${CMAKE_MSVC_RUNTIME_LIBRARY}" `
-	    -DCMAKE_INSTALL_PREFIX="${PREFIX}" "${CMAKE_SYSTEM_VERSION}"; `
+	    -DCMAKE_INSTALL_PREFIX="${PREFIX}"; `
 	    ExitOnError
 	& $CMake --build . --config ${Config} --verbose; ExitOnError
 	& $CMake --build . --config ${Config} --target install --verbose; `
@@ -232,7 +234,7 @@ try {
 	    -DCRYPTO_LIBRARIES="${CRYPTO_LIBRARIES}" `
 	    -DCMAKE_C_FLAGS_DEBUG="${CFLAGS_DEBUG} ${Fido2Flags}" `
 	    -DCMAKE_C_FLAGS_RELEASE="${CFLAGS_RELEASE} ${Fido2Flags}" `
-	    -DCMAKE_INSTALL_PREFIX="${PREFIX}" "${CMAKE_SYSTEM_VERSION}"; `
+	    -DCMAKE_INSTALL_PREFIX="${PREFIX}"; `
 	    ExitOnError
 	& $CMake --build . --config ${Config} --verbose; ExitOnError
 	& $CMake --build . --config ${Config} --target regress --verbose; `


### PR DESCRIPTION
See for example https://github.com/actions/runner-images/issues/10981
Failing pipeline: https://github.com/Yubico/libfido2/actions/runs/12120784303/job/33790258713#step:3:159

While here, use the -A Arch,version= syntax since CMake may ignore
CMAKE_SYSTEM_VERSION.