### PR TITLE
nfc_linux: Don't close stdin if fido_nl_new fails

### DIFF
--- a/src/nfc_linux.c
+++ b/src/nfc_linux.c
@@ -237,7 +237,7 @@ nfc_new(uint32_t dev)
 
 	if ((ctx = calloc(1, sizeof(*ctx))) == NULL ||
 	    (ctx->nl = fido_nl_new()) == NULL) {
-		nfc_free(&ctx);
+		free(ctx);
 		return NULL;
 	}
 


### PR DESCRIPTION
The call to nfc_free is not needed because when calloc fails ctx will be NULL and nfc_free will do nothing, when fido_nl_new() fails ctx->nl will be null and does not need to be freed.
Additionally ctx->fd is 0 (due to calloc zero-initializing ctx) and should not be closed.
Therefore I replaced this with a free call to just undo the (potential)
allocation by calloc.
