### PR TITLE
winhello: supply rp name and user display name

### DIFF
--- a/src/winhello.c
+++ b/src/winhello.c
@@ -313,7 +313,9 @@ pack_rp(wchar_t **id, wchar_t **name, WEBAUTHN_RP_ENTITY_INFORMATION *out,
 		fido_log_debug("%s: id", __func__);
 		return -1;
 	}
-	if (in->name && (out->pwszName = *name = to_utf16(in->name)) == NULL) {
+	/* NOTE: webauthn requires rp.name; hybrid transport enforces it. */
+	if ((out->pwszName = *name = to_utf16(in->name ? in->name : in->id))
+	    == NULL) {
 		fido_log_debug("%s: name", __func__);
 		return -1;
 	}
@@ -324,6 +326,8 @@ static int
 pack_user(wchar_t **name, wchar_t **icon, wchar_t **display_name,
     WEBAUTHN_USER_ENTITY_INFORMATION *out, const fido_user_t *in)
 {
+	const char *dn;
+
 	if (in->id.ptr == NULL || in->id.len > ULONG_MAX) {
 		fido_log_debug("%s: id", __func__);
 		return -1;
@@ -344,9 +348,11 @@ pack_user(wchar_t **name, wchar_t **icon, wchar_t **display_name,
 			return -1;
 		}
 	}
-	if (in->display_name != NULL) {
-		if ((out->pwszDisplayName = *display_name =
-		    to_utf16(in->display_name)) == NULL) {
+	/* NOTE: webauthn requires user.displayName; hybrid enforces it. */
+	dn = in->display_name ? in->display_name : in->name;
+	if (dn != NULL) {
+		if ((out->pwszDisplayName = *display_name = to_utf16(dn))
+		    == NULL) {
 			fido_log_debug("%s: display_name", __func__);
 			return -1;
 		}


### PR DESCRIPTION
Creating a credential through `windows://hello` fails with
`FIDO_ERR_OPERATION_DENIED` when the request is routed over the hybrid
transport (QR code to a phone). The same request succeeds against a local
authenticator or a USB token.

webauthn requires `rp.name` and `user.displayName`. `pack_rp()` and
`pack_user()` forward NULL when the caller does not set them. webauthn.dll
tolerates that locally, but over hybrid the request reaches the phone and is
rejected as `NotAllowedError` (`0x800704c7`).

This affects `fido2-cred` itself, which calls `fido_cred_set_rp(cred, rpid,
NULL)` and `fido_cred_set_user(..., uname, NULL, NULL)`, and OpenSSH, whose
`sk-usbhid.c` calls `fido_cred_set_rp(cred, application, NULL)` — hence
`ssh-keygen -t ecdsa-sk` cannot enroll against a phone on Windows.

Isolated with a standalone program calling `WebAuthNAuthenticatorMakeCredential()`
directly, with neither libfido2 nor OpenSSH involved. All runs used rp id `ssh:`
and completed over `WEBAUTHN_CTAP_TRANSPORT_HYBRID`:

| rp.name  | user.displayName | result          |
| -------- | ---------------- | --------------- |
| `"ssh:"` | `"openssh"`      | success         |
| NULL     | `"openssh"`      | NotAllowedError |
| `"ssh:"` | NULL             | NotAllowedError |
| NULL     | NULL             | NotAllowedError |

Either field breaks the request on its own. A subsequent GetAssertion with the
credential from the successful run also succeeded.

Fall back to the rp id and to the user name respectively. Only the winhello
backend is touched — `cbor_encode_rp_entity()` and `cbor_encode_user_entity()`
keep omitting both fields on the CTAP path, where they are optional.


Tested on Windows 11 (build 26200.8655), webauthn.dll API version 9,
against an iPhone (iOS 26.6) over the hybrid transport.