### PR TITLE
fuzz: revert pin=NULL logic

### DIFF
--- a/fuzz/fuzz_assert.c
+++ b/fuzz/fuzz_assert.c
@@ -23,7 +23,6 @@
 enum {
 	OPT_FORCE_U2F = 1,
 	OPT_NFC = 2,
-	OPT_NO_PIN = 4,
 };
 
 /* Parameter set defining a FIDO2 get assertion operation. */
@@ -249,7 +248,7 @@ get_assert(fido_assert_t *assert, uint8_t opt, const struct blob *cdh,
 	fido_assert_set_rp(assert, rp_id);
 	fido_assert_set_hmac_salt(assert, cred->body, cred->len);
 
-	if (opt & (OPT_NO_PIN | OPT_FORCE_U2F))
+	if (opt & OPT_FORCE_U2F || strlen(pin) == 0)
 		pin = NULL;
 
 	fido_dev_get_assert(dev, assert, pin);

--- a/fuzz/fuzz_cred.c
+++ b/fuzz/fuzz_cred.c
@@ -23,7 +23,6 @@
 enum {
 	OPT_FORCE_U2F = 1,
 	OPT_NFC = 2,
-	OPT_NO_PIN = 4,
 };
 
 /* Parameter set defining a FIDO2 make credential operation. */
@@ -272,7 +271,7 @@ make_cred(fido_cred_t *cred, uint8_t opt, int type, const struct blob *cdh,
 	/* XXX reuse cred as hmac salt */
 	fido_cred_set_hmac_salt(cred, excl_cred->body, excl_cred->len);
 
-	if (opt & (OPT_FORCE_U2F | OPT_NO_PIN))
+	if (opt & OPT_FORCE_U2F || strlen(pin) == 0)
 		pin = NULL;
 
 	fido_dev_make_cred(dev, cred, pin);


### PR DESCRIPTION
So that we can reuse the old corpus and not necessarily have to wait for the fuzzer to discover this new option flag.