### PR TITLE
ecdh: drop EVP_MD_meth_dup() workaround

### DIFF
--- a/src/ecdh.c
+++ b/src/ecdh.c
@@ -37,8 +37,7 @@ int
 hkdf_sha256(uint8_t *key, size_t keylen, const char *info,
     const fido_blob_t *secret)
 {
-	const EVP_MD *const_md;
-	EVP_MD *md = NULL;
+	const EVP_MD *md;
 	EVP_PKEY_CTX *ctx = NULL;
 	uint8_t salt[32];
 	int ok = -1;
@@ -48,8 +47,7 @@ hkdf_sha256(uint8_t *key, size_t keylen, const char *info,
 		fido_log_debug("%s: invalid param", __func__);
 		goto fail;
 	}
-	if ((const_md = EVP_sha256()) == NULL ||
-	    (md = EVP_MD_meth_dup(const_md)) == NULL ||
+	if ((md = EVP_sha256()) == NULL ||
 	    (ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL)) == NULL) {
 		fido_log_debug("%s: init", __func__);
 		goto fail;
@@ -70,8 +68,6 @@ hkdf_sha256(uint8_t *key, size_t keylen, const char *info,
 
 	ok = 0;
 fail:
-	if (md != NULL)
-		EVP_MD_meth_free(md);
 	if (ctx != NULL)
 		EVP_PKEY_CTX_free(ctx);
 


### PR DESCRIPTION
We used this to handle the fact that EVP_PKEY_CTX_set_hkdf_md() taking a reference to a non-const EVP_MD; this was changed in OpenSSL 3.0 and the EVP_MD_meth_dup() function was deprecated. The EVP_MD_meth_dup() function was removed in OpenSSL 4.0. Since we no longer support any OpenSSL version <3.0, we can simplify our implementation.

Resolves #966.