### PR TITLE
info: add fido_cbor_info_maxpinlen()

### DIFF
--- a/fuzz/export.gnu
+++ b/fuzz/export.gnu
@@ -107,6 +107,7 @@
 		fido_cbor_info_maxcredidlen;
 		fido_cbor_info_maxlargeblob;
 		fido_cbor_info_maxmsgsiz;
+		fido_cbor_info_maxpinlen;
 		fido_cbor_info_maxrpid_minpinlen;
 		fido_cbor_info_minpinlen;
 		fido_cbor_info_new;

--- a/fuzz/fuzz_mgmt.c
+++ b/fuzz/fuzz_mgmt.c
@@ -323,6 +323,8 @@ dev_get_cbor_info(const struct param *p)
 	consume(&n, sizeof(n));
 	n = (uint64_t)fido_cbor_info_pin_policy(ci);
 	consume(&n, sizeof(n));
+	n = (uint64_t)fido_cbor_info_maxpinlen(ci);
+	consume(&n, sizeof(n));
 
 	consume(fido_cbor_info_aaguid_ptr(ci), fido_cbor_info_aaguid_len(ci));
 	consume(fido_cbor_info_protocols_ptr(ci),

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -142,6 +142,7 @@ list(APPEND MAN_ALIAS
 	fido_cbor_info_new fido_cbor_info_maxcredidlen
 	fido_cbor_info_new fido_cbor_info_maxlargeblob
 	fido_cbor_info_new fido_cbor_info_maxmsgsiz
+	fido_cbor_info_new fido_cbor_info_maxpinlen
 	fido_cbor_info_new fido_cbor_info_maxrpid_minpinlen
 	fido_cbor_info_new fido_cbor_info_minpinlen
 	fido_cbor_info_new fido_cbor_info_new_pin_required

--- a/man/fido_cbor_info_new.3
+++ b/man/fido_cbor_info_new.3
@@ -66,6 +66,7 @@
 .Nm fido_cbor_info_maxcredidlen ,
 .Nm fido_cbor_info_maxlargeblob ,
 .Nm fido_cbor_info_maxrpid_minpinlen ,
+.Nm fido_cbor_info_maxpinlen ,
 .Nm fido_cbor_info_minpinlen ,
 .Nm fido_cbor_info_pin_policy ,
 .Nm fido_cbor_info_fwversion ,
@@ -143,6 +144,8 @@
 .Fn fido_cbor_info_maxlargeblob "const fido_cbor_info_t *ci"
 .Ft uint64_t
 .Fn fido_cbor_info_maxrpid_minpinlen "const fido_cbor_info_t *ci"
+.Ft uint64_t
+.Fn fido_cbor_info_maxpinlen "const fido_cbor_info_t *ci"
 .Ft uint64_t
 .Fn fido_cbor_info_minpinlen "const fido_cbor_info_t *ci"
 .Ft int
@@ -314,6 +317,16 @@ The
 function returns the maximum length in bytes of an authenticator's
 serialized largeBlob array as reported in
 .Fa ci .
+.Pp
+The
+.Fn fido_cbor_info_maxpinlen
+function returns the maximum PIN length enforced by the
+authenticator as reported in
+.Fa ci .
+The maximum PIN length attribute is a CTAP 2.3 addition.
+If the attribute is not advertised by the authenticator, the
+.Fn fido_cbor_info_maxpinlen
+function returns zero.
 .Pp
 The
 .Fn fido_cbor_info_minpinlen

--- a/src/export.gnu
+++ b/src/export.gnu
@@ -109,6 +109,7 @@
 		fido_cbor_info_maxcredidlen;
 		fido_cbor_info_maxlargeblob;
 		fido_cbor_info_maxmsgsiz;
+		fido_cbor_info_maxpinlen;
 		fido_cbor_info_maxrpid_minpinlen;
 		fido_cbor_info_minpinlen;
 		fido_cbor_info_new;

--- a/src/export.llvm
+++ b/src/export.llvm
@@ -107,6 +107,7 @@ _fido_cbor_info_maxcredcntlst
 _fido_cbor_info_maxcredidlen
 _fido_cbor_info_maxlargeblob
 _fido_cbor_info_maxmsgsiz
+_fido_cbor_info_maxpinlen
 _fido_cbor_info_maxrpid_minpinlen
 _fido_cbor_info_minpinlen
 _fido_cbor_info_new

--- a/src/export.msvc
+++ b/src/export.msvc
@@ -108,6 +108,7 @@ fido_cbor_info_maxcredcntlst
 fido_cbor_info_maxcredidlen
 fido_cbor_info_maxlargeblob
 fido_cbor_info_maxmsgsiz
+fido_cbor_info_maxpinlen
 fido_cbor_info_maxrpid_minpinlen
 fido_cbor_info_minpinlen
 fido_cbor_info_new

--- a/src/fido.h
+++ b/src/fido.h
@@ -260,6 +260,7 @@ uint64_t fido_cbor_info_maxcredidlen(const fido_cbor_info_t *);
 uint64_t fido_cbor_info_maxlargeblob(const fido_cbor_info_t *);
 uint64_t fido_cbor_info_maxmsgsiz(const fido_cbor_info_t *);
 uint64_t fido_cbor_info_maxrpid_minpinlen(const fido_cbor_info_t *);
+uint64_t fido_cbor_info_maxpinlen(const fido_cbor_info_t *);
 uint64_t fido_cbor_info_minpinlen(const fido_cbor_info_t *);
 uint64_t fido_cbor_info_uv_attempts(const fido_cbor_info_t *);
 int64_t  fido_cbor_info_uv_count_since_pin(const fido_cbor_info_t *);

--- a/src/fido/types.h
+++ b/src/fido/types.h
@@ -290,6 +290,7 @@ typedef struct fido_cbor_info {
 	fido_str_array_t  rsttransports;  /* transports for reset */
 	int               pinpolicy;      /* enforces pin complexity */
 	fido_blob_t       pinpolicyurl;   /* url to pin policy */
+	uint64_t          maxpinlen;      /* non-default max pin length */
 } fido_cbor_info_t;
 
 typedef struct fido_dev_info {

--- a/src/info.c
+++ b/src/info.c
@@ -362,6 +362,8 @@ parse_reply_element(const cbor_item_t *key, const cbor_item_t *val, void *arg)
 		return (0);
 	case 28: /* pinComplexityPolicyUrl */
 		return (fido_blob_decode(val, &ci->pinpolicyurl));
+	case 29: /* maxPINLength */
+		return (cbor_decode_uint64(val, &ci->maxpinlen));
 	default: /* ignore */
 		fido_log_debug("%s: cbor type: 0x%02x", __func__, cbor_get_uint8(key));
 		return (0);
@@ -741,4 +743,10 @@ size_t
 fido_cbor_info_pin_policy_url_len(const fido_cbor_info_t *ci)
 {
 	return (ci->pinpolicyurl.len);
+}
+
+uint64_t
+fido_cbor_info_maxpinlen(const fido_cbor_info_t *ci)
+{
+	return (ci->maxpinlen);
 }

--- a/tools/token.c
+++ b/tools/token.c
@@ -208,10 +208,10 @@ print_maxrpid_minpinlen(uint64_t maxrpid)
 }
 
 static void
-print_minpinlen(uint64_t minpinlen)
+print_pinlen(const char *prefix, uint64_t minpinlen)
 {
 	if (minpinlen > 0)
-		printf("minpinlen: %d\n", (int)minpinlen);
+		printf("%s: %d\n", prefix, (int)minpinlen);
 }
 
 static void
@@ -435,7 +435,10 @@ token_info(int argc, char **argv, char *path)
 	print_rk_remaining(fido_cbor_info_rk_remaining(ci));
 
 	/* print minimum pin length */
-	print_minpinlen(fido_cbor_info_minpinlen(ci));
+	print_pinlen("minpinlen", fido_cbor_info_minpinlen(ci));
+
+	/* print maximum pin length */
+	print_pinlen("maxpinlen", fido_cbor_info_maxpinlen(ci));
 
 	/* print supported pin protocols */
 	print_byte_array("pin protocols", fido_cbor_info_protocols_ptr(ci),


### PR DESCRIPTION
An alternative to returning zero is to initialize with the [specification mandated maximum PIN length](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authnrClientPin-pin-composition)

> Authenticators MUST enforce the following, baseline, requirements on PINs:
> ...
> - Maximum PIN Length: 63 bytes
>
> ...

Thoughts?