### PR TITLE
pin: nullable (ecdh, pk) for fido_dev_get_uv_token()

### DIFF
--- a/src/assert.c
+++ b/src/assert.c
@@ -83,7 +83,8 @@ parse_assert_reply(const cbor_item_t *key, const cbor_item_t *val, void *arg)
 
 static int
 fido_dev_get_assert_tx(fido_dev_t *dev, fido_assert_t *assert,
-    const es256_pk_t *pk, const fido_blob_t *ecdh, const char *pin, int *ms)
+    const es256_pk_t *pk, const fido_blob_t *ecdh, const fido_blob_t *token,
+    int *ms)
 {
 	fido_blob_t	 f;
 	fido_opt_t	 uv = assert->uv;
@@ -128,10 +129,9 @@ fido_dev_get_assert_tx(fido_dev_t *dev, fido_assert_t *assert,
 		}
 
 	/* user verification */
-	if (pin != NULL || fido_dev_puat_blob(dev) != NULL ||
-	    (uv == FIDO_OPT_TRUE && fido_dev_supports_permissions(dev))) {
-		if ((r = cbor_add_uv_params(dev, cmd, &assert->cdh, pk, ecdh,
-		    pin, assert->rp_id, &argv[5], &argv[6], ms)) != FIDO_OK) {
+	if (token != NULL) {
+		if ((r = cbor_add_uv_params(dev, &assert->cdh, token, &argv[5],
+		    &argv[6])) != FIDO_OK) {
 			fido_log_debug("%s: cbor_add_uv_params", __func__);
 			goto fail;
 		}
@@ -266,11 +266,12 @@ out:
 
 static int
 fido_dev_get_assert_wait(fido_dev_t *dev, fido_assert_t *assert,
-    const es256_pk_t *pk, const fido_blob_t *ecdh, const char *pin, int *ms)
+    const es256_pk_t *pk, const fido_blob_t *ecdh, const fido_blob_t *token,
+    int *ms)
 {
 	int r;
 
-	if ((r = fido_dev_get_assert_tx(dev, assert, pk, ecdh, pin,
+	if ((r = fido_dev_get_assert_tx(dev, assert, pk, ecdh, token,
 	    ms)) != FIDO_OK ||
 	    (r = fido_dev_get_assert_rx(dev, assert, ms)) != FIDO_OK)
 		return (r);
@@ -305,30 +306,17 @@ decrypt_hmac_secrets(const fido_dev_t *dev, fido_assert_t *assert,
 	return (0);
 }
 
-static bool
-need_ecdh(const fido_dev_t *dev, const fido_assert_t *assert, const char *pin)
-{
-	if (assert->ext.mask & FIDO_EXT_HMAC_SECRET)
-		return true;
-
-	/* If available, prefer cached PUAT */
-	if (fido_dev_puat_blob(dev) != NULL)
-		return false;
-
-	if (pin != NULL)
-		return true;
-
-	return assert->uv == FIDO_OPT_TRUE &&
-	    fido_dev_supports_permissions(dev);
-}
-
 int
 fido_dev_get_assert(fido_dev_t *dev, fido_assert_t *assert, const char *pin)
 {
-	fido_blob_t	*ecdh = NULL;
-	es256_pk_t	*pk = NULL;
-	int		 ms = dev->timeout_ms;
-	int		 r;
+	fido_blob_t		 tmp_token;
+	const fido_blob_t	*token = NULL;
+	fido_blob_t		*ecdh = NULL;
+	es256_pk_t		*pk = NULL;
+	int			 ms = dev->timeout_ms;
+	int			 r;
+
+	memset(&tmp_token, 0, sizeof(tmp_token));
 
 #ifdef USE_WINHELLO
 	if (dev->flags & FIDO_DEV_WINHELLO)
@@ -347,13 +335,26 @@ fido_dev_get_assert(fido_dev_t *dev, fido_assert_t *assert, const char *pin)
 		return (u2f_authenticate(dev, assert, &ms));
 	}
 
-	if (need_ecdh(dev, assert, pin) && (r = fido_do_ecdh(dev, &pk, &ecdh,
-	    &ms)) != FIDO_OK) {
+	/* (pk, ecdh) nullable unless the hmac-secret extension is requested */
+	if ((assert->ext.mask & FIDO_EXT_HMAC_SECRET) &&
+	    (r = fido_do_ecdh(dev, &pk, &ecdh, &ms)) != FIDO_OK) {
 		fido_log_debug("%s: fido_do_ecdh", __func__);
 		goto fail;
 	}
 
-	r = fido_dev_get_assert_wait(dev, assert, pk, ecdh, pin, &ms);
+	if (!fido_blob_is_empty(&dev->puat))
+		token = &dev->puat;
+	else if (pin != NULL || (assert->uv == FIDO_OPT_TRUE &&
+	    fido_dev_supports_permissions(dev))) {
+		if ((r = fido_dev_get_uv_token(dev, CTAP_CBOR_ASSERT, pin,
+		    ecdh, pk, assert->rp_id, &tmp_token, &ms)) != FIDO_OK) {
+			fido_log_debug("%s: fido_dev_get_uv_token", __func__);
+			goto fail;
+		}
+		token = &tmp_token;
+	}
+
+	r = fido_dev_get_assert_wait(dev, assert, pk, ecdh, token, &ms);
 	if (r == FIDO_OK && (assert->ext.mask & FIDO_EXT_HMAC_SECRET))
 		if (decrypt_hmac_secrets(dev, assert, ecdh) < 0) {
 			fido_log_debug("%s: decrypt_hmac_secrets", __func__);
@@ -364,6 +365,7 @@ fido_dev_get_assert(fido_dev_t *dev, fido_assert_t *assert, const char *pin)
 fail:
 	es256_pk_free(&pk);
 	fido_blob_free(&ecdh);
+	fido_blob_reset(&tmp_token);
 
 	return (r);
 }

--- a/src/bio.c
+++ b/src/bio.c
@@ -68,10 +68,9 @@ bio_get_cmd(const fido_dev_t *dev)
 
 static int
 bio_tx(fido_dev_t *dev, uint8_t subcmd, cbor_item_t **sub_argv, size_t sub_argc,
-    const char *pin, const fido_blob_t *token, int *ms)
+    const fido_blob_t *token, int *ms)
 {
 	cbor_item_t	*argv[5];
-	fido_blob_t	 token_store;
 	fido_blob_t	 f;
 	fido_blob_t	 hmac;
 	const uint8_t	 cmd = bio_get_cmd(dev);
@@ -80,22 +79,12 @@ bio_tx(fido_dev_t *dev, uint8_t subcmd, cbor_item_t **sub_argv, size_t sub_argc,
 	memset(&f, 0, sizeof(f));
 	memset(&hmac, 0, sizeof(hmac));
 	memset(&argv, 0, sizeof(argv));
-	memset(&token_store, 0, sizeof(token_store));
 
 	/* modality, subCommand */
 	if ((argv[0] = cbor_build_uint8(1)) == NULL ||
 	    (argv[1] = cbor_build_uint8(subcmd)) == NULL) {
 		fido_log_debug("%s: cbor encode", __func__);
 		goto fail;
-	}
-
-	if (pin && !token) {
-		if ((r = fido_dev_get_uv_token(dev, bio_get_cmd(dev), pin, NULL,
-		    NULL, NULL, &token_store, ms) != FIDO_OK)) {
-			fido_log_debug("%s: fido_dev_get_uv_token", __func__);
-			goto fail;
-		}
-		token = &token_store;
 	}
 
 	if (token) {
@@ -123,11 +112,25 @@ bio_tx(fido_dev_t *dev, uint8_t subcmd, cbor_item_t **sub_argv, size_t sub_argc,
 	r = FIDO_OK;
 fail:
 	cbor_vector_free(argv, nitems(argv));
-	fido_blob_reset(&token_store);
 	free(f.ptr);
 	free(hmac.ptr);
 
 	return (r);
+}
+
+static int
+bio_resolve_token(fido_dev_t *dev, fido_blob_t *token, const char *pin, int *ms)
+{
+	if (!fido_blob_is_empty(&dev->puat)) {
+		if (fido_blob_set(token, dev->puat.ptr, dev->puat.len) != 0) {
+			fido_log_debug("%s: fido_blob_set", __func__);
+			return FIDO_ERR_INTERNAL;
+		}
+		return FIDO_OK;
+	}
+
+	return fido_dev_get_uv_token(dev, bio_get_cmd(dev), pin, NULL, NULL,
+	    NULL, token, ms);
 }
 
 static void
@@ -271,13 +274,24 @@ static int
 bio_get_template_array_wait(fido_dev_t *dev, fido_bio_template_array_t *ta,
     const char *pin, int *ms)
 {
+	fido_blob_t token;
 	int r;
 
-	if ((r = bio_tx(dev, CMD_ENUM, NULL, 0, pin, fido_dev_puat_blob(dev),
-	    ms)) != FIDO_OK || (r = bio_rx_template_array(dev, ta, ms)) != FIDO_OK)
-		return (r);
+	memset(&token, 0, sizeof(token));
 
-	return (FIDO_OK);
+	if ((r = bio_resolve_token(dev, &token, pin, ms)) != FIDO_OK) {
+		fido_log_debug("%s: bio_resolve_token", __func__);
+		goto fail;
+	}
+
+	if ((r = bio_tx(dev, CMD_ENUM, NULL, 0, &token, ms)) != FIDO_OK ||
+	    (r = bio_rx_template_array(dev, ta, ms)) != FIDO_OK)
+		goto fail;
+
+	r = FIDO_OK;
+fail:
+	fido_blob_reset(&token);
+	return (r);
 }
 
 int
@@ -296,10 +310,12 @@ static int
 bio_set_template_name_wait(fido_dev_t *dev, const fido_bio_template_t *t,
     const char *pin, int *ms)
 {
+	fido_blob_t	 token;
 	cbor_item_t	*argv[2];
 	int		 r = FIDO_ERR_INTERNAL;
 
 	memset(&argv, 0, sizeof(argv));
+	memset(&token, 0, sizeof(token));
 
 	if ((argv[0] = fido_blob_encode(&t->id)) == NULL ||
 	    (argv[1] = cbor_build_string(t->name)) == NULL) {
@@ -307,8 +323,12 @@ bio_set_template_name_wait(fido_dev_t *dev, const fido_bio_template_t *t,
 		goto fail;
 	}
 
-	if ((r = bio_tx(dev, CMD_SET_NAME, argv, 2, pin, fido_dev_puat_blob(dev),
-	    ms)) != FIDO_OK ||
+	if ((r = bio_resolve_token(dev, &token, pin, ms)) != FIDO_OK) {
+		fido_log_debug("%s: bio_resolve_token", __func__);
+		goto fail;
+	}
+
+	if ((r = bio_tx(dev, CMD_SET_NAME, argv, 2, &token, ms)) != FIDO_OK ||
 	    (r = fido_rx_cbor_status(dev, ms)) != FIDO_OK) {
 		fido_log_debug("%s: tx/rx", __func__);
 		goto fail;
@@ -317,6 +337,7 @@ bio_set_template_name_wait(fido_dev_t *dev, const fido_bio_template_t *t,
 	r = FIDO_OK;
 fail:
 	cbor_vector_free(argv, nitems(argv));
+	fido_blob_reset(&token);
 
 	return (r);
 }
@@ -450,7 +471,7 @@ bio_enroll_begin_wait(fido_dev_t *dev, fido_bio_template_t *t,
 		goto fail;
 	}
 
-	if ((r = bio_tx(dev, cmd, argv, 3, NULL, &e->token, ms)) != FIDO_OK ||
+	if ((r = bio_tx(dev, cmd, argv, 3, &e->token, ms)) != FIDO_OK ||
 	    (r = bio_rx_enroll_begin(dev, t, e, ms)) != FIDO_OK) {
 		fido_log_debug("%s: tx/rx", __func__);
 		goto fail;
@@ -467,23 +488,15 @@ int
 fido_bio_dev_enroll_begin(fido_dev_t *dev, fido_bio_template_t *t,
     fido_bio_enroll_t *e, uint32_t timo_ms, const char *pin)
 {
-	const fido_blob_t	*token;
-	int			 ms = dev->timeout_ms;
-	int			 r;
+	int ms = dev->timeout_ms;
+	int r;
 
-	token = fido_dev_puat_blob(dev);
-
-	if ((pin == NULL && token == NULL) || !fido_blob_is_empty(&e->token))
+	if ((pin == NULL && fido_blob_is_empty(&dev->puat)) ||
+	    !fido_blob_is_empty(&e->token))
 		return (FIDO_ERR_INVALID_ARGUMENT);
 
-	if (token)
-		r = fido_blob_set(&e->token, token->ptr, token->len);
-	else
-		r = fido_dev_get_uv_token(dev, bio_get_cmd(dev), pin, NULL,
-		    NULL, NULL, &e->token, &ms);
-
-	if (r != FIDO_OK) {
-		fido_log_debug("%s: token", __func__);
+	if ((r = bio_resolve_token(dev, &e->token, pin, &ms)) != FIDO_OK) {
+		fido_log_debug("%s: bio_resolve_token", __func__);
 		return (r);
 	}
 
@@ -540,7 +553,7 @@ bio_enroll_continue_wait(fido_dev_t *dev, const fido_bio_template_t *t,
 		goto fail;
 	}
 
-	if ((r = bio_tx(dev, cmd, argv, 3, NULL, &e->token, ms)) != FIDO_OK ||
+	if ((r = bio_tx(dev, cmd, argv, 3, &e->token, ms)) != FIDO_OK ||
 	    (r = bio_rx_enroll_continue(dev, e, ms)) != FIDO_OK) {
 		fido_log_debug("%s: tx/rx", __func__);
 		goto fail;
@@ -571,7 +584,7 @@ bio_enroll_cancel_wait(fido_dev_t *dev, int *ms)
 	const uint8_t	cmd = CMD_ENROLL_CANCEL;
 	int		r;
 
-	if ((r = bio_tx(dev, cmd, NULL, 0, NULL, NULL, ms)) != FIDO_OK ||
+	if ((r = bio_tx(dev, cmd, NULL, 0, NULL, ms)) != FIDO_OK ||
 	    (r = fido_rx_cbor_status(dev, ms)) != FIDO_OK) {
 		fido_log_debug("%s: tx/rx", __func__);
 		return (r);
@@ -593,18 +606,24 @@ bio_enroll_remove_wait(fido_dev_t *dev, const fido_bio_template_t *t,
     const char *pin, int *ms)
 {
 	cbor_item_t	*argv[1];
+	fido_blob_t	 token;
 	const uint8_t	 cmd = CMD_ENROLL_REMOVE;
 	int		 r = FIDO_ERR_INTERNAL;
 
 	memset(&argv, 0, sizeof(argv));
+	memset(&token, 0, sizeof(token));
 
 	if ((argv[0] = fido_blob_encode(&t->id)) == NULL) {
 		fido_log_debug("%s: cbor encode", __func__);
 		goto fail;
 	}
 
-	if ((r = bio_tx(dev, cmd, argv, 1, pin, fido_dev_puat_blob(dev),
-	    ms)) != FIDO_OK ||
+	if ((r = bio_resolve_token(dev, &token, pin, ms)) != FIDO_OK) {
+		fido_log_debug("%s: bio_resolve_token" , __func__);
+		goto fail;
+	}
+
+	if ((r = bio_tx(dev, cmd, argv, 1, &token, ms)) != FIDO_OK ||
 	    (r = fido_rx_cbor_status(dev, ms)) != FIDO_OK) {
 		fido_log_debug("%s: tx/rx", __func__);
 		goto fail;
@@ -613,6 +632,7 @@ bio_enroll_remove_wait(fido_dev_t *dev, const fido_bio_template_t *t,
 	r = FIDO_OK;
 fail:
 	cbor_vector_free(argv, nitems(argv));
+	fido_blob_reset(&token);
 
 	return (r);
 }
@@ -705,8 +725,7 @@ bio_get_info_wait(fido_dev_t *dev, fido_bio_info_t *i, int *ms)
 {
 	int r;
 
-	if ((r = bio_tx(dev, CMD_GET_INFO, NULL, 0, NULL, NULL,
-	    ms)) != FIDO_OK ||
+	if ((r = bio_tx(dev, CMD_GET_INFO, NULL, 0, NULL, ms)) != FIDO_OK ||
 	    (r = bio_rx_info(dev, i, ms)) != FIDO_OK) {
 		fido_log_debug("%s: tx/rx", __func__);
 		return (r);

--- a/src/bio.c
+++ b/src/bio.c
@@ -300,9 +300,6 @@ fido_bio_dev_get_template_array(fido_dev_t *dev, fido_bio_template_array_t *ta,
 {
 	int ms = dev->timeout_ms;
 
-	if (pin == NULL && fido_dev_puat_blob(dev) == NULL)
-		return (FIDO_ERR_INVALID_ARGUMENT);
-
 	return (bio_get_template_array_wait(dev, ta, pin, &ms));
 }
 
@@ -348,7 +345,7 @@ fido_bio_dev_set_template_name(fido_dev_t *dev, const fido_bio_template_t *t,
 {
 	int ms = dev->timeout_ms;
 
-	if ((pin == NULL && fido_dev_puat_blob(dev) == NULL) || t->name == NULL)
+	if (t->name == NULL)
 		return (FIDO_ERR_INVALID_ARGUMENT);
 
 	return (bio_set_template_name_wait(dev, t, pin, &ms));
@@ -491,8 +488,7 @@ fido_bio_dev_enroll_begin(fido_dev_t *dev, fido_bio_template_t *t,
 	int ms = dev->timeout_ms;
 	int r;
 
-	if ((pin == NULL && fido_blob_is_empty(&dev->puat)) ||
-	    !fido_blob_is_empty(&e->token))
+	if (!fido_blob_is_empty(&e->token))
 		return (FIDO_ERR_INVALID_ARGUMENT);
 
 	if ((r = bio_resolve_token(dev, &e->token, pin, &ms)) != FIDO_OK) {

--- a/src/bio.c
+++ b/src/bio.c
@@ -67,29 +67,6 @@ bio_get_cmd(const fido_dev_t *dev)
 }
 
 static int
-bio_get_uv_token(fido_dev_t *dev, const char *pin, uint8_t cmd,
-    fido_blob_t *token, int *ms)
-{
-	es256_pk_t	*pk = NULL;
-	fido_blob_t	*ecdh = NULL;
-	int		 r;
-
-	if ((r = fido_do_ecdh(dev, &pk, &ecdh, ms)) != FIDO_OK) {
-		fido_log_debug("%s: fido_do_ecdh", __func__);
-		return r;
-	}
-
-	r = fido_dev_get_uv_token(dev, cmd, pin, ecdh, pk, NULL, token, ms);
-	if (r != FIDO_OK)
-		fido_log_debug("%s: fido_dev_get_uv_token", __func__);
-
-	es256_pk_free(&pk);
-	fido_blob_free(&ecdh);
-
-	return r;
-}
-
-static int
 bio_tx(fido_dev_t *dev, uint8_t subcmd, cbor_item_t **sub_argv, size_t sub_argc,
     const char *pin, const fido_blob_t *token, int *ms)
 {
@@ -113,10 +90,11 @@ bio_tx(fido_dev_t *dev, uint8_t subcmd, cbor_item_t **sub_argv, size_t sub_argc,
 	}
 
 	if (pin && !token) {
-		if ((r = bio_get_uv_token(dev, pin, cmd, &token_store,
-		    ms)) != FIDO_OK)
+		if ((r = fido_dev_get_uv_token(dev, bio_get_cmd(dev), pin, NULL,
+		    NULL, NULL, &token_store, ms) != FIDO_OK)) {
+			fido_log_debug("%s: fido_dev_get_uv_token", __func__);
 			goto fail;
-
+		}
 		token = &token_store;
 	}
 
@@ -501,10 +479,13 @@ fido_bio_dev_enroll_begin(fido_dev_t *dev, fido_bio_template_t *t,
 	if (token)
 		r = fido_blob_set(&e->token, token->ptr, token->len);
 	else
-		r = bio_get_uv_token(dev, pin, CTAP_CBOR_BIO_ENROLL_PRE, &e->token, &ms);
+		r = fido_dev_get_uv_token(dev, bio_get_cmd(dev), pin, NULL,
+		    NULL, NULL, &e->token, &ms);
 
-	if (r != FIDO_OK)
+	if (r != FIDO_OK) {
+		fido_log_debug("%s: token", __func__);
 		return (r);
+	}
 
 	return (bio_enroll_begin_wait(dev, t, e, timo_ms, &ms));
 }

--- a/src/config.c
+++ b/src/config.c
@@ -44,15 +44,18 @@ static int
 config_tx(fido_dev_t *dev, uint8_t subcmd, cbor_item_t **paramv, size_t paramc,
     const char *pin, int *ms)
 {
+	const fido_blob_t *token;
+	fido_blob_t tmp_token;
 	cbor_item_t *argv[4];
-	es256_pk_t *pk = NULL;
-	fido_blob_t *ecdh = NULL, f, hmac;
+	fido_blob_t f, hmac;
 	const uint8_t cmd = CTAP_CBOR_CONFIG;
 	int r = FIDO_ERR_INTERNAL;
 
 	memset(&f, 0, sizeof(f));
 	memset(&hmac, 0, sizeof(hmac));
 	memset(&argv, 0, sizeof(argv));
+	memset(&tmp_token, 0, sizeof(tmp_token));
+	token = fido_dev_puat_blob(dev);
 
 	/* subCommand */
 	if ((argv[0] = cbor_build_uint8(subcmd)) == NULL) {
@@ -68,22 +71,23 @@ config_tx(fido_dev_t *dev, uint8_t subcmd, cbor_item_t **paramv, size_t paramc,
 	}
 
 	/* pinProtocol, pinAuth */
-	if (pin != NULL || fido_dev_puat_blob(dev) != NULL ||
+	if (pin != NULL || token != NULL ||
 	    (fido_dev_supports_permissions(dev) && fido_dev_has_uv(dev))) {
 		if (config_prepare_hmac(subcmd, argv[1], &hmac) < 0) {
 			fido_log_debug("%s: config_prepare_hmac", __func__);
 			goto fail;
 		}
-
-		/* If available, prefer cached PUAT */
-		if (fido_dev_puat_blob(dev) == NULL &&
-		    (r = fido_do_ecdh(dev, &pk, &ecdh, ms)) != FIDO_OK) {
-			fido_log_debug("%s: fido_do_ecdh", __func__);
-			goto fail;
+		if (token == NULL) {
+			if ((r = fido_dev_get_uv_token(dev, cmd, pin, NULL,
+			    NULL, NULL, &tmp_token, ms)) != FIDO_OK) {
+				fido_log_debug("%s: fido_dev_get_uv_token",
+				    __func__);
+				goto fail;
+			}
+			token = &tmp_token;
 		}
-
-		if ((r = cbor_add_uv_params(dev, cmd, &hmac, pk, ecdh, pin,
-		    NULL, &argv[3], &argv[2], ms)) != FIDO_OK) {
+		if ((r = cbor_add_uv_params(dev, &hmac, token, &argv[3],
+		    &argv[2])) != FIDO_OK) {
 			fido_log_debug("%s: cbor_add_uv_params", __func__);
 			goto fail;
 		}
@@ -100,8 +104,7 @@ config_tx(fido_dev_t *dev, uint8_t subcmd, cbor_item_t **paramv, size_t paramc,
 	r = FIDO_OK;
 fail:
 	cbor_vector_free(argv, nitems(argv));
-	es256_pk_free(&pk);
-	fido_blob_free(&ecdh);
+	fido_blob_reset(&tmp_token);
 	free(f.ptr);
 	free(hmac.ptr);
 

--- a/src/cred.c
+++ b/src/cred.c
@@ -51,7 +51,8 @@ parse_makecred_reply(const cbor_item_t *key, const cbor_item_t *val, void *arg)
 
 static int
 fido_dev_make_cred_tx(fido_dev_t *dev, fido_cred_t *cred,
-    const es256_pk_t *pk, const fido_blob_t *ecdh, const char *pin, int *ms)
+    const es256_pk_t *pk, const fido_blob_t *ecdh, const fido_blob_t *token,
+    int *ms)
 {
 	fido_blob_t	 f;
 	fido_opt_t	 uv = cred->uv;
@@ -89,11 +90,9 @@ fido_dev_make_cred_tx(fido_dev_t *dev, fido_cred_t *cred,
 		}
 
 	/* user verification */
-	if (pin != NULL ||
-	    fido_dev_puat_blob(dev) != NULL ||
-	    (uv == FIDO_OPT_TRUE && fido_dev_supports_permissions(dev))) {
-		if ((r = cbor_add_uv_params(dev, cmd, &cred->cdh, pk, ecdh,
-		    pin, cred->rp.id, &argv[7], &argv[8], ms)) != FIDO_OK) {
+	if (token != NULL) {
+		if ((r = cbor_add_uv_params(dev, &cred->cdh, token, &argv[7],
+		    &argv[8])) != FIDO_OK) {
 			fido_log_debug("%s: cbor_add_uv_params", __func__);
 			goto fail;
 		}
@@ -178,11 +177,12 @@ fail:
 
 static int
 fido_dev_make_cred_wait(fido_dev_t *dev, fido_cred_t *cred,
-    const es256_pk_t *pk, const fido_blob_t *ecdh, const char *pin, int *ms)
+    const es256_pk_t *pk, const fido_blob_t *ecdh, const fido_blob_t *token,
+    int *ms)
 {
 	int  r;
 
-	if ((r = fido_dev_make_cred_tx(dev, cred, pk, ecdh, pin, ms)) != FIDO_OK ||
+	if ((r = fido_dev_make_cred_tx(dev, cred, pk, ecdh, token, ms)) != FIDO_OK ||
 	    (r = fido_dev_make_cred_rx(dev, cred, ms)) != FIDO_OK)
 		return (r);
 
@@ -197,29 +197,17 @@ decrypt_hmac_secret(const fido_dev_t *dev, fido_cred_t *cred,
 	    &cred->hmac_secret));
 }
 
-static bool
-need_ecdh(const fido_dev_t *dev, const fido_cred_t *cred, const char *pin)
-{
-	if (cred->ext.attr.mask & FIDO_EXT_HMAC_SECRET_MC)
-		return true;
-
-	/* If available, prefer cached PUAT */
-	if (fido_dev_puat_blob(dev) != NULL)
-		return false;
-
-	if (pin != NULL)
-		return true;
-
-	return cred->uv == FIDO_OPT_TRUE && fido_dev_supports_permissions(dev);
-}
-
 int
 fido_dev_make_cred(fido_dev_t *dev, fido_cred_t *cred, const char *pin)
 {
-	fido_blob_t	*ecdh = NULL;
-	es256_pk_t	*pk = NULL;
-	int		 ms = dev->timeout_ms;
-	int 		 r;
+	const fido_blob_t	*token = NULL;
+	fido_blob_t	         tmp_token;
+	fido_blob_t	        *ecdh = NULL;
+	es256_pk_t	        *pk = NULL;
+	int		         ms = dev->timeout_ms;
+	int 		         r;
+
+	memset(&tmp_token, 0, sizeof(tmp_token));
 
 #ifdef USE_WINHELLO
 	if (dev->flags & FIDO_DEV_WINHELLO)
@@ -232,20 +220,33 @@ fido_dev_make_cred(fido_dev_t *dev, fido_cred_t *cred, const char *pin)
 		return (u2f_register(dev, cred, &ms));
 	}
 
-	if (cred->cdh.ptr == NULL || cred->type == 0) {
-		fido_log_debug("%s: cdh=%p, type=%d", __func__,
-		    (void *)cred->cdh.ptr, cred->type);
+	if (cred->cdh.ptr == NULL || cred->type == 0 || cred->rp.id == NULL) {
+		fido_log_debug("%s: cdh=%p, type=%d, rp.id=%p", __func__,
+		    (void *)cred->cdh.ptr, cred->type, (void *)cred->rp.id);
 		r = FIDO_ERR_INVALID_ARGUMENT;
 		goto fail;
 	}
 
-	if (need_ecdh(dev, cred, pin) && (r = fido_do_ecdh(dev, &pk, &ecdh,
-	    &ms)) != FIDO_OK) {
+	/* (pk, ecdh) nullable unless the hmac-secret extension is requested */
+	if ((cred->ext.attr.mask & FIDO_EXT_HMAC_SECRET_MC) &&
+	    (r = fido_do_ecdh(dev, &pk, &ecdh, &ms)) != FIDO_OK) {
 		fido_log_debug("%s: fido_do_ecdh", __func__);
 		goto fail;
 	}
 
-	r = fido_dev_make_cred_wait(dev, cred, pk, ecdh, pin, &ms);
+	if (!fido_blob_is_empty(&dev->puat))
+		token = &dev->puat;
+	else if (pin != NULL || (cred->uv == FIDO_OPT_TRUE &&
+	    fido_dev_supports_permissions(dev))) {
+		if ((r = fido_dev_get_uv_token(dev, CTAP_CBOR_MAKECRED, pin,
+		    ecdh, pk, cred->rp.id, &tmp_token, &ms)) != FIDO_OK) {
+			fido_log_debug("%s: fido_dev_get_uv_token", __func__);
+			goto fail;
+		}
+		token = &tmp_token;
+	}
+
+	r = fido_dev_make_cred_wait(dev, cred, pk, ecdh, token, &ms);
 	if (r == FIDO_OK && (cred->ext.attr.mask & FIDO_EXT_HMAC_SECRET_MC)) {
 		if (decrypt_hmac_secret(dev, cred, ecdh) < 0) {
 			fido_log_debug("%s: decrypt_hmac_secret", __func__);
@@ -257,6 +258,7 @@ fido_dev_make_cred(fido_dev_t *dev, fido_cred_t *cred, const char *pin)
 fail:
 	es256_pk_free(&pk);
 	fido_blob_free(&ecdh);
+	fido_blob_reset(&tmp_token);
 
 	return (r);
 }

--- a/src/credman.c
+++ b/src/credman.c
@@ -124,17 +124,19 @@ static int
 credman_tx(fido_dev_t *dev, uint8_t subcmd, const void *param, const char *pin,
     const char *rp_id, fido_opt_t uv, int *ms)
 {
-	fido_blob_t	 f;
-	fido_blob_t	*ecdh = NULL;
-	fido_blob_t	 hmac;
-	es256_pk_t	*pk = NULL;
-	cbor_item_t	*argv[4];
-	const uint8_t	 cmd = credman_get_cmd(dev);
-	int		 r = FIDO_ERR_INTERNAL;
+	const fido_blob_t	*token;
+	fido_blob_t		 tmp_token;
+	fido_blob_t		 f;
+	fido_blob_t		 hmac;
+	cbor_item_t		*argv[4];
+	const uint8_t		 cmd = credman_get_cmd(dev);
+	int			 r = FIDO_ERR_INTERNAL;
 
 	memset(&f, 0, sizeof(f));
 	memset(&hmac, 0, sizeof(hmac));
 	memset(&argv, 0, sizeof(argv));
+	memset(&tmp_token, 0, sizeof(tmp_token));
+	token = fido_dev_puat_blob(dev);
 
 	if (fido_dev_is_fido2(dev) == false) {
 		fido_log_debug("%s: fido_dev_is_fido2", __func__);
@@ -149,21 +151,22 @@ credman_tx(fido_dev_t *dev, uint8_t subcmd, const void *param, const char *pin,
 	}
 
 	/* pinProtocol, pinAuth */
-	if (pin != NULL || fido_dev_puat_blob(dev) != NULL ||
-	    uv == FIDO_OPT_TRUE) {
+	if (pin != NULL || token != NULL || uv == FIDO_OPT_TRUE) {
 		if (credman_prepare_hmac(subcmd, param, &argv[1], &hmac) < 0) {
 			fido_log_debug("%s: credman_prepare_hmac", __func__);
 			goto fail;
 		}
-
-		if (fido_dev_puat_blob(dev) == NULL) {
-			if ((r = fido_do_ecdh(dev, &pk, &ecdh, ms)) != FIDO_OK) {
-				fido_log_debug("%s: fido_do_ecdh", __func__);
+		if (token == NULL) {
+			if ((r = fido_dev_get_uv_token(dev, cmd, pin, NULL,
+			    NULL, rp_id, &tmp_token, ms)) != FIDO_OK) {
+				fido_log_debug("%s: fido_dev_get_uv_token",
+				    __func__);
 				goto fail;
 			}
+			token = &tmp_token;
 		}
-		if ((r = cbor_add_uv_params(dev, cmd, &hmac, pk, ecdh, pin,
-		    rp_id, &argv[3], &argv[2], ms)) != FIDO_OK) {
+		if ((r = cbor_add_uv_params(dev, &hmac, token, &argv[3],
+		    &argv[2])) != FIDO_OK) {
 			fido_log_debug("%s: cbor_add_uv_params", __func__);
 			goto fail;
 		}
@@ -179,9 +182,8 @@ credman_tx(fido_dev_t *dev, uint8_t subcmd, const void *param, const char *pin,
 
 	r = FIDO_OK;
 fail:
-	es256_pk_free(&pk);
-	fido_blob_free(&ecdh);
 	cbor_vector_free(argv, nitems(argv));
+	fido_blob_reset(&tmp_token);
 	free(f.ptr);
 	free(hmac.ptr);
 

--- a/src/extern.h
+++ b/src/extern.h
@@ -97,9 +97,8 @@ int cbor_map_iter(const cbor_item_t *, void *, int(*)(const cbor_item_t *,
 int cbor_string_copy(const cbor_item_t *, char **);
 int cbor_parse_reply(const unsigned char *, size_t, void *,
     int(*)(const cbor_item_t *, const cbor_item_t *, void *));
-int cbor_add_uv_params(fido_dev_t *, uint8_t, const fido_blob_t *,
-    const es256_pk_t *, const fido_blob_t *, const char *, const char *,
-    cbor_item_t **, cbor_item_t **, int *);
+int cbor_add_uv_params(const fido_dev_t *, const fido_blob_t *,
+    const fido_blob_t *, cbor_item_t **, cbor_item_t **);
 void cbor_vector_free(cbor_item_t **, size_t);
 int cbor_array_append(cbor_item_t **, cbor_item_t *);
 int cbor_array_drop(cbor_item_t **, size_t);

--- a/src/largeblob.c
+++ b/src/largeblob.c
@@ -550,13 +550,13 @@ largeblob_set_array(fido_dev_t *dev, const cbor_item_t *item, const char *pin,
     int *ms)
 {
 	unsigned char dgst[SHA256_DIGEST_LENGTH];
-	fido_blob_t cbor, token_store;
+	fido_blob_t cbor, tmp_token;
 	const fido_blob_t *token = NULL;
 	size_t chunklen, maxchunklen, totalsize;
 	int r;
 
 	memset(&cbor, 0, sizeof(cbor));
-	memset(&token_store, 0, sizeof(token_store));
+	memset(&tmp_token, 0, sizeof(tmp_token));
 
 	if ((maxchunklen = get_chunklen(dev)) == 0) {
 		fido_log_debug("%s: maxchunklen=%zu", __func__, maxchunklen);
@@ -592,7 +592,7 @@ largeblob_set_array(fido_dev_t *dev, const cbor_item_t *item, const char *pin,
 			fido_log_debug("%s: fido_dev_get_uv_token", __func__);
 			goto fail;
 		}
-		token = &token_store;
+		token = &tmp_token;
 	}
 
 	for (size_t offset = 0; offset < cbor.len; offset += chunklen) {
@@ -614,7 +614,7 @@ largeblob_set_array(fido_dev_t *dev, const cbor_item_t *item, const char *pin,
 
 	r = FIDO_OK;
 fail:
-	fido_blob_reset(&token_store);
+	fido_blob_reset(&tmp_token);
 	fido_blob_reset(&cbor);
 
 	return r;

--- a/src/largeblob.c
+++ b/src/largeblob.c
@@ -546,35 +546,6 @@ fail:
 }
 
 static int
-largeblob_get_uv_token(fido_dev_t *dev, const char *pin, fido_blob_t *token,
-    int *ms)
-{
-	es256_pk_t *pk = NULL;
-	fido_blob_t *ecdh = NULL;
-	int r;
-
-	if ((r = fido_do_ecdh(dev, &pk, &ecdh, ms)) != FIDO_OK) {
-		fido_log_debug("%s: fido_do_ecdh", __func__);
-		goto fail;
-	}
-	if ((r = fido_dev_get_uv_token(dev, CTAP_CBOR_LARGEBLOB, pin, ecdh, pk,
-	    NULL, token, ms)) != FIDO_OK) {
-		fido_log_debug("%s: fido_dev_get_uv_token", __func__);
-		goto fail;
-	}
-
-	r = FIDO_OK;
-fail:
-	if (r != FIDO_OK)
-		fido_blob_reset(token);
-
-	fido_blob_free(&ecdh);
-	es256_pk_free(&pk);
-
-	return r;
-}
-
-static int
 largeblob_set_array(fido_dev_t *dev, const cbor_item_t *item, const char *pin,
     int *ms)
 {
@@ -616,9 +587,9 @@ largeblob_set_array(fido_dev_t *dev, const cbor_item_t *item, const char *pin,
 
 	if ((token = fido_dev_puat_blob(dev)) == NULL &&
 	    (pin != NULL || fido_dev_supports_permissions(dev))) {
-		if ((r = largeblob_get_uv_token(dev, pin, &token_store,
-		    ms)) != FIDO_OK) {
-			fido_log_debug("%s: largeblob_get_uv_token", __func__);
+		if ((r = fido_dev_get_uv_token(dev, CTAP_CBOR_LARGEBLOB, pin,
+		    NULL, NULL, NULL, &tmp_token, ms)) != FIDO_OK) {
+			fido_log_debug("%s: fido_dev_get_uv_token", __func__);
 			goto fail;
 		}
 		token = &token_store;

--- a/src/pin.c
+++ b/src/pin.c
@@ -340,46 +340,63 @@ cmd_to_perm(uint8_t cmd)
 	}
 }
 
+static int
+fido_dev_get_uv_token_wait(fido_dev_t *dev, unsigned int perm, const char *pin,
+    const fido_blob_t *ecdh, const es256_pk_t *pk, const char *rpid,
+    fido_blob_t *token, int *ms)
+{
+	fido_blob_t *tmp_ecdh = NULL;
+	es256_pk_t *tmp_pk = NULL;
+	int r;
+
+	if (perm == 0)
+		return (FIDO_ERR_INVALID_ARGUMENT);
+
+	if ((ecdh == NULL) != (pk == NULL))
+		return (FIDO_ERR_INVALID_ARGUMENT);
+
+	if (ecdh == NULL && pk == NULL) {
+		if ((r = fido_do_ecdh(dev, &tmp_pk, &tmp_ecdh,
+		    ms)) != FIDO_OK) {
+			fido_log_debug("%s: fido_do_ecdh", __func__);
+			goto fail;
+		}
+		ecdh = tmp_ecdh;
+		pk = tmp_pk;
+	}
+
+	r = uv_token_wait(dev, perm, pin, ecdh, pk, rpid, token, ms);
+fail:
+	es256_pk_free(&tmp_pk);
+	fido_blob_free(&tmp_ecdh);
+
+	return (r);
+}
+
+/* internal helper */
 int
 fido_dev_get_uv_token(fido_dev_t *dev, uint8_t cmd, const char *pin,
     const fido_blob_t *ecdh, const es256_pk_t *pk, const char *rpid,
     fido_blob_t *token, int *ms)
 {
-	uint8_t perm = cmd_to_perm(cmd);
-
-	if (perm == 0)
-		return (FIDO_ERR_INTERNAL);
-
-	return (uv_token_wait(dev, perm, pin, ecdh, pk, rpid, token, ms));
+	return (fido_dev_get_uv_token_wait(dev, cmd_to_perm(cmd), pin, ecdh, pk,
+	    rpid, token, ms));
 }
 
+/* public interface */
 int
 fido_dev_get_puat(fido_dev_t *dev, unsigned int perm, const char *rpid,
     const char *pin)
 {
-	fido_blob_t	*ecdh = NULL;
-	es256_pk_t	*pk = NULL;
-	int		 ms = dev->timeout_ms;
-	int		 r;
+	int ms = dev->timeout_ms;
 
 	fido_blob_reset(&dev->puat);
 
-	if (!fido_dev_is_fido2(dev) || fido_dev_is_winhello(dev)) {
-		r = FIDO_ERR_INVALID_ARGUMENT;
-		goto fail;
-	}
+	if (!fido_dev_is_fido2(dev) || fido_dev_is_winhello(dev))
+		return (FIDO_ERR_INVALID_ARGUMENT);
 
-	if ((r = fido_do_ecdh(dev, &pk, &ecdh, &ms)) != FIDO_OK) {
-		fido_log_debug("%s: fido_do_ecdh", __func__);
-		goto fail;
-	}
-
-	r = uv_token_wait(dev, perm, pin, ecdh, pk, rpid, &dev->puat, &ms);
-fail:
-	es256_pk_free(&pk);
-	fido_blob_free(&ecdh);
-
-	return (r);
+	return (fido_dev_get_uv_token_wait(dev, perm, pin, NULL, NULL, rpid,
+	    &dev->puat, &ms));
 }
 
 static int

--- a/src/pin.c
+++ b/src/pin.c
@@ -736,34 +736,17 @@ fido_dev_get_uv_retry_count(fido_dev_t *dev, int *retries)
 }
 
 int
-cbor_add_uv_params(fido_dev_t *dev, uint8_t cmd, const fido_blob_t *hmac_data,
-    const es256_pk_t *pk, const fido_blob_t *ecdh, const char *pin,
-    const char *rpid, cbor_item_t **auth, cbor_item_t **opt, int *ms)
+cbor_add_uv_params(const fido_dev_t *dev, const fido_blob_t *hmac_data,
+    const fido_blob_t *token, cbor_item_t **auth, cbor_item_t **opt)
 {
-	fido_blob_t      	 token_store;
-	const fido_blob_t	*token;
-	int		 	 r;
-
-	memset(&token_store, 0, sizeof(token_store));
-
-	if ((token = fido_dev_puat_blob(dev)) == NULL) {
-		if ((r = fido_dev_get_uv_token(dev, cmd, pin, ecdh, pk, rpid,
-		    &token_store, ms)) != FIDO_OK) {
-			fido_log_debug("%s: fido_dev_get_uv_token", __func__);
-			return r;
-		}
-		token = &token_store;
-	}
+	if (token == NULL)
+		return (FIDO_ERR_INVALID_ARGUMENT);
 
 	if ((*auth = cbor_encode_pin_auth(dev, token, hmac_data)) == NULL ||
 	    (*opt = cbor_encode_pin_opt(dev)) == NULL) {
 		fido_log_debug("%s: cbor encode", __func__);
-		r = FIDO_ERR_INTERNAL;
-		goto fail;
+		return (FIDO_ERR_INTERNAL);
 	}
 
-	r = FIDO_OK;
-fail:
-	fido_blob_reset(&token_store);
-	return (r);
+	return (FIDO_OK);
 }


### PR DESCRIPTION
An attempt to improve some of the PUAT handling, mainly in `assert.c` and `cred.c`.

`fido_dev_get_uv_token()` has historically always required the caller to provide `ecdh` and `pk`, though it's rarely needed for anything but the `hmac-secret` extension. By allowing these two arguments to be `NULL` and, if so, calling `fido_do_ecdh()` internally we can:

- remove `need_ecdh()` from both `cred.c` and `assert.c` and instead condition a call to `fido_do_ecdh()` on _only_ the presence of `hmac-secret`; and condition `fido_dev_get_uv_token()` _only_ on whether we're going to perform some form of UV;
- remove a few `xxx_get_uv_token()` helper functions that all do the very same thing as this new variant of `fido_dev_get_uv_token()`; and
- turn `cbor_add_uv_params()` into a pure encoder, narrowing its responsibilities (where it would previously also fetch a PIN/UV auth token from the device).

While here, adopt the changes from #962 to minimize conflicts.

Closes #962.