### PR TITLE
man: don't silence mandoc linting errors

### DIFF
--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -299,7 +299,8 @@ endforeach()
 # man_lint
 foreach(f ${MAN_SOURCES})
 	add_custom_command(OUTPUT ${f}.lint
-		COMMAND mandoc -T lint -W warning ${f} > ${f}.lint
+		COMMAND mandoc -T lint -W warning ${f}
+		COMMAND ${CMAKE_COMMAND} -E touch ${f}.lint
 		DEPENDS ${f})
 	list(APPEND LINT_FILES ${f}.lint)
 endforeach()


### PR DESCRIPTION
Do not redirect mandoc's output, use a plain sentinel file instead. This should address the build system comment in [gh#877](https://github.com/Yubico/libfido2/pull/877#issuecomment-2966792300).