### PR TITLE
udev: Add Nitrokey 3A NFC

### DIFF
--- a/udev/70-u2f.rules
+++ b/udev/70-u2f.rules
@@ -3,14 +3,14 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
 # met:
-#
+# 
 #    1. Redistributions of source code must retain the above copyright
 #       notice, this list of conditions and the following disclaimer.
 #    2. Redistributions in binary form must reproduce the above copyright
 #       notice, this list of conditions and the following disclaimer in
 #       the documentation and/or other materials provided with the
 #       distribution.
-#
+# 
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -170,6 +170,9 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct
 
 # CanoKey by Clay Logic
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42d4", TAG+="uaccess", GROUP="plugdev", MODE="0660"
+
+# Nitrokey 3A NFC by Clay Logic
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42dd", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
 # JaCarta U2F by Aladdin Software Security R.D.
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="24dc", ATTRS{idProduct}=="0101", TAG+="uaccess", GROUP="plugdev", MODE="0660"

--- a/udev/fidodevs
+++ b/udev/fidodevs
@@ -95,6 +95,7 @@ product CLAYLOGIC	0x42b1	Nitrokey FIDO2
 product CLAYLOGIC	0x42b2	Nitrokey 3C NFC
 product CLAYLOGIC	0x42b3	Safetech SafeKey
 product CLAYLOGIC	0x42d4	CanoKey
+product CLAYLOGIC	0x42dd	Nitrokey 3A NFC
 
 product ALLADIN		0x0101	JaCarta U2F
 product ALLADIN		0x0501	JaCarta U2F


### PR DESCRIPTION
This entry makes the said token work.
I'm following the convention of the file but more Nitrokey devices could be sourced from [1].

[1] https://raw.githubusercontent.com/Nitrokey/nitrokey-udev-rules/main/41-nitrokey.rules