### PR TITLE
ci: ensure that we're using AppleClang

### DIFF
--- a/.actions/build-osx-clang
+++ b/.actions/build-osx-clang
@@ -12,8 +12,8 @@ SCAN="$(brew --prefix llvm)/bin/scan-build"
 # Build, analyze, and install libfido2.
 for T in Debug Release; do
 	mkdir build-$T
-	(cd build-$T && ${SCAN} cmake -DCMAKE_BUILD_TYPE=$T ..)
-	${SCAN} --status-bugs make -j"$(sysctl -n hw.ncpu)" -C build-$T
+	(cd build-$T && ${SCAN} --use-cc="$CC" cmake -DCMAKE_BUILD_TYPE=$T ..)
+	${SCAN} --status-bugs --use-cc="$CC" make -j"$(sysctl -n hw.ncpu)" -C build-$T
 	make -C build-$T man_symlink_html
 	make -C build-$T regress
 	sudo make -C build-$T install

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -21,14 +21,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-15, macos-14 ]
-        cc: [ clang ]
     steps:
     - uses: actions/checkout@v4
     - name: dependencies
       env:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: brew install libcbor llvm mandoc openssl@3.0 pkg-config zlib
+    - name: appleclang
+      run: echo "CC=$(xcrun -f clang)" >> $GITHUB_ENV
     - name: build
-      env:
-        CC: ${{ matrix.cc }}
       run: ./.actions/build-osx-clang


### PR DESCRIPTION
Recent updates to the OSX runners appear to put Homebrew clang earlier in $PATH.