### PR TITLE
Add PRF Example Utility for CTAP2 hmac-secret Extension

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -53,6 +53,10 @@ target_link_libraries(retries ${_FIDO2_LIBRARY})
 add_executable(select select.c ${COMPAT_SOURCES})
 target_link_libraries(select ${_FIDO2_LIBRARY})
 
+# prf
+add_executable(prf prf.c extern.h ${COMPAT_SOURCES})
+target_link_libraries(prf ${_FIDO2_LIBRARY})
+
 if(MINGW)
 	# needed for nanosleep() in mingw
 	target_link_libraries(select winpthread)

--- a/examples/README.adoc
+++ b/examples/README.adoc
@@ -1,4 +1,4 @@
-= Examples
+== Examples
 
 === Definitions
 
@@ -6,8 +6,7 @@ The following definitions are used in the description below:
 
 - <device>
 
-	The file system path or subsystem-specific identification string of a
-	FIDO device.
+	The file system path or subsystem-specific identification string of a FIDO device.
 
 - <pin>, [oldpin]
 
@@ -15,8 +14,7 @@ The following definitions are used in the description below:
 
 - <cred_id>
 
-	The file system path of a file containing a FIDO credential ID in
-	binary representation.
+	The file system path of a file containing a FIDO credential ID in binary representation.
 
 - <pubkey>
 
@@ -30,69 +28,107 @@ The following definitions are used in the description below:
 
 The following examples are provided:
 
-- manifest
+==== manifest
 
-	Prints a list of configured FIDO devices.
+Prints a list of configured FIDO devices.
 
-- info <device>
+==== info
 
-	Prints information about <device>.
+	info <device>
 
-- reset <device>
+Prints information about <device>.
 
-	Performs a factory reset on <device>.
+==== reset 
 
-- setpin <pin> [oldpin] <device>
+	reset <device>
 
-	Configures <pin> as the new PIN of <device>. If [oldpin] is provided,
-	the device's PIN is changed from [oldpin] to <pin>.
+Performs a factory reset on <device>.
 
-- cred [-t es256|es384|rs256|eddsa] [-k pubkey] [-ei cred_id] [-P pin]
-       [-T seconds] [-b blobkey] [-hruv] [-c cred_protect] <device>
+==== setpin
+ 
+	setpin <pin> [oldpin] <device>
 
-	Creates a new credential on <device> and verify that the credential
-	was signed by the authenticator. The device's attestation certificate
-	is not verified. If option -k is specified, the credential's public
-	key is stored in <pubkey>. If option -i is specified, the credential
-	ID is stored in <cred_id>. The -e option may be used to add <cred_id>
-	to the list of excluded credentials. If option -h is specified,
-	the hmac-secret FIDO2 extension is enabled on the generated
-	credential. If option -r is specified, the generated credential
-	will involve a resident key. User verification may be requested
-	through the -v option. If option -u is specified, the credential
-	is generated using U2F (CTAP1) instead of FIDO2 (CTAP2) commands.
-	The -T option may be used to enforce a timeout of <seconds>. If the
-	option -b is specified, the credential's "largeBlob" key is stored in
-	<blobkey>. If the option -c is specified the the generated credential
-	will be bound by the specified protection policy. If the option -a is
-	specified, enterprise attestation will be requested.
+Configures <pin> as the new PIN of <device>. If [oldpin] is provided, the device's PIN is changed from [oldpin] to <pin>.
 
-- assert [-t es256|es384|rs256|eddsa] [-a cred_id] [-h hmac_secret] [-P pin]
-         [-s hmac_salt] [-T seconds] [-b blobkey] [-puv] <pubkey> <device>
+==== cred
 
-	Asks <device> for a FIDO2 assertion corresponding to [cred_id],
-	which may be omitted for resident keys. The obtained assertion
-	is verified using <pubkey>. The -p option requests that the user
-	be present and checks whether the user presence bit was signed by the
-	authenticator. The -v option requests user verification and checks
-	whether the user verification bit was signed by the authenticator.
-	If option -u is specified, the assertion is generated using
-	U2F (CTAP1) instead of FIDO2 (CTAP2) commands. If option -s is
-	specified, a FIDO2 hmac-secret is requested from the authenticator,
-	and the contents of <hmac_salt> are used as the salt. If option -h
-	is specified, the resulting hmac-secret is stored in <hmac_secret>.
-	The -T option may be used to enforce a timeout of <seconds>. If the
-	option -b specified, the credential's "largeBlob" key is stored in
-	<blobkey>.
+	cred [-t es256|es384|rs256|eddsa] [-k pubkey] [-ei cred_id] [-P pin] [-T seconds] [-b blobkey] [-hruv] [-c cred_protect] <device>
 
-- retries <device>
-	Get the number of PIN attempts left on <device> before lockout.
+Creates a new credential on <device> and verify that the credential was signed by the authenticator. The device's attestation certificate is not verified. If option -k is specified, the credential's public key is stored in <pubkey>. If option -i is specified, the credential ID is stored in <cred_id>. The -e option may be used to add <cred_id> to the list of excluded credentials. If option -h is specified, the hmac-secret FIDO2 extension is enabled on the generated credential. If option -r is specified, the generated credential will involve a resident key. User verification may be requested through the -v option. If option -u is specified, the credential is generated using U2F (CTAP1) instead of FIDO2 (CTAP2) commands. The -T option may be used to enforce a timeout of <seconds>. If the option -b is specified, the credential's "largeBlob" key is stored in <blobkey>. If the option -c is specified the the generated credential will be bound by the specified protection policy. If the option -a is specified, enterprise attestation will be requested.
 
-- select
+==== assert
 
-	Enumerates available FIDO devices and, if more than one is present,
-	simultaneously requests touch on all of them, printing information
-	about the device touched.
+	assert [-p] [-v] [-u] [-s hmac_salt] [-h hmac_secret] [-T seconds] [-b blobkey] <pubkey> <device>
+
+Asks <device> for a FIDO2 assertion corresponding to [cred_id], which may be omitted for resident keys. The obtained assertion is verified using <pubkey>. The -p option requests that the user be present and checks whether the user presence bit was signed by the authenticator. The -v option requests user verification and checks whether the user verification bit was signed by the authenticator. If option -u is specified, the assertion is generated using U2F (CTAP1) instead of FIDO2 (CTAP2) commands. If option -s is specified, a FIDO2 hmac-secret is requested from the authenticator, and the contents of <hmac_salt> are used as the salt. If option -h is specified, the resulting hmac-secret is stored in <hmac_secret>. The -T option may be used to enforce a timeout of <seconds>. If the option -b specified, the credential's "largeBlob" key is stored in <blobkey>.
+
+==== retries
+
+	retries <device>
+	
+Get the number of PIN attempts left on <device> before lockout.
+
+==== select
+
+	select
+
+Enumerates available FIDO devices and, if more than one is present, simultaneously requests touch on all of them, printing information about the device touched.
+
+==== prf
+
+The `prf` utility is a complete, self-contained example demonstrating the use of the CTAP2 `hmac-secret` extension for hardware-backed, end-to-end encryption.
+
+It shows the full cryptographic lifecycle:
+
+1.  Creating a FIDO2 credential with the `hmac-secret` capability enabled.
+2.  Deriving a raw 32-byte secret from the YubiKey using this credential.
+3.  Using HKDF (via OpenSSL) to transform the raw secret into a purpose-bound AES-256-GCM key.
+4.  Encrypting a plaintext message.
+5.  Decrypting the ciphertext back to the original message.
+
+This tool serves as a reference implementation for developers building native applications that require strong, phishing-resistant, client-side encryption. While this example demonstrates modern cryptographic best practices, it is intended as an educational example. Developers must perform their own security reviews and threat modeling to ensure the patterns and cryptographic choices are appropriate for their specific use case.
+
+===== Usage
+
+The `prf` utility has three modes of operation: Make Credential (`-M`), Encrypt (`-E`), and Decrypt (`-D`).
+
+. **Step 1: Make a PRF-capable credential**
++
+[source,bash]
+----
+# The hmac-secret extension is enabled by default in this tool
+$ ./prf -M /dev/hidraw0
+# Output will be two hex strings:
+# <credential_id_hex>
+# <public_key_hex>
+----
++
+Copy the first hex string, which is the **credential ID**. You will need it for the next steps.
+
+. **Step 2: Encrypt a message**
++
+[source,bash]
+----
+# Pass the device, the credential ID from Step 1, and your message
+$ ./prf -E /dev/hidraw0 <credential_id_hex> "my secret message"
+# Output will be one long hex string, which is a concatenation of:
+# <iv_hex><ciphertext_hex><tag_hex>
+----
++
+This command derives the secret from your YubiKey, creates an AES key, encrypts the message, and outputs the complete data needed for decryption.
+
+. **Step 3: Decrypt the message**
++
+[source,bash]
+----
+# Pass the device, credential ID, and the full hex string from Step 2
+$ ./prf -D /dev/hidraw0 <credential_id_hex> <iv_hex_ciphertext_hex_tag_hex>
+# Expected output:
+my secret message
+----
++
+This command re-derives the exact same key from your YubiKey to decrypt the ciphertext and verify its integrity.
+
 
 Debugging is possible through the use of the FIDO_DEBUG environment variable.
 If set, libfido2 will produce a log of its transactions with the authenticator.

--- a/examples/prf.c
+++ b/examples/prf.c
@@ -1,0 +1,395 @@
+/*
+ * Copyright (c) 2025 Yubico AB. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+/*
+ * Example demonstrating the CTAP2 hmac-secret extension.
+ * This shows how to:
+ * 1. Create a credential with hmac-secret extension enabled
+ * 2. Encrypt a message using PRF-derived key with HKDF + AES-GCM
+ * 3. Decrypt the message back to plaintext
+ *
+ * Usage:
+ * prf -M <device>                         # Make credential with PRF support
+ * prf -E <device> <cred_id_hex> <message>      # Encrypt message
+ * prf -D <device> <cred_id_hex> <ciphertext>   # Decrypt message
+ * 
+ * This tool serves as a reference implementation for developers building native 
+ * applications that require strong, phishing-resistant, client-side encryption. 
+ * While this example demonstrates modern cryptographic best practices, it is 
+ * intended as an educational example. Developers must perform their own security 
+ * reviews and threat modeling to ensure the patterns and cryptographic choices 
+ * are appropriate for their specific use case.
+ */
+
+#include <errno.h>
+#include <fido.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/kdf.h>
+
+#include "../openbsd-compat/openbsd-compat.h"
+#include "extern.h"
+
+static const unsigned char cdh[32] = {
+    0xf9, 0x64, 0x57, 0xe7, 0x2d, 0x97, 0xf6, 0xbb,
+    0xdd, 0xd7, 0xfb, 0x06, 0x37, 0x62, 0xea, 0x26,
+    0x20, 0x44, 0x8e, 0x69, 0x7c, 0x03, 0xf2, 0x31,
+    0x2f, 0x99, 0xdc, 0xaf, 0x3e, 0x8a, 0x91, 0x6b,
+};
+
+static const unsigned char user_id[32] = {
+    0x78, 0x1c, 0x78, 0x60, 0xad, 0x88, 0xd2, 0x63,
+    0x32, 0x62, 0x2a, 0xf1, 0x74, 0x5d, 0xed, 0xb2,
+    0xe7, 0xa4, 0x2b, 0x44, 0x89, 0x29, 0x39, 0xc5,
+    0x56, 0x64, 0x01, 0x27, 0x0d, 0xbb, 0xc4, 0x49,
+};
+
+static void
+usage(void)
+{
+    fprintf(stderr, "usage: prf -M <device>\n");
+    fprintf(stderr, "       prf -E <device> <cred_id_hex> <message>\n");
+    fprintf(stderr, "       prf -D <device> <cred_id_hex> <ciphertext_hex>\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, "  -M          make a new PRF-capable credential\n");
+    fprintf(stderr, "  -E          encrypt a message using a PRF-derived key\n");
+    fprintf(stderr, "  -D          decrypt a message using a PRF-derived key\n");
+    exit(EXIT_FAILURE);
+}
+
+static void
+print_hex(const char *label, const unsigned char *ptr, size_t len)
+{
+    size_t i;
+
+    printf("%s", label);
+    for (i = 0; i < len; i++) {
+        printf("%02x", ptr[i]);
+    }
+    printf("\n");
+}
+
+static unsigned char *
+hex_decode(const char *hex_str, size_t *len)
+{
+    size_t hex_len = strlen(hex_str);
+    unsigned char *buf;
+    size_t i;
+
+    if (hex_len % 2 != 0)
+        errx(1, "hex string must have even length");
+
+    *len = hex_len / 2;
+    if ((buf = malloc(*len)) == NULL)
+        errx(1, "malloc");
+
+    for (i = 0; i < *len; i++) {
+        if (sscanf(hex_str + i * 2, "%2hhx", &buf[i]) != 1)
+            errx(1, "invalid hex character");
+    }
+
+    return buf;
+}
+
+static unsigned char *
+get_prf_secret(const char *device_path, const unsigned char *cred_id, size_t cred_id_len)
+{
+    fido_dev_t *dev;
+    fido_assert_t *assert;
+    unsigned char salt[32];
+    unsigned char *secret;
+    int r;
+
+    /* Create application-specific salt */
+    memset(salt, 0, sizeof(salt));
+    strcpy((char *)salt, "my-app-encryption-v1");
+
+    if ((dev = fido_dev_new()) == NULL)
+        errx(1, "fido_dev_new");
+    if ((r = fido_dev_open(dev, device_path)) != FIDO_OK)
+        errx(1, "fido_dev_open: %s (0x%x)", fido_strerr(r), r);
+
+    if ((assert = fido_assert_new()) == NULL)
+        errx(1, "fido_assert_new");
+
+    /* Set assertion parameters */
+    if ((r = fido_assert_set_clientdata_hash(assert, cdh, sizeof(cdh))) != FIDO_OK)
+        errx(1, "fido_assert_set_clientdata_hash: %s (0x%x)", fido_strerr(r), r);
+    if ((r = fido_assert_set_rp(assert, "localhost")) != FIDO_OK)
+        errx(1, "fido_assert_set_rp: %s (0x%x)", fido_strerr(r), r);
+    if ((r = fido_assert_allow_cred(assert, cred_id, cred_id_len)) != FIDO_OK)
+        errx(1, "fido_assert_allow_cred: %s (0x%x)", fido_strerr(r), r);
+
+    /* Enable hmac-secret extension and set salt */
+    if ((r = fido_assert_set_extensions(assert, FIDO_EXT_HMAC_SECRET)) != FIDO_OK)
+        errx(1, "fido_assert_set_extensions: %s (0x%x)", fido_strerr(r), r);
+    if ((r = fido_assert_set_hmac_salt(assert, salt, sizeof(salt))) != FIDO_OK)
+        errx(1, "fido_assert_set_hmac_salt: %s (0x%x)", fido_strerr(r), r);
+
+    if ((r = fido_dev_get_assert(dev, assert, NULL)) != FIDO_OK)
+        errx(1, "fido_dev_get_assert: %s (0x%x)", fido_strerr(r), r);
+
+    if (fido_assert_count(assert) != 1)
+        errx(1, "unexpected assertion count %zu", fido_assert_count(assert));
+
+    /* Copy the secret */
+    if (fido_assert_hmac_secret_ptr(assert, 0) == NULL)
+        errx(1, "no hmac-secret returned");
+
+    if ((secret = malloc(32)) == NULL)
+        errx(1, "malloc");
+    memcpy(secret, fido_assert_hmac_secret_ptr(assert, 0), 32);
+
+    fido_assert_free(&assert);
+    fido_dev_close(dev);
+    fido_dev_free(&dev);
+
+    return secret;
+}
+
+static int
+derive_key_hkdf(const unsigned char *prf_secret, unsigned char *aes_key)
+{
+    EVP_PKEY_CTX *pctx;
+    const unsigned char info[] = "AES-GCM-256-Key-v1";
+    size_t outlen = 32;
+
+    if ((pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL)) == NULL)
+        return -1;
+
+    if (EVP_PKEY_derive_init(pctx) <= 0 ||
+        EVP_PKEY_CTX_set_hkdf_md(pctx, EVP_sha256()) <= 0 ||
+        EVP_PKEY_CTX_set1_hkdf_key(pctx, prf_secret, 32) <= 0 ||
+        EVP_PKEY_CTX_add1_hkdf_info(pctx, info, sizeof(info) - 1) <= 0 ||
+        EVP_PKEY_derive(pctx, aes_key, &outlen) <= 0) {
+        EVP_PKEY_CTX_free(pctx);
+        return -1;
+    }
+
+    EVP_PKEY_CTX_free(pctx);
+    return 0;
+}
+
+static int
+prf_encrypt(const char *device_path, const char *cred_id_hex, const char *message)
+{
+    unsigned char *cred_id, *prf_secret, aes_key[32];
+    unsigned char iv[12], tag[16], *ciphertext;
+    size_t cred_id_len, message_len, ciphertext_len;
+    EVP_CIPHER_CTX *ctx;
+    int len;
+
+    /* Decode credential ID */
+    cred_id = hex_decode(cred_id_hex, &cred_id_len);
+
+    /* Get PRF secret */
+    prf_secret = get_prf_secret(device_path, cred_id, cred_id_len);
+
+    /* Derive AES key using HKDF */
+    if (derive_key_hkdf(prf_secret, aes_key) != 0)
+        errx(1, "HKDF key derivation failed");
+
+    /* Generate random IV */
+    if (RAND_bytes(iv, sizeof(iv)) != 1)
+        errx(1, "RAND_bytes failed");
+
+    message_len = strlen(message);
+    if ((ciphertext = malloc(message_len)) == NULL)
+        errx(1, "malloc");
+
+    /* Encrypt */
+    if ((ctx = EVP_CIPHER_CTX_new()) == NULL)
+        errx(1, "EVP_CIPHER_CTX_new");
+
+    if (EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL) != 1 ||
+        EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, sizeof(iv), NULL) != 1 ||
+        EVP_EncryptInit_ex(ctx, NULL, NULL, aes_key, iv) != 1 ||
+        EVP_EncryptUpdate(ctx, ciphertext, &len, (const unsigned char *)message, (int)message_len) != 1 ||
+        EVP_EncryptFinal_ex(ctx, ciphertext + len, &len) != 1 ||
+        EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, sizeof(tag), tag) != 1)
+        errx(1, "encryption failed");
+
+    ciphertext_len = message_len;
+
+    /* Output: IV + ciphertext + tag (all hex encoded) */
+    print_hex("", iv, sizeof(iv));
+    print_hex("", ciphertext, ciphertext_len);
+    print_hex("", tag, sizeof(tag));
+
+    /* Clean up */
+    memset(prf_secret, 0, 32);
+    memset(aes_key, 0, sizeof(aes_key));
+    free(cred_id);
+    free(prf_secret);
+    free(ciphertext);
+    EVP_CIPHER_CTX_free(ctx);
+
+    return 0;
+}
+
+static int
+prf_decrypt(const char *device_path, const char *cred_id_hex, const char *ciphertext_hex)
+{
+    unsigned char *cred_id, *prf_secret, aes_key[32];
+    unsigned char *combined_data, iv[12], tag[16], *ciphertext, *plaintext;
+    size_t cred_id_len, combined_len, ciphertext_len;
+    EVP_CIPHER_CTX *ctx;
+    int len, plaintext_len;
+
+    /* Decode credential ID and ciphertext */
+    cred_id = hex_decode(cred_id_hex, &cred_id_len);
+    combined_data = hex_decode(ciphertext_hex, &combined_len);
+
+    /* Extract IV, ciphertext, and tag */
+    if (combined_len < sizeof(iv) + sizeof(tag))
+        errx(1, "ciphertext too short");
+
+    memcpy(iv, combined_data, sizeof(iv));
+    ciphertext_len = combined_len - sizeof(iv) - sizeof(tag);
+    ciphertext = combined_data + sizeof(iv);
+    memcpy(tag, combined_data + sizeof(iv) + ciphertext_len, sizeof(tag));
+
+    if ((plaintext = malloc(ciphertext_len + 1)) == NULL)
+        errx(1, "malloc");
+
+    /* Get PRF secret */
+    prf_secret = get_prf_secret(device_path, cred_id, cred_id_len);
+
+    /* Derive AES key using HKDF */
+    if (derive_key_hkdf(prf_secret, aes_key) != 0)
+        errx(1, "HKDF key derivation failed");
+
+    /* Decrypt */
+    if ((ctx = EVP_CIPHER_CTX_new()) == NULL)
+        errx(1, "EVP_CIPHER_CTX_new");
+
+    if (EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL) != 1 ||
+        EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, sizeof(iv), NULL) != 1 ||
+        EVP_DecryptInit_ex(ctx, NULL, NULL, aes_key, iv) != 1 ||
+        EVP_DecryptUpdate(ctx, plaintext, &len, ciphertext, (int)ciphertext_len) != 1)
+        errx(1, "decryption failed");
+
+    plaintext_len = len;
+
+    if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, sizeof(tag), tag) != 1 ||
+        EVP_DecryptFinal_ex(ctx, plaintext + len, &len) != 1)
+        errx(1, "authentication failed - wrong key or corrupted data");
+
+    plaintext[plaintext_len] = '\0';
+    printf("%s\n", plaintext);
+
+    /* Clean up */
+    memset(prf_secret, 0, 32);
+    memset(aes_key, 0, sizeof(aes_key));
+    free(cred_id);
+    free(prf_secret);
+    free(combined_data);
+    free(plaintext);
+    EVP_CIPHER_CTX_free(ctx);
+
+    return 0;
+}
+
+static int
+prf_make(const char *path)
+{
+    fido_dev_t *dev;
+    fido_cred_t *cred;
+    int r;
+
+    if ((dev = fido_dev_new()) == NULL)
+        errx(1, "fido_dev_new");
+    if ((r = fido_dev_open(dev, path)) != FIDO_OK)
+        errx(1, "fido_dev_open: %s (0x%x)", fido_strerr(r), r);
+
+    if ((cred = fido_cred_new()) == NULL)
+        errx(1, "fido_cred_new");
+
+    /* Set credential parameters */
+    if ((r = fido_cred_set_type(cred, COSE_ES256)) != FIDO_OK)
+        errx(1, "fido_cred_set_type: %s (0x%x)", fido_strerr(r), r);
+    if ((r = fido_cred_set_clientdata_hash(cred, cdh, sizeof(cdh))) != FIDO_OK)
+        errx(1, "fido_cred_set_clientdata_hash: %s (0x%x)", fido_strerr(r), r);
+    if ((r = fido_cred_set_rp(cred, "localhost", "localhost")) != FIDO_OK)
+        errx(1, "fido_cred_set_rp: %s (0x%x)", fido_strerr(r), r);
+    if ((r = fido_cred_set_user(cred, user_id, sizeof(user_id), "john",
+        "John Doe", NULL)) != FIDO_OK)
+        errx(1, "fido_cred_set_user: %s (0x%x)", fido_strerr(r), r);
+
+    /*
+     * Enable the hmac-secret extension. This is the crucial step
+     * that instructs the authenticator to generate the necessary
+     * internal key material for future PRF operations.
+     */
+    if ((r = fido_cred_set_extensions(cred, FIDO_EXT_HMAC_SECRET)) != FIDO_OK)
+        errx(1, "fido_cred_set_extensions: %s (0x%x)", fido_strerr(r), r);
+
+    if ((r = fido_dev_make_cred(dev, cred, NULL)) != FIDO_OK)
+        errx(1, "fido_dev_make_cred: %s (0x%x)", fido_strerr(r), r);
+
+    /* Output credential ID and public key */
+    print_hex("", fido_cred_id_ptr(cred), fido_cred_id_len(cred));
+    print_hex("", fido_cred_pubkey_ptr(cred), fido_cred_pubkey_len(cred));
+
+    fido_cred_free(&cred);
+    fido_dev_close(dev);
+    fido_dev_free(&dev);
+
+    return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    bool make_cred = false;
+    bool encrypt = false;
+    bool decrypt = false;
+    int ch;
+
+    while ((ch = getopt(argc, argv, "MED")) != -1) {
+        switch (ch) {
+        case 'M':
+            make_cred = true;
+            break;
+        case 'E':
+            encrypt = true;
+            break;
+        case 'D':
+            decrypt = true;
+            break;
+        default:
+            usage();
+        }
+    }
+
+    argc -= optind;
+    argv += optind;
+
+    if ((make_cred + encrypt + decrypt) != 1)
+        usage();
+
+    if (make_cred) {
+        if (argc != 1)
+            usage();
+        return prf_make(argv[0]);
+    } else if (encrypt) {
+        if (argc != 3)
+            usage();
+        return prf_encrypt(argv[0], argv[1], argv[2]);
+    } else { /* decrypt */
+        if (argc != 3)
+            usage();
+        return prf_decrypt(argv[0], argv[1], argv[2]);
+    }
+}


### PR DESCRIPTION
### Summary

This pull request introduces a new example utility, prf, demonstrating the use of the CTAP2 hmac-secret extension for hardware-backed, end-to-end encryption using FIDO2 authenticators (e.g., YubiKey). The utility provides a complete cryptographic lifecycle, including credential creation, key derivation, encryption, and decryption.

### Key Changes

- New Example: prf
    - Implements credential creation with hmac-secret extension enabled.
    - Derives a raw 32-byte secret from the authenticator.
    - Uses HKDF (OpenSSL) to transform the secret into an AES-256-GCM key.
    - Provides AES-GCM encryption and decryption routines.
    - Command-line interface supporting three modes:
        - -M: Make credential
        - -E: Encrypt message
        - -D: Decrypt message
- CMake Integration
    - Adds prf to the examples build.
    - Ensures OpenSSL is linked for cryptographic operations.
- Documentation
    - Updates README.adoc with detailed usage instructions and workflow for the new utility.

### Usage

1. Make Credential
`./prf -M <device>`
Outputs credential ID and public key.
1. Encrypt Message
`./prf -E <device> <cred_id_hex> <message>`
Outputs hex-encoded IV, ciphertext, and tag.
1. Decrypt Message
`./prf -D <device> <cred_id_hex> <iv_ciphertext_tag_hex>
`Outputs the original plaintext message.

### Notes

- The utility is intended as a reference implementation for developers.
- Modern cryptographic best practices are demonstrated, but users should perform their own security reviews.
- Requires OpenSSL development headers (openssl/hkdf.h, etc.).

### Motivation
This addition provides a practical, educational example for developers building native applications that require strong, phishing-resistant, client-side encryption using FIDO2 authenticators.

Please review the code, documentation, and build integration. Feedback and suggestions are welcome!

