### PR TITLE
cbor: install allocation cap to mitigate oversized cbor_load() alloc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -148,3 +148,10 @@ Please use https://github.com/Yubico/libfido2/issues[GitHub Issues] to report
 bugs. To report security issues, please contact security@yubico.com. A PGP
 public key can be found at
 https://www.yubico.com/support/security-advisories/issue-rating-system/.
+
+=== Security considerations
+
+*libfido2* applies defense-in-depth measures against malicious or
+malfunctioning authenticators, including CBOR messages crafted to trigger
+oversized memory allocations. See link:SECURITY-CONSIDERATIONS.md[] for
+details.

--- a/SECURITY-CONSIDERATIONS.md
+++ b/SECURITY-CONSIDERATIONS.md
@@ -1,0 +1,76 @@
+# CBOR allocation limits
+
+## Background
+
+`cbor_load()` (libcbor) pre-allocates storage for definite-length CBOR
+arrays and maps sized by the element count declared in the message header,
+*before* reading any element data. The only check applied to that count is
+an integer-overflow check
+([`_cbor_safe_to_multiply`](https://github.com/PJK/libcbor/blob/master/src/cbor/internal/memory_utils.c)) -
+there is no sanity bound relative to the size of the input itself.
+
+As a result, a handful of bytes can cause `cbor_load()` to attempt an
+allocation of an arbitrary size. This was reported upstream as
+[PJK/libcbor#418](https://github.com/PJK/libcbor/issues/418) (a 5-byte input
+triggering a ~2.3GB allocation, and a 9-byte input triggering a ~128GB
+allocation) and closed as "won't fix": libcbor considers this the
+responsibility of the consumer.
+[PJK/libcbor#422](https://github.com/PJK/libcbor/pull/422) (merged in
+0.14.0) documents the recommended mitigation: install a capping allocator
+via `cbor_set_allocs()` (see `examples/capped_alloc.c` in libcbor) so that
+`cbor_load()` fails with `CBOR_ERR_MEMERROR` instead of making an oversized
+allocation.
+
+In *libfido2*, `cbor_load()` is reachable from a FIDO authenticator's CTAP
+responses (`src/assert.c`, `src/cbor.c`, `src/cred.c`, `src/credman.c`,
+`src/largeblob.c`, `src/winhello.c`). A malicious or malfunctioning
+authenticator could therefore use a tiny CBOR message to make a host
+process attempt a multi-gigabyte (or larger) allocation, regardless of the
+small `FIDO_MAXMSG`/`FIDO_MAXMSG_CRED` limits applied to the raw transport
+buffer - those limits bound the number of *bytes read*, not the element
+count *declared* inside those bytes.
+
+## Mitigation
+
+`fido_init()` (`src/dev.c`) calls `fido_init_cbor_allocs()`
+(`src/cbor_alloc.c`), which installs a capping allocator via
+`cbor_set_allocs()`. The allocator tracks the total size of live libcbor
+allocations and rejects any allocation that would push the total above
+`FIDO_CBOR_MAX_ALLOC` (`src/fido/param.h`, 64MB by default). Once the budget
+is exhausted, `cbor_load()` returns `NULL` with
+`result.error.code == CBOR_ERR_MEMERROR`, which every `cbor_load()` caller
+in *libfido2* already treats as an ordinary decode failure.
+
+64MB is well above `FIDO_MAXMSG` (2048 bytes), `FIDO_MAXMSG_CRED` (4096
+bytes), and any realistic `largeBlob` array, while remaining far below a
+level that could exhaust process memory or trigger the OOM killer.
+`FIDO_CBOR_MAX_ALLOC` may be overridden at build time for embedded targets
+with tighter memory budgets.
+
+Because `cbor_set_allocs()` configures a single, process-wide set of
+function pointers in libcbor, and `fido_init()` is documented to be called
+once per thread (see `fido_init(3)`), the allocation-size counter in
+`src/cbor_alloc.c` is thread-local (`TLS`). This follows the per-thread
+budget alternative suggested in PJK/libcbor#422, and assumes - as is the
+case throughout *libfido2* - that a `cbor_item_t` allocated by `cbor_load()`
+in one thread is not freed from another.
+
+A regression test for this is in `regress/dev.c`
+(`cbor_alloc_cap()`): it feeds `cbor_load()` a 9-byte CBOR array header
+declaring 268M elements (which would otherwise provoke a ~2GB allocation)
+and asserts that it is rejected with `CBOR_ERR_MEMERROR`.
+
+## Relationship to fuzz/README's libcbor patch
+
+`fuzz/README` documents an unrelated, fuzzing-only patch to libcbor that
+caps `_cbor_alloc_multiple` at 1000 items. That patch exists to keep
+ASAN/MSAN/UBSAN memory usage bounded *during fuzzing* and is far too
+restrictive for production use - it would reject legitimate messages with
+more than 1000 array/map elements. It is applied to a local libcbor build
+used only by the fuzzing harness and does not protect applications linking
+against a normal libcbor.
+
+The mitigation described above is independent of that patch: it ships in
+*libfido2* itself, applies to every build (not just fuzzing builds), and
+uses a memory budget rather than an element-count limit so it does not
+reject legitimate large messages.

--- a/man/fido_init.3
+++ b/man/fido_init.3
@@ -76,6 +76,19 @@ will not fallback to U2F in
 if a device claims to support FIDO2 but fails to respond to
 a CTAP 2.0 greeting.
 .Pp
+.Fn fido_init
+also installs a per-thread allocator that bounds the total size of CBOR
+allocations performed by
+.Em libfido2
+to
+.Dv FIDO_CBOR_MAX_ALLOC
+bytes (64MB by default).
+This guards against malicious or malfunctioning authenticators that declare
+an oversized element count in a CBOR message header in order to make
+.Em libfido2
+attempt an excessive memory allocation; once the budget is exhausted,
+the offending message is rejected as if it were malformed.
+.Pp
 The
 .Fn fido_set_log_handler
 function causes

--- a/regress/dev.c
+++ b/regress/dev.c
@@ -214,6 +214,22 @@ timeout_misc(void)
 	fido_dev_free(&dev);
 }
 
+/* PJK/libcbor#418 */
+static void
+cbor_alloc_cap(void)
+{
+	/* array header declaring 0x10000000 (268M) elements */
+	const unsigned char blob[] = {
+		0x9b, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00,
+	};
+	struct cbor_load_result cbor;
+	cbor_item_t *item;
+
+	item = cbor_load(blob, sizeof(blob), &cbor);
+	assert(item == NULL);
+	assert(cbor.error.code == CBOR_ERR_MEMERROR);
+}
+
 int
 main(void)
 {
@@ -228,6 +244,7 @@ main(void)
 	timeout_rx();
 	timeout_ok();
 	timeout_misc();
+	cbor_alloc_cap();
 
 	exit(0);
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ list(APPEND FIDO_SOURCES
 	blob.c
 	buf.c
 	cbor.c
+	cbor_alloc.c
 	compress.c
 	config.c
 	cred.c

--- a/src/cbor_alloc.c
+++ b/src/cbor_alloc.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 Yubico AB. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "fido.h"
+
+#ifndef TLS
+#define TLS
+#endif
+
+/*
+ * cbor_load() pre-allocates storage for definite-length arrays and maps
+ * sized by the element count declared in a message's CBOR header, before
+ * reading any element data. The declared count is attacker-controlled and
+ * is otherwise only checked for integer overflow, so a malicious or
+ * malfunctioning authenticator can use a few bytes of input to make
+ * cbor_load() attempt an allocation of up to FIDO_CBOR_MAX_ALLOC bytes
+ * times libcbor's per-item overhead. See PJK/libcbor#418, which was closed
+ * as "won't fix" in favor of consumer-side mitigation, and PJK/libcbor#422,
+ * which documents cbor_set_allocs() as that mitigation (examples/
+ * capped_alloc.c).
+ *
+ * fido_init_cbor_allocs() installs a capping allocator that bounds the
+ * total size of live libcbor allocations to FIDO_CBOR_MAX_ALLOC. Once the
+ * budget is exhausted, cbor_load() fails with CBOR_ERR_MEMERROR instead of
+ * making an oversized allocation; libfido2's cbor_load() callers already
+ * treat a NULL return as a (non-fatal) decode failure.
+ *
+ * cbor_set_allocs() configures a single, process-wide set of allocator
+ * function pointers in libcbor; per the fido_init(3) man page, fido_init()
+ * is called once per thread, so cbor_allocated is kept TLS and the budget
+ * applies per-thread. This matches the per-thread budget alternative
+ * suggested by PJK/libcbor#422 and assumes (as is the case throughout
+ * libfido2) that a cbor_item_t allocated by cbor_load() in one thread is
+ * not freed from another.
+ */
+
+#if defined(__APPLE__)
+#include <malloc/malloc.h>
+#define ALLOC_SIZE(ptr) malloc_size(ptr)
+#elif defined(__linux__) && defined(__GLIBC__)
+#include <malloc.h>
+#define ALLOC_SIZE(ptr) malloc_usable_size(ptr)
+#elif defined(_WIN32)
+#include <malloc.h>
+#define ALLOC_SIZE(ptr) _msize(ptr)
+#endif
+
+static TLS size_t cbor_allocated;
+
+#ifdef ALLOC_SIZE
+
+static void *
+capped_malloc(size_t size)
+{
+	void *ptr;
+
+	if (size > FIDO_CBOR_MAX_ALLOC - cbor_allocated)
+		return NULL;
+	if ((ptr = malloc(size)) != NULL)
+		cbor_allocated += ALLOC_SIZE(ptr);
+
+	return ptr;
+}
+
+static void *
+capped_realloc(void *ptr, size_t size)
+{
+	size_t old_size = ptr != NULL ? ALLOC_SIZE(ptr) : 0;
+	void *new_ptr;
+
+	if (size > FIDO_CBOR_MAX_ALLOC - cbor_allocated + old_size)
+		return NULL;
+	if ((new_ptr = realloc(ptr, size)) != NULL) {
+		cbor_allocated -= old_size;
+		cbor_allocated += ALLOC_SIZE(new_ptr);
+	}
+
+	return new_ptr;
+}
+
+static void
+capped_free(void *ptr)
+{
+	if (ptr != NULL)
+		cbor_allocated -= ALLOC_SIZE(ptr);
+
+	free(ptr);
+}
+
+#else /* !ALLOC_SIZE */
+
+/*
+ * No portable way to query the live size of an allocation: track only a
+ * monotonically increasing high-water mark. The cap is still enforced, but
+ * memory freed mid-decode is not reclaimed from the budget until
+ * fido_init_cbor_allocs() is called again for a new operation.
+ */
+
+static void *
+capped_malloc(size_t size)
+{
+	void *ptr;
+
+	if (size > FIDO_CBOR_MAX_ALLOC - cbor_allocated)
+		return NULL;
+	if ((ptr = malloc(size)) != NULL)
+		cbor_allocated += size;
+
+	return ptr;
+}
+
+static void *
+capped_realloc(void *ptr, size_t size)
+{
+	void *new_ptr;
+
+	if (size > FIDO_CBOR_MAX_ALLOC - cbor_allocated)
+		return NULL;
+	if ((new_ptr = realloc(ptr, size)) != NULL)
+		cbor_allocated += size;
+
+	return new_ptr;
+}
+
+static void
+capped_free(void *ptr)
+{
+	free(ptr);
+}
+
+#endif /* ALLOC_SIZE */
+
+void
+fido_init_cbor_allocs(void)
+{
+	cbor_allocated = 0;
+	cbor_set_allocs(capped_malloc, capped_realloc, capped_free);
+}

--- a/src/dev.c
+++ b/src/dev.c
@@ -412,6 +412,8 @@ fido_init(int flags)
 		fido_log_init();
 
 	disable_u2f_fallback = (flags & FIDO_DISABLE_U2F_FALLBACK);
+
+	fido_init_cbor_allocs();
 }
 
 fido_dev_t *

--- a/src/extern.h
+++ b/src/extern.h
@@ -104,6 +104,9 @@ void cbor_vector_free(cbor_item_t **, size_t);
 int cbor_array_append(cbor_item_t **, cbor_item_t *);
 int cbor_array_drop(cbor_item_t **, size_t);
 
+/* cbor allocator */
+void fido_init_cbor_allocs(void);
+
 /* deflate */
 int fido_compress(fido_blob_t *, const fido_blob_t *);
 int fido_uncompress(fido_blob_t *, const fido_blob_t *, size_t);

--- a/src/fido/param.h
+++ b/src/fido/param.h
@@ -101,6 +101,20 @@
 #define FIDO_MAXMSG	2048
 #endif
 
+/*
+ * Total memory budget, in bytes, for libcbor allocations made while
+ * decoding a single CBOR message. cbor_load() pre-allocates storage for
+ * definite-length arrays and maps sized by the element count declared in
+ * the message header, before reading any element data; without a cap, a
+ * malicious or malfunctioning authenticator can use a tiny message to
+ * trigger a multi-gigabyte allocation (see PJK/libcbor#418). This budget
+ * is well above FIDO_MAXMSG/FIDO_MAXMSG_CRED and any realistic largeBlob
+ * array, but far below what could exhaust process memory.
+ */
+#ifndef FIDO_CBOR_MAX_ALLOC
+#define FIDO_CBOR_MAX_ALLOC	(64 * 1024 * 1024) /* 64MB */
+#endif
+
 /* CTAP capability bits. */
 #define FIDO_CAP_WINK	0x01 /* if set, device supports CTAP_CMD_WINK */
 #define FIDO_CAP_CBOR	0x04 /* if set, device supports CTAP_CMD_CBOR */


### PR DESCRIPTION
## Summary

`cbor_load()` (libcbor) pre-allocates storage for definite-length CBOR
arrays/maps sized by the element count declared in the message header,
*before* reading any element data. The only check on that count is an
integer-overflow check — there's no bound relative to the size of the
input itself. A handful of bytes can therefore make `cbor_load()` attempt
an allocation of an arbitrary size.

In *libfido2*, `cbor_load()` is reachable from a FIDO authenticator's CTAP
responses (`src/assert.c`, `src/cbor.c`, `src/cred.c`, `src/credman.c`,
`src/largeblob.c`, `src/winhello.c`). A malicious or malfunctioning
authenticator can therefore use a *tiny* CBOR message to make a host
process attempt a multi-gigabyte (or larger) allocation. The existing
`FIDO_MAXMSG`/`FIDO_MAXMSG_CRED` limits don't help here — they bound the
number of bytes *read*, not the element count *declared* inside those
bytes.

This was reported upstream as
[PJK/libcbor#418](https://github.com/PJK/libcbor/issues/418) (a 5-byte
input triggering a ~2.3GB allocation, a 9-byte input triggering a ~128GB
allocation) and closed **won't-fix** — libcbor considers this the
consumer's responsibility.
[PJK/libcbor#422](https://github.com/PJK/libcbor/pull/422) (merged in
0.14.0) documents the recommended mitigation: install a capping allocator
via `cbor_set_allocs()` (see `examples/capped_alloc.c` in libcbor).

## Fix

`fido_init()` now calls `fido_init_cbor_allocs()` (new file
`src/cbor_alloc.c`), which installs a capping allocator via
`cbor_set_allocs()`. It tracks the total size of live libcbor allocations
and rejects any allocation that would push the running total above
`FIDO_CBOR_MAX_ALLOC` (`src/fido/param.h`, **64MB by default**, overridable
at build time). Once the budget is exhausted, `cbor_load()` returns `NULL`
with `result.error.code == CBOR_ERR_MEMERROR`, which every `cbor_load()`
caller in *libfido2* already treats as an ordinary decode failure — no
caller-side changes needed.

64MB is well above `FIDO_MAXMSG` (2048B), `FIDO_MAXMSG_CRED` (4096B), and
any realistic `largeBlob` array, but far below a level that could exhaust
process memory or trigger the OOM killer.

Since `cbor_set_allocs()` configures a single, process-wide set of
function pointers, and `fido_init()` is documented (`fido_init(3)`) to be
called once per thread, the allocation counter is `TLS` — a per-thread
budget, per the alternative suggested in PJK/libcbor#422.

## Not related to `fuzz/README`'s libcbor patch

`fuzz/README` documents a separate, fuzzing-only libcbor patch that caps
`_cbor_alloc_multiple` at 1000 items, to bound ASAN/MSAN/UBSAN memory
during fuzzing. That patch is far too restrictive for production (it'd
reject legitimate messages with >1000 elements) and only applies to the
local libcbor build used by the fuzz harness. This PR's mitigation ships
in *libfido2* itself, applies to every build, and uses a memory budget
rather than an element-count limit so it doesn't reject legitimate large
messages.

That `fuzz/README` patch was first added in 2018 (~7 years ago, relative
to libcbor 0.10.1) — the underlying allocation-sizing issue it works
around upstream has been around at least that long, and PJK/libcbor#418
is simply the most recent (2024) report of it.

## Changes

- `src/cbor_alloc.c` (new): capping allocator, installed via
  `cbor_set_allocs()`
- `src/dev.c`: `fido_init()` calls `fido_init_cbor_allocs()`
- `src/fido/param.h`: new `FIDO_CBOR_MAX_ALLOC` (64MB default)
- `src/extern.h`, `src/CMakeLists.txt`: wire up the new TU
- `regress/dev.c`: new `cbor_alloc_cap()` regression test — feeds
  `cbor_load()` a 9-byte array header declaring 268M elements (would
  otherwise provoke a ~2GB allocation) and asserts it's rejected with
  `CBOR_ERR_MEMERROR`
- `SECURITY-CONSIDERATIONS.md` (new), `README.adoc`, `man/fido_init.3`:
  document the threat model and mitigation

## Test plan

- [x] New regression test `cbor_alloc_cap()` in `regress/dev.c` passes
- [x] Existing `regress/dev` suite still passes (capping allocator doesn't
      affect normal-sized CBOR messages)

## References

- PJK/libcbor#418 — oversized `cbor_load()` allocations from tiny inputs
  (won't-fix upstream)
- PJK/libcbor#422 — `cbor_set_allocs()` capping-allocator mitigation
  (`examples/capped_alloc.c`)
