### PR TITLE
Add support to pass a window handle to windows hello

### DIFF
--- a/src/assert.c
+++ b/src/assert.c
@@ -802,6 +802,7 @@ fido_assert_reset_tx(fido_assert_t *assert)
 	memset(&assert->ext, 0, sizeof(assert->ext));
 	assert->rp_id = NULL;
 	assert->appid = NULL;
+	assert->window = NULL;
 	assert->up = FIDO_OPT_OMIT;
 	assert->uv = FIDO_OPT_OMIT;
 }

--- a/src/assert.c
+++ b/src/assert.c
@@ -664,12 +664,29 @@ fido_assert_set_winhello_appid(fido_assert_t *assert, const char *id)
 
 	return (FIDO_OK);
 }
+
+int
+fido_assert_set_winhello_window(fido_assert_t *assert, void *window)
+{
+	assert->window = window;
+
+	return (FIDO_OK);
+}
 #else
 int
 fido_assert_set_winhello_appid(fido_assert_t *assert, const char *id)
 {
 	(void)assert;
 	(void)id;
+
+	return (FIDO_ERR_UNSUPPORTED_EXTENSION);
+}
+
+int
+fido_assert_set_winhello_window(fido_assert_t *assert, void *window)
+{
+	(void)assert;
+	(void)window;
 
 	return (FIDO_ERR_UNSUPPORTED_EXTENSION);
 }

--- a/src/cred.c
+++ b/src/cred.c
@@ -741,6 +741,21 @@ fido_cred_set_x509(fido_cred_t *cred, const unsigned char *ptr, size_t len)
 }
 
 int
+fido_cred_set_winhello_window(fido_cred_t *cred, void *window)
+{
+#ifdef USE_WINHELLO
+	cred->window = window;
+
+	return (FIDO_OK);
+#else
+	(void)cred;
+	(void)window;
+
+	return (FIDO_ERR_UNSUPPORTED_EXTENSION);
+#endif
+}
+
+int
 fido_cred_set_sig(fido_cred_t *cred, const unsigned char *ptr, size_t len)
 {
 	if (fido_blob_set(&cred->attstmt.sig, ptr, len) < 0)

--- a/src/cred.c
+++ b/src/cred.c
@@ -598,6 +598,7 @@ fido_cred_reset_tx(fido_cred_t *cred)
 	cred->rk = FIDO_OPT_OMIT;
 	cred->uv = FIDO_OPT_OMIT;
 	cred->ea.mode = 0;
+	cred->window = NULL;
 }
 
 void

--- a/src/fido.h
+++ b/src/fido.h
@@ -146,6 +146,7 @@ int fido_assert_set_up(fido_assert_t *, fido_opt_t);
 int fido_assert_set_uv(fido_assert_t *, fido_opt_t);
 int fido_assert_set_sig(fido_assert_t *, size_t, const unsigned char *, size_t);
 int fido_assert_set_winhello_appid(fido_assert_t *, const char *);
+int fido_assert_set_winhello_window(fido_assert_t*, void *);
 int fido_assert_verify(const fido_assert_t *, size_t, int, const void *);
 int fido_cbor_info_algorithm_cose(const fido_cbor_info_t *, size_t);
 int fido_cred_empty_exclude_list(fido_cred_t *);
@@ -175,6 +176,7 @@ int fido_cred_type(const fido_cred_t *);
 int fido_cred_set_user(fido_cred_t *, const unsigned char *, size_t,
     const char *, const char *, const char *);
 int fido_cred_set_x509(fido_cred_t *, const unsigned char *, size_t);
+int fido_cred_set_winhello_window(fido_cred_t*, void *);
 int fido_cred_verify(const fido_cred_t *);
 int fido_cred_verify_self(const fido_cred_t *);
 #ifdef _FIDO_SIGSET_DEFINED

--- a/src/fido/types.h
+++ b/src/fido/types.h
@@ -191,6 +191,7 @@ typedef struct fido_cred {
 	fido_blob_t       largeblob_key; /* decoded large blob key */
 	fido_blob_t       blob;          /* CTAP 2.1 credBlob */
 	fido_cred_ea_t    ea;            /* enterprise attestation */
+	void* window;                    /* winhello window handle */
 } fido_cred_t;
 
 typedef struct fido_assert_extattr {
@@ -228,6 +229,7 @@ typedef struct fido_assert {
 	fido_assert_stmt  *stmt;         /* array of expected assertions */
 	size_t             stmt_cnt;     /* number of allocated assertions */
 	size_t             stmt_len;     /* number of received assertions */
+	void              *window;       /* winhello window handle */
 } fido_assert_t;
 
 typedef struct fido_opt_array {

--- a/src/winhello.c
+++ b/src/winhello.c
@@ -918,7 +918,7 @@ int
 fido_winhello_get_assert(fido_dev_t *dev, fido_assert_t *assert,
     const char *pin, int ms)
 {
-	HWND			 w;
+	HWND			 w = assert->window;
 	struct winhello_assert	*ctx;
 	int			 r = FIDO_ERR_INTERNAL;
 
@@ -930,7 +930,7 @@ fido_winhello_get_assert(fido_dev_t *dev, fido_assert_t *assert,
 		fido_log_debug("%s: calloc", __func__);
 		goto fail;
 	}
-	if ((w = GetForegroundWindow()) == NULL) {
+	if (w == NULL && (w = GetForegroundWindow()) == NULL) {
 		fido_log_debug("%s: GetForegroundWindow", __func__);
 		if ((w = GetTopWindow(NULL)) == NULL) {
 			fido_log_debug("%s: GetTopWindow", __func__);
@@ -995,7 +995,7 @@ int
 fido_winhello_make_cred(fido_dev_t *dev, fido_cred_t *cred, const char *pin,
     int ms)
 {
-	HWND			 w;
+	HWND			 w = cred->window;
 	struct winhello_cred	*ctx;
 	int			 r = FIDO_ERR_INTERNAL;
 
@@ -1007,7 +1007,7 @@ fido_winhello_make_cred(fido_dev_t *dev, fido_cred_t *cred, const char *pin,
 		fido_log_debug("%s: calloc", __func__);
 		goto fail;
 	}
-	if ((w = GetForegroundWindow()) == NULL) {
+	if (w == NULL && (w = GetForegroundWindow()) == NULL) {
 		fido_log_debug("%s: GetForegroundWindow", __func__);
 		if ((w = GetTopWindow(NULL)) == NULL) {
 			fido_log_debug("%s: GetTopWindow", __func__);


### PR DESCRIPTION
Add support to pass a specific window handle to winhello WebAuthNAuthenticatorGetAssertion and WebAuthNAuthenticatorMakeCredential

Makes for better parenting of different application windows instead of just relying on GetForegroundWindow/GetTopWindow (they are still used if not setting anything)

Note the handle is supposed to be a HWND (just a pointer) but I could not find a clean way to either define it (but then redefinition errors) or avoid the whole including windows.h/windef.h mess in fido.h, so void* it is