### PR TITLE
man/*.3: use .Lb in the SYNOPSIS section

### DIFF
--- a/man/eddsa_pk_new.3
+++ b/man/eddsa_pk_new.3
@@ -36,6 +36,7 @@
 .Nm eddsa_pk_to_EVP_PKEY
 .Nd FIDO2 COSE EDDSA API
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In openssl/evp.h
 .In fido/eddsa.h
 .Ft eddsa_pk_t *

--- a/man/es256_pk_new.3
+++ b/man/es256_pk_new.3
@@ -37,6 +37,7 @@
 .Nm es256_pk_to_EVP_PKEY
 .Nd FIDO2 COSE ES256 API
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In openssl/ec.h
 .In fido/es256.h
 .Ft es256_pk_t *

--- a/man/es384_pk_new.3
+++ b/man/es384_pk_new.3
@@ -37,6 +37,7 @@
 .Nm es384_pk_to_EVP_PKEY
 .Nd FIDO2 COSE ES384 API
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In openssl/ec.h
 .In fido/es384.h
 .Ft es384_pk_t *

--- a/man/fido_assert_allow_cred.3
+++ b/man/fido_assert_allow_cred.3
@@ -33,6 +33,7 @@
 .Nm fido_assert_empty_allow_list
 .Nd manage allow lists in a FIDO2 assertion
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Ft int
 .Fn fido_assert_allow_cred "fido_assert_t *assert" "const unsigned char *ptr" "size_t len"

--- a/man/fido_assert_new.3
+++ b/man/fido_assert_new.3
@@ -58,6 +58,7 @@
 .Nm fido_assert_flags
 .Nd FIDO2 assertion API
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Ft fido_assert_t *
 .Fn fido_assert_new "void"

--- a/man/fido_assert_set_authdata.3
+++ b/man/fido_assert_set_authdata.3
@@ -44,6 +44,7 @@
 .Nm fido_assert_set_winhello_appid
 .Nd set parameters of a FIDO2 assertion
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Bd -literal
 typedef enum {

--- a/man/fido_assert_verify.3
+++ b/man/fido_assert_verify.3
@@ -32,6 +32,7 @@
 .Nm fido_assert_verify
 .Nd verifies the signature of a FIDO2 assertion statement
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Ft int
 .Fn fido_assert_verify "const fido_assert_t *assert" "size_t idx" "int cose_alg" "const void *pk"

--- a/man/fido_bio_dev_get_info.3
+++ b/man/fido_bio_dev_get_info.3
@@ -38,6 +38,7 @@
 .Nm fido_bio_dev_set_template_name
 .Nd FIDO2 biometric authenticator API
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .In fido/bio.h
 .Ft int

--- a/man/fido_bio_enroll_new.3
+++ b/man/fido_bio_enroll_new.3
@@ -35,6 +35,7 @@
 .Nm fido_bio_enroll_remaining_samples
 .Nd FIDO2 biometric enrollment API
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .In fido/bio.h
 .Bd -literal

--- a/man/fido_bio_info_new.3
+++ b/man/fido_bio_info_new.3
@@ -35,6 +35,7 @@
 .Nm fido_bio_info_max_samples
 .Nd FIDO2 biometric sensor information API
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .In fido/bio.h
 .Ft fido_bio_info_t *

--- a/man/fido_bio_template.3
+++ b/man/fido_bio_template.3
@@ -42,6 +42,7 @@
 .Nm fido_bio_template_set_name
 .Nd FIDO2 biometric template API
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .In fido/bio.h
 .Ft fido_bio_template_t *

--- a/man/fido_cbor_info_new.3
+++ b/man/fido_cbor_info_new.3
@@ -65,6 +65,7 @@
 .Nm fido_cbor_info_new_pin_required
 .Nd FIDO2 CBOR Info API
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Ft fido_cbor_info_t *
 .Fn fido_cbor_info_new "void"

--- a/man/fido_cred_exclude.3
+++ b/man/fido_cred_exclude.3
@@ -33,6 +33,7 @@
 .Nm fido_cred_empty_exclude_list
 .Nd manage exclude lists in a FIDO2 credential
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Ft int
 .Fn fido_cred_exclude "fido_cred_t *cred" "const unsigned char *ptr" "size_t len"

--- a/man/fido_cred_new.3
+++ b/man/fido_cred_new.3
@@ -69,6 +69,7 @@
 .Nm fido_cred_sigcount
 .Nd FIDO2 credential API
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Ft fido_cred_t *
 .Fn fido_cred_new "void"

--- a/man/fido_cred_set_authdata.3
+++ b/man/fido_cred_set_authdata.3
@@ -51,6 +51,7 @@
 .Nm fido_cred_set_type
 .Nd set parameters of a FIDO2 credential
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Bd -literal
 typedef enum {

--- a/man/fido_cred_verify.3
+++ b/man/fido_cred_verify.3
@@ -33,6 +33,7 @@
 .Nm fido_cred_verify_self
 .Nd verify the attestation signature of a FIDO2 credential
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Ft int
 .Fn fido_cred_verify "const fido_cred_t *cred"

--- a/man/fido_credman_metadata_new.3
+++ b/man/fido_credman_metadata_new.3
@@ -51,6 +51,7 @@
 .Nm fido_credman_get_dev_rp
 .Nd FIDO2 credential management API
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .In fido/credman.h
 .Ft fido_credman_metadata_t *

--- a/man/fido_dev_enable_entattest.3
+++ b/man/fido_dev_enable_entattest.3
@@ -36,6 +36,7 @@
 .Nm fido_dev_set_pin_minlen_rpid
 .Nd CTAP 2.1 configuration authenticator API
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .In fido/config.h
 .Ft int

--- a/man/fido_dev_get_assert.3
+++ b/man/fido_dev_get_assert.3
@@ -32,6 +32,7 @@
 .Nm fido_dev_get_assert
 .Nd obtains an assertion from a FIDO2 device
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Ft int
 .Fn fido_dev_get_assert "fido_dev_t *dev" "fido_assert_t *assert" "const char *pin"

--- a/man/fido_dev_get_touch_begin.3
+++ b/man/fido_dev_get_touch_begin.3
@@ -33,6 +33,7 @@
 .Nm fido_dev_get_touch_status
 .Nd asynchronously wait for touch on a FIDO2 authenticator
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Ft int
 .Fn fido_dev_get_touch_begin "fido_dev_t *dev"

--- a/man/fido_dev_info_manifest.3
+++ b/man/fido_dev_info_manifest.3
@@ -41,6 +41,7 @@
 .Nm fido_dev_info_set
 .Nd FIDO2 device discovery functions
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Ft int
 .Fn fido_dev_info_manifest "fido_dev_info_t *devlist" "size_t ilen" "size_t *olen"

--- a/man/fido_dev_largeblob_get.3
+++ b/man/fido_dev_largeblob_get.3
@@ -36,6 +36,7 @@
 .Nm fido_dev_largeblob_set_array
 .Nd FIDO2 large blob API
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Ft int
 .Fn fido_dev_largeblob_get "fido_dev_t *dev" "const unsigned char *key_ptr" "size_t key_len" "unsigned char **blob_ptr" "size_t *blob_len"

--- a/man/fido_dev_make_cred.3
+++ b/man/fido_dev_make_cred.3
@@ -32,6 +32,7 @@
 .Nm fido_dev_make_cred
 .Nd generates a new credential on a FIDO2 device
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Ft int
 .Fn fido_dev_make_cred "fido_dev_t *dev" "fido_cred_t *cred" "const char *pin"

--- a/man/fido_dev_open.3
+++ b/man/fido_dev_open.3
@@ -54,6 +54,7 @@
 .Nm fido_dev_minor
 .Nd FIDO2 device open/close and related functions
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Ft int
 .Fn fido_dev_open "fido_dev_t *dev" "const char *path"

--- a/man/fido_dev_set_io_functions.3
+++ b/man/fido_dev_set_io_functions.3
@@ -36,6 +36,7 @@
 .Nm fido_dev_io_handle
 .Nd FIDO2 device I/O interface
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Bd -literal
 typedef void *fido_dev_io_open_t(const char *);

--- a/man/fido_dev_set_pin.3
+++ b/man/fido_dev_set_pin.3
@@ -35,6 +35,7 @@
 .Nm fido_dev_reset
 .Nd FIDO2 device management functions
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Ft int
 .Fn fido_dev_set_pin "fido_dev_t *dev" "const char *pin" "const char *oldpin"

--- a/man/fido_init.3
+++ b/man/fido_init.3
@@ -33,6 +33,7 @@
 .Nm fido_set_log_handler
 .Nd initialise the FIDO2 library
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Bd -literal
 typedef void fido_log_handler_t(const char *);

--- a/man/fido_strerr.3
+++ b/man/fido_strerr.3
@@ -32,6 +32,7 @@
 .Nm fido_strerr
 .Nd FIDO2 error codes
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In fido.h
 .Ft const char *
 .Fn fido_strerr "int n"

--- a/man/rs256_pk_new.3
+++ b/man/rs256_pk_new.3
@@ -37,6 +37,7 @@
 .Nm rs256_pk_to_EVP_PKEY
 .Nd FIDO2 COSE RS256 API
 .Sh SYNOPSIS
+.Lb libfido2 libcbor libcrypto libz
 .In openssl/rsa.h
 .In fido/rs256.h
 .Ft rs256_pk_t *


### PR DESCRIPTION
Hello,

the https://mandoc.bsd.lv/ and https://www.openbsd.org/ projects have recently introduced a new way to use the mdoc(7) .Lb macro: as the first macro in the SYNOPSIS section.  With bleeding-edge mandoc(1), this results in output looking like this:

  $ man -l man/fido_init.3
  [...]
  SYNOPSIS
     /* -lfido2 -lcbor -lcrypto -lz */
     #include <fido.h>
  [...]

The advantages compared to the old way of using the .Lb macro (which was introduced around the year 2000 in FreeBSD, NetBSD and GNU roff) are:
 * Very concise output informing the user about the required linker options.
 * The C comment syntax agrees with how the rest of the SYNOPSIS is presented.
 * No need for an excessively verbose LIBRARY section distracting the reader.
 * No need for maintaining lists of library descriptions inside the mandoc and roff formatters that are very hard to maintain, usually out of date, often inconsistent among formatters and operating systems, and sometimes even confict with each other.

All other mdoc(7) library manual pages in OpenBSD have already been adjusted, see for example https://man.openbsd.org/SSL_CTX_new.3 .  libfido2 is the last base system library to handle.  Damien Miller <djm@>
suggested to first send the patch uspream before committing to OpenBSD.

The new style of using .Lb has been presented on both the mandoc and groff mailing lists, and nobody voiced concerns.  An illumos developer spoke up and supported the general direction, which is not too surprising because illumos has already put .Lb macros into the SYNOPSIS sections of a small number of manual pages some years ago, so establishing the new style will improve formatting for them.

I will later write and commit a patch to groff_mdoc(7) supporting this new style, so long-term compatibility issues are not expected.

Regarding short-term compatibilty (until operating systems update their formatters), the output is not too pretty, but not unitelligible either.  For example, with *old* mandoc, the output looks as follows:

  $ /oldbin/mandoc man/fido_init.3  | less
  [...]
  SYNOPSIS
     library “libfido2” libcbor libcrypto libz
     #include <fido.h>

With *old* groff, output looks similar, but of course only until operating systems update.

I think updating library documentation early provides more benefit for users than waiting - those users already having up-to-date formatters get ideal output at once, all others get more information, even if - for the first time - in a slightly ugly form.



