### PR TITLE
ci: macos-13 runner is deprecated

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-15, macos-14, macos-13 ]
+        os: [ macos-15, macos-14 ]
         cc: [ clang ]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
See https://github.com/actions/runner-images?tab=readme-ov-file#available-images