### PR TITLE
random: use a consistent implementation for fuzzing

### DIFF
--- a/src/random.c
+++ b/src/random.c
@@ -25,6 +25,12 @@
 
 #include "fido.h"
 
+#ifdef FIDO_FUZZ
+/* XXX: force consistent harnesses */
+#undef HAVE_ARC4RANDOM_BUF
+#undef HAVE_DEV_URANDOM
+#endif
+
 #if defined(_WIN32)
 #include <windows.h>
 


### PR DESCRIPTION
In order to get consistent runs across different systems, we need to try to make sure that the build stays mostly consistent across systems.

fido_get_random() is currently not used in a way that affects the behavior of the harness itself, but if one system uses arc4random_buf() and one system uses getrandom(), the coverage for the same corpus entry will be different because the former is infallible and therefore not wrapped in fuzz/wrap.c.

As a future task, we should consider using an implementation of our own in fuzzer builds to ensure consistent random *values* out of  fido_get_random() as well.