### PR TITLE
windows: use forward slash path separators with gpg

### DIFF
--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -122,10 +122,10 @@ try {
 		}
 
 		Copy-Item "$PSScriptRoot\libressl.gpg" -Destination "${BUILD}"
-		& $GPG --homedir ${GpgHome} --list-keys
-		& $GPG --homedir ${GpgHome} --quiet --no-default-keyring `
+		& $GPG --homedir ./.gnupg --list-keys
+		& $GPG --homedir ./.gnupg --quiet --no-default-keyring `
 		    --keyring ./libressl.gpg `
-		    --verify .\${LIBRESSL}.tar.gz.asc .\${LIBRESSL}.tar.gz
+		    --verify ./${LIBRESSL}.tar.gz.asc ./${LIBRESSL}.tar.gz
 		if ($LastExitCode -ne 0) {
 			throw "GPG signature verification failed"
 		}

--- a/windows/cygwin.ps1
+++ b/windows/cygwin.ps1
@@ -46,24 +46,28 @@ New-Item -Type Directory "${GpgHome}" -Force
 New-Item -Type File "${GpgHome}\common.conf" -Force
 
 # Fetch and verify Cygwin.
+Push-Location ${Cygwin}
 try {
-	if (-Not (Test-Path ${Cygwin}\${Setup} -PathType leaf)) {
+	if (-Not (Test-Path .\${Setup} -PathType leaf)) {
 		Invoke-WebRequest ${URL}/${Setup} `
-		    -OutFile ${Cygwin}\${Setup}
+		    -OutFile .\${Setup}
 	}
-	if (-Not (Test-Path ${Cygwin}\${Setup}.sig -PathType leaf)) {
+	if (-Not (Test-Path .\${Setup}.sig -PathType leaf)) {
 		Invoke-WebRequest ${URL}/${Setup}.sig `
-		    -OutFile ${Cygwin}\${Setup}.sig
+		    -OutFile .\${Setup}.sig
 	}
-	& $GPG --homedir ${GpgHome} --list-keys
-	& $GPG --homedir ${GpgHome} --quiet --no-default-keyring `
-	    --keyring ${PSScriptRoot}/cygwin.gpg `
-	    --verify ${Cygwin}\${Setup}.sig ${Cygwin}\${Setup}
+	Copy-Item "$PSScriptRoot\cygwin.gpg" -Destination "${Cygwin}"
+	& $GPG --homedir ./.gnupg --list-keys
+	& $GPG --homedir ./.gnupg --quiet --no-default-keyring `
+	    --keyring ./cygwin.gpg `
+	    --verify ./${Setup}.sig ./${Setup}
 	if ($LastExitCode -ne 0) {
 		throw "GPG signature verification failed"
 	}
 } catch {
 	throw "Failed to fetch and verify Cygwin"
+} finally {
+	Pop-Location
 }
 
 # Bootstrap Cygwin.


### PR DESCRIPTION
In CI, we're using gpg bundled with git which suddenly started refusing the GNUPGHOME directory we've had to create. It does works with relative paths using forward slash path separators.

Additionally tested using a Windows VM with gpg4win.