### PR TITLE
fuzz: improvements

### DIFF
--- a/fuzz/fuzz_assert.c
+++ b/fuzz/fuzz_assert.c
@@ -551,6 +551,10 @@ mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 		mutate_string(p->rp_id);
 		mutate_string(p->pin);
 
+		if ((p->ext & FIDO_EXT_HMAC_SECRET) && p->cred.len > 64) {
+			p->cred.len = (p->cred.len & 1) ? 64 : 32;
+		}
+
 		p->opt &= OPT_MASK;
 	}
 

--- a/fuzz/fuzz_assert.c
+++ b/fuzz/fuzz_assert.c
@@ -29,6 +29,8 @@ enum {
 	OPT_MASK = (((OPT_EDGE - 1) << 1) - 1),
 };
 
+#define IS_U2F(o) ((o) & OPT_FORCE_U2F)
+
 /* Parameter set defining a FIDO2 get assertion operation. */
 struct param {
 	char pin[MAXSTR];
@@ -171,6 +173,18 @@ fail:
 	return cbor_len;
 }
 
+static void
+reset(struct blob *wiredata, int u2f)
+{
+	if (u2f) {
+		wiredata->len = sizeof(dummy_wire_data_u2f);
+		memcpy(&wiredata->body, &dummy_wire_data_u2f, wiredata->len);
+	} else {
+		wiredata->len = sizeof(dummy_wire_data_fido);
+		memcpy(&wiredata->body, &dummy_wire_data_fido, wiredata->len);
+	}
+}
+
 size_t
 pack_dummy(uint8_t *ptr, size_t len)
 {
@@ -191,15 +205,14 @@ pack_dummy(uint8_t *ptr, size_t len)
 	dummy.es256.len = sizeof(dummy_es256);
 	dummy.rs256.len = sizeof(dummy_rs256);
 	dummy.eddsa.len = sizeof(dummy_eddsa);
-	dummy.wire_data.len = sizeof(dummy_wire_data_fido);
 
 	memcpy(&dummy.cred.body, &dummy_cdh, dummy.cred.len); /* XXX */
 	memcpy(&dummy.cdh.body, &dummy_cdh, dummy.cdh.len);
-	memcpy(&dummy.wire_data.body, &dummy_wire_data_fido,
-	    dummy.wire_data.len);
 	memcpy(&dummy.es256.body, &dummy_es256, dummy.es256.len);
 	memcpy(&dummy.rs256.body, &dummy_rs256, dummy.rs256.len);
 	memcpy(&dummy.eddsa.body, &dummy_eddsa, dummy.eddsa.len);
+
+	reset(&dummy.wire_data, 0);
 
 	assert((blob_len = pack(blob, sizeof(blob), &dummy)) != 0);
 
@@ -518,6 +531,8 @@ out:
 void
 mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 {
+	const uint8_t old_opt = p->opt;
+
 	if (flags & MUTATE_SEED)
 		p->seed = (int)seed;
 
@@ -540,15 +555,8 @@ mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 	}
 
 	if (flags & MUTATE_WIREDATA) {
-		if (p->opt & OPT_FORCE_U2F) {
-			p->wire_data.len = sizeof(dummy_wire_data_u2f);
-			memcpy(&p->wire_data.body, &dummy_wire_data_u2f,
-			    p->wire_data.len);
-		} else {
-			p->wire_data.len = sizeof(dummy_wire_data_fido);
-			memcpy(&p->wire_data.body, &dummy_wire_data_fido,
-			    p->wire_data.len);
-		}
+		if (IS_U2F(old_opt) != IS_U2F(p->opt))
+			reset(&p->wire_data, IS_U2F(p->opt));
 		mutate_blob(&p->wire_data);
 	}
 }

--- a/fuzz/fuzz_attobj.c
+++ b/fuzz/fuzz_attobj.c
@@ -210,7 +210,7 @@ pack(uint8_t *ptr, size_t len, const struct param *p)
 
 	memset(argv, 0, sizeof(argv));
 
-	if ((array = cbor_new_definite_array(17)) == NULL ||
+	if ((array = cbor_new_definite_array(5)) == NULL ||
 	    (argv[0] = pack_int(p->seed)) == NULL ||
 	    (argv[1] = pack_string(p->rp_id)) == NULL ||
 	    (argv[2] = pack_blob(&p->cdh)) == NULL ||

--- a/fuzz/fuzz_attobj.c
+++ b/fuzz/fuzz_attobj.c
@@ -280,9 +280,6 @@ mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 
 	if (flags & MUTATE_PARAM) {
 		mutate_byte(&p->type);
-		p->attobj.len = sizeof(dummy_attestation_object);
-		memcpy(&p->attobj.body, &dummy_attestation_object,
-		    p->attobj.len);
 		mutate_blob(&p->attobj);
 	}
 }

--- a/fuzz/fuzz_cred.c
+++ b/fuzz/fuzz_cred.c
@@ -29,6 +29,8 @@ enum {
 	OPT_MASK = (((OPT_EDGE - 1) << 1) - 1),
 };
 
+#define IS_U2F(o) ((o) & OPT_FORCE_U2F)
+
 /* Parameter set defining a FIDO2 make credential operation. */
 struct param {
 	char pin[MAXSTR];
@@ -181,6 +183,18 @@ fail:
 	return cbor_len;
 }
 
+static void
+reset(struct blob *wiredata, int u2f)
+{
+	if (u2f) {
+		wiredata->len = sizeof(dummy_wire_data_u2f);
+		memcpy(&wiredata->body, &dummy_wire_data_u2f, wiredata->len);
+	} else {
+		wiredata->len = sizeof(dummy_wire_data_fido);
+		memcpy(&wiredata->body, &dummy_wire_data_fido, wiredata->len);
+	}
+}
+
 size_t
 pack_dummy(uint8_t *ptr, size_t len)
 {
@@ -202,12 +216,11 @@ pack_dummy(uint8_t *ptr, size_t len)
 
 	dummy.cdh.len = sizeof(dummy_cdh);
 	dummy.user_id.len = sizeof(dummy_user_id);
-	dummy.wire_data.len = sizeof(dummy_wire_data_fido);
 
 	memcpy(&dummy.cdh.body, &dummy_cdh, dummy.cdh.len);
 	memcpy(&dummy.user_id.body, &dummy_user_id, dummy.user_id.len);
-	memcpy(&dummy.wire_data.body, &dummy_wire_data_fido,
-	    dummy.wire_data.len);
+
+	reset(&dummy.wire_data, 0);
 
 	assert((blob_len = pack(blob, sizeof(blob), &dummy)) != 0);
 
@@ -481,6 +494,8 @@ test(const struct param *p)
 void
 mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 {
+	const uint8_t old_opt = p->opt;
+
 	if (flags & MUTATE_SEED)
 		p->seed = (int)seed;
 
@@ -505,15 +520,8 @@ mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 	}
 
 	if (flags & MUTATE_WIREDATA) {
-		if (p->opt & OPT_FORCE_U2F) {
-			p->wire_data.len = sizeof(dummy_wire_data_u2f);
-			memcpy(&p->wire_data.body, &dummy_wire_data_u2f,
-			    p->wire_data.len);
-		} else {
-			p->wire_data.len = sizeof(dummy_wire_data_fido);
-			memcpy(&p->wire_data.body, &dummy_wire_data_fido,
-			    p->wire_data.len);
-		}
+		if (IS_U2F(old_opt) != IS_U2F(p->opt))
+			reset(&p->wire_data, IS_U2F(p->opt));
 		mutate_blob(&p->wire_data);
 	}
 }

--- a/fuzz/fuzz_cred.c
+++ b/fuzz/fuzz_cred.c
@@ -516,6 +516,9 @@ mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 		mutate_string(p->rp_id);
 		mutate_string(p->rp_name);
 
+		if ((p->ext & FIDO_EXT_HMAC_SECRET) && p->excl_cred.len > 64)
+			p->excl_cred.len = (p->excl_cred.len & 1) ? 64 : 32;
+
 		p->opt &= OPT_MASK;
 	}
 

--- a/fuzz/fuzz_mgmt.c
+++ b/fuzz/fuzz_mgmt.c
@@ -564,5 +564,6 @@ mutate(struct param *p, unsigned int seed, unsigned int flags) NO_MSAN
 		mutate_blob(&p->set_pin_wire_data);
 		mutate_blob(&p->change_pin_wire_data);
 		mutate_blob(&p->retry_wire_data);
+		mutate_blob(&p->config_wire_data);
 	}
 }

--- a/fuzz/libfuzzer.c
+++ b/fuzz/libfuzzer.c
@@ -197,8 +197,6 @@ LLVMFuzzerCustomMutator(uint8_t *data, size_t size, size_t maxsize,
 	uint8_t blob[MAXCORPUS];
 	size_t blob_len;
 
-	memset(&p, 0, sizeof(p));
-
 #ifdef WITH_MSAN
 	__msan_unpoison(data, maxsize);
 #endif

--- a/fuzz/wrap.c
+++ b/fuzz/wrap.c
@@ -415,6 +415,22 @@ WRAP(const EVP_MD *,
 	1
 )
 
+WRAP(const EVP_MD *,
+	EVP_sha384,
+	(void),
+	NULL,
+	(),
+	1
+)
+
+WRAP(const EVP_CIPHER *,
+	EVP_aes_128_cbc,
+	(void),
+	NULL,
+	(),
+	1
+)
+
 WRAP(const EVP_CIPHER *,
 	EVP_aes_256_cbc,
 	(void),
@@ -525,6 +541,14 @@ WRAP(cbor_item_t *,
 WRAP(cbor_item_t *,
 	cbor_build_negint16,
 	(uint16_t value),
+	NULL,
+	(value),
+	1
+)
+
+WRAP(cbor_item_t *,
+	cbor_build_negint64,
+	(uint64_t value),
 	NULL,
 	(value),
 	1
@@ -660,6 +684,45 @@ WRAP(int,
 	    stream_size),
 	1
 )
+
+WRAP(int,
+	inflateInit2_,
+	(z_streamp strm, int windowBits, const char *version, int stream_size),
+	Z_STREAM_ERROR,
+	(strm, windowBits, version, stream_size),
+	1
+)
+
+int __wrap_inflate(z_streamp, int);
+int __real_inflate(z_streamp, int);
+
+int
+__wrap_inflate(z_streamp strm, int flush)
+{
+	if (prng_up && uniform_random(400) < 1)
+		return Z_BUF_ERROR;
+
+	/* should never happen, but we check for it */
+	if (prng_up && uniform_random(400) < 1) {
+		strm->avail_out = 1;
+		return Z_STREAM_END;
+	}
+
+	return __real_inflate(strm, flush);
+}
+
+int __wrap_uncompress(Bytef *, uLongf *, const Bytef *, uLong);
+int __real_uncompress(Bytef *, uLongf *, const Bytef *, uLong);
+
+int
+__wrap_uncompress(Bytef *dest, uLongf *destLen, const Bytef *source,
+    uLong sourceLen)
+{
+	if (prng_up && uniform_random(400) < 1)
+		return Z_BUF_ERROR;
+
+	return __real_uncompress(dest, destLen, source, sourceLen);
+}
 
 int __wrap_deflate(z_streamp, int);
 int __real_deflate(z_streamp, int);

--- a/fuzz/wrapped.sym
+++ b/fuzz/wrapped.sym
@@ -11,6 +11,7 @@ cbor_array_push
 cbor_build_bool
 cbor_build_bytestring
 cbor_build_negint16
+cbor_build_negint64
 cbor_build_negint8
 cbor_build_string
 cbor_build_uint16
@@ -27,6 +28,9 @@ cbor_serialize_alloc
 clock_gettime
 deflate
 deflateInit2_
+inflate
+inflateInit2_
+uncompress
 EC_KEY_get0_group
 EC_KEY_get0_private_key
 EC_KEY_new_by_curve_name
@@ -60,8 +64,10 @@ EVP_PKEY_new_raw_public_key
 EVP_PKEY_paramgen
 EVP_PKEY_paramgen_init
 EVP_PKEY_verify_init
+EVP_aes_128_cbc
 EVP_sha1
 EVP_sha256
+EVP_sha384
 fido_tx
 getrandom
 HMAC


### PR DESCRIPTION
- soft reset wiredata in fuzz-{assert,cred};
- truncate hmac-secret blobs;
- fuzz_attobj: adjust cbor array allocation;
- fuzz_attobj: don't reset object on every mutation;
- fuzz_mgmt: mutate config_wire_data;
- trim unnecessary memset();
- wrap more symbols.