### PR TITLE
manpage fido2-token.1: `fido2-token -G -b -k` does not require UV

### DIFF
--- a/man/fido2-token.1
+++ b/man/fido2-token.1
@@ -215,7 +215,6 @@ where
 holds the blob's base64-encoded 32-byte AES-256 GCM encryption key.
 The blob is written to
 .Ar blob_path .
-A PIN or equivalent user-verification gesture is required.
 .It Fl G Fl b Fl n Ar rp_id Oo Fl i Ar cred_id Oc Ar blob_path Ar device
 Gets a CTAP 2.1
 .Dq largeBlob


### PR DESCRIPTION
When you request the largeBlob based on the blob's base64-encoded 32 byte GCM key, the ctap standard does not require to get any pinUvAuthToken, as the largeBlob command can be sent directly. `fido2-token` does not require a PIN or equivalent user-verification gesture in this case. This commit just updates the documentation, to match the actual behavior.

The alternative command `fido2-token -G -b -n` does indeed first call credentialManagement to look up the key and therefore needs a token with the appropriate permission, so for the alternative command, this sentence is correct.