### PR TITLE
ci: set FIDO_REGRESS_RS1_XFAIL for cygwin builds

### DIFF
--- a/.github/workflows/cygwin_builds.yml
+++ b/.github/workflows/cygwin_builds.yml
@@ -26,5 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: build
+      env:
+          FIDO_REGRESS_RS1_XFAIL: 1
       run: |
         .\windows\cygwin.ps1 -Config ${{ matrix.config }}


### PR DESCRIPTION
They appear to have applied a policy similar to Fedora; see https://github.com/Yubico/libfido2/issues/692 for more details and a failed pipeline at https://github.com/Yubico/libfido2/actions/runs/24384086749/job/71213740343. 