### PR TITLE
windows: bump libressl to 4.1.0

### DIFF
--- a/windows/const.ps1
+++ b/windows/const.ps1
@@ -7,9 +7,9 @@
 New-Variable -Name 'LIBRESSL_URL' `
     -Value 'https://ftp.openbsd.org/pub/OpenBSD/LibreSSL' `
     -Option Constant
-New-Variable -Name 'LIBRESSL' -Value 'libressl-4.0.0' -Option Constant
+New-Variable -Name 'LIBRESSL' -Value 'libressl-4.1.0' -Option Constant
 New-Variable -Name 'CRYPTO_LIB' -Value 'crypto' -Option Constant
-New-Variable -Name 'CRYPTO_DLL' -Value 'crypto-55' -Option Constant
+New-Variable -Name 'CRYPTO_DLL' -Value 'crypto-56' -Option Constant
 
 # libcbor coordinates.
 New-Variable -Name 'LIBCBOR' -Value 'libcbor-0.12.0' -Option Constant


### PR DESCRIPTION
[LibreSSL 4.1.0](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-4.1.0-relnotes.txt) was released Apr 30th, 2025