### PR TITLE
misc: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = tab
+tab_width = 8
+max_line_length = 80
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
https://editorconfig.org/ is supported out of the box by many text editors, defining a consistent set of settings to facilitate maintaining consistent coding styles. Additionally, GitHub's renderer should honor these styles (otherwise defaulting to 4 space tabs) [which helps in review stages](https://github.com/Yubico/libfido2/pull/911#discussion_r2494948706).

Compare a file under [this commit](https://github.com/Yubico/libfido2/blob/c881dede2b6e17275c8dc67405fde00d5d8b3e21/src/winhello.c#L629) and on [`main`](https://github.com/Yubico/libfido2/blob/9f3e3a40ad9a13eca13d8888e34bb4f9192b0cfb/src/winhello.c#L629) to see the differences.