### PR TITLE
nfc: only append Le field in final APDU segment

### DIFF
--- a/src/nfc.c
+++ b/src/nfc.c
@@ -34,7 +34,10 @@ tx_short_apdu(fido_dev_t *d, const iso7816_header_t *h, const uint8_t *payload,
 	apdu[3] = h->p2;
 	apdu[4] = payload_len;
 	memcpy(&apdu[5], payload, payload_len);
-	apdu_len = (size_t)(5 + payload_len + 1);
+	apdu_len = (size_t)(5 + payload_len);
+
+	if (!(cla_flags & 0x10))
+		apdu_len += 1;
 
 	if (d->io.write(d->io_handle, apdu, apdu_len) < 0) {
 		fido_log_debug("%s: write", __func__);


### PR DESCRIPTION
Fixes some scenarios for PCSC FIDO2 tokens in integrated smartcard readers.
This fix was proposed by @LDVG in https://github.com/Yubico/libfido2/discussions/855.