### PR TITLE
check for allocations before freeing

### DIFF
--- a/tools/credman.c
+++ b/tools/credman.c
@@ -140,8 +140,10 @@ print_rk(const fido_credman_rk_t *rk, size_t idx)
 
 	r = 0;
 out:
-	free(user_id);
-	free(id);
+	if (user_id)
+		free(user_id);
+	if (id)
+		free(id);
 
 	return r;
 }
@@ -299,7 +301,7 @@ credman_update_rk(const char *path, const char *user_id, const char *cred_id,
 		warnx("fido_cred_new");
 		goto out;
 	}
-	if ((r = fido_cred_set_id(cred, cred_id_ptr, cred_id_len)) != FIDO_OK) { 
+	if ((r = fido_cred_set_id(cred, cred_id_ptr, cred_id_len)) != FIDO_OK) {
 		warnx("fido_cred_set_id: %s",  fido_strerr(r));
 		goto out;
 	}


### PR DESCRIPTION
in base64_encode(fido_cred_id_ptr(cred), fido_cred_id_len(cred),
	    &id) < 0 || base64_encode(fido_cred_user_id_ptr(cred),
	    fido_cred_user_id_len(cred), &user_id) < 0), 
either of id or user_id can come out of this call allocated.  non-zero return in base64_encode can also come from failed allocation of id and a successful allocation of user_id or the other way round. freeing both directly without checking if their allocation was successful risks freeing unallocated memory.