### PR TITLE
ci: drop ubuntu 20.04 runners

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -21,7 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-20.04, cc: gcc-9 }
           - { os: ubuntu-22.04, cc: gcc-10 }
           - { os: ubuntu-22.04, cc: gcc-11 }
           - { os: ubuntu-24.04, cc: gcc-12 }
@@ -30,7 +29,6 @@ jobs:
           - { os: ubuntu-22.04, cc: clang-17 }
           - { os: ubuntu-24.04, cc: clang-18 }
           - { os: ubuntu-24.04, cc: clang-19 }
-          - { os: ubuntu-20.04, cc: i686-w64-mingw32-gcc-9 }
           - { os: ubuntu-22.04, cc: i686-w64-mingw32-gcc-10 }
           - { os: ubuntu-24.04, cc: i686-w64-mingw32-gcc-11 }
     steps:


### PR DESCRIPTION
Will be removed by GitHub 2025-04-01.