### PR TITLE
ci: bring in macos-15 runner

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-14, macos-13 ]
+        os: [ macos-15, macos-14, macos-13 ]
         cc: [ clang ]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Note that the macos-15 runner is in public preview.