### PR TITLE
simplify and integrate tools/include_check.sh

### DIFF
--- a/.actions/build-linux-gcc
+++ b/.actions/build-linux-gcc
@@ -21,3 +21,15 @@ done
 	sudo update-alternatives --set awk "$(which original-awk)"
 }
 udev/check.sh udev/fidodevs
+
+# Check installed header files.
+CFLAGS="$(pkg-config --cflags libcrypto)"
+export CFLAGS
+find /usr/local/include/fido.h /usr/local/include/fido -type f -name '*.h' \
+    -print0 | xargs -0 tools/include_check.sh
+
+# Check internal header files.
+find examples fuzz openbsd-compat regress src/fido tools -type f -name '*.h' \
+    -print0 | xargs -0 tools/include_check.sh
+find src -type f -name '*.h' ! -name 'webauthn.h' -print0 | xargs -0 \
+    env CFLAGS="$CFLAGS -D_FIDO_INTERNAL" tools/include_check.sh

--- a/src/blob.h
+++ b/src/blob.h
@@ -8,6 +8,8 @@
 #ifndef _BLOB_H
 #define _BLOB_H
 
+#include <sys/types.h>
+
 #include <cbor.h>
 #include <stdlib.h>
 

--- a/src/extern.h
+++ b/src/extern.h
@@ -16,6 +16,7 @@
 #include <signal.h>
 #endif
 
+#include <openssl/evp.h>
 #include <stdint.h>
 
 #include "fido/types.h"

--- a/tools/include_check.sh
+++ b/tools/include_check.sh
@@ -1,29 +1,15 @@
-#!/bin/sh -u
+#!/bin/sh
 
 # Copyright (c) 2019 Yubico AB. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 # SPDX-License-Identifier: BSD-2-Clause
 
-SKIP='(webauthn.h)'
-
-check() {
-	try="cc $CFLAGS -Isrc -xc -c - -o /dev/null 2>&1"
-	git ls-files "$1" | grep '.*\.h$' | while read -r header; do
-		if echo "$header" | grep -Eq "$SKIP"; then
-			echo "Skipping $header"
-		else
-			body="#include \"$header\""
-			echo "echo $body | $try"
-			echo "$body" | eval "$try"
-		fi
-	done
-}
-
-check examples
-check fuzz
-check openbsd-compat
-CFLAGS="${CFLAGS} -D_FIDO_INTERNAL" check src
-check src/fido.h
-check src/fido
-check tools
+rc=0
+try="cc $CFLAGS -Isrc -xc -c - -o /dev/null 2>&1"
+for header in "$@"; do
+	body="#include \"$header\""
+	echo "echo $body | $try"
+	echo "$body" | eval "$try" || rc=1
+done
+exit "$rc"


### PR DESCRIPTION
- tools/include_check: simplify;
- actions/build-linux-gcc: run tools/include_check;
- src/extern.h: fix standalone inclusion;
- src/blob.h: include sys/types.h.

linux-only for now; other platforms require a config.h equivalent, which CMake does not provide