### PR TITLE
ci: bump upload-artifact to v4

### DIFF
--- a/.github/workflows/cifuzz_oss.yml
+++ b/.github/workflows/cifuzz_oss.yml
@@ -39,7 +39,7 @@ jobs:
         fuzz-seconds: 600
         dry-run: false
     - name: upload crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: ${{ matrix.sanitizer }}-artifacts


### PR DESCRIPTION
v3 is [closing down by EOM](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/); none of the [breaking changes](https://github.com/actions/upload-artifact/tree/65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08?tab=readme-ov-file#breaking-changes) appear relevant to us.